### PR TITLE
changed label text for consistency

### DIFF
--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -248,7 +248,7 @@
           % if settings.REGISTRATION_EXTRA_FIELDS['market'] != 'hidden':
           <li class="field group">
             <div class="field ${settings.REGISTRATION_EXTRA_FIELDS['market']} select" id="field-market">
-              <label for="market">${_('Select your nearest city')}</label>
+              <label for="market">${_('Select Nearest City')}</label>
               <select id="market" name="market" ${'required aria-required="true"' if settings.REGISTRATION_EXTRA_FIELDS['market'] == 'required' else ''}>
                 <option value="">--</option>
                 %for code, market_name in UserProfile.MARKET_CHOICES:


### PR DESCRIPTION
Sorry for the rapid fire on this one, @tkeemon - team wasn't happy with my choice of label for the dropdown ;)
Label is now capitalized, and is not a full sentence.
