### PR TITLE
changing "discussion" tab to say "Forum"

### DIFF
--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -375,7 +375,7 @@ class DiscussionTab(EnrolledOrStaffTab):
     def __init__(self, tab_dict=None):
         super(DiscussionTab, self).__init__(
             # Translators: "Discussion" is the title of the course forum page
-            name=tab_dict['name'] if tab_dict else _('Discussion'),
+            name='Forum', #tab_dict['name'] if tab_dict else _('Discussion'),
             tab_id=self.type,
             link_func=link_reverse_func('django_comment_client.forum.views.forum_form_discussion'),
         )


### PR DESCRIPTION
not particularly happy with this change, but I can't for the life of me figure out where in the hell the ['name'] property of the Discussion tabs are populated.