### PR TITLE
Multitenant DB support

### DIFF
--- a/common/djangoapps/appsembler/mapper.py
+++ b/common/djangoapps/appsembler/mapper.py
@@ -1,0 +1,25 @@
+"""Maps a request to a tenant using the first part of the hostname.
+
+For example:
+  foo.example.com:8000 -> foo
+  bar.baz.example.com -> bar
+
+This is a simple example; you should probably verify tenant names
+are valid before returning them, since the returned tenant name will
+be issued in a `USE` SQL query.
+"""
+
+from db_multitenant import mapper
+
+
+class SimpleTenantMapper(mapper.TenantMapper):
+    def get_tenant_name(self, request):
+        """Takes the first part of the hostname as the tenant"""
+        hostname = request.get_host().split(':')[0].lower()
+        return hostname.split('.')[0]
+
+    def get_dbname(self, request):
+        return self.get_tenant_name(request)
+
+    def get_cache_prefix(self, request):
+        return self.get_tenant_name(request)

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -15,6 +15,8 @@ from bson.son import SON
 from opaque_keys.edx.keys import AssetKey
 from xmodule.modulestore.django import ASSET_IGNORE_REGEX
 
+from db_multitenant import utils
+from threadlocals.threadlocals import get_current_request
 
 class MongoContentStore(ContentStore):
 
@@ -29,6 +31,11 @@ class MongoContentStore(ContentStore):
 
         # Remove the replicaSet parameter.
         kwargs.pop('replicaSet', None)
+
+        req = get_current_request()
+        mapper = utils.get_mapper()
+        db = mapper.get_dbname(req)
+
 
         _db = pymongo.database.Database(
             pymongo.MongoClient(

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -6,6 +6,7 @@ from xmodule.contentstore.content import XASSET_LOCATION_TAG
 
 import logging
 
+from db_multitenant.utils import get_mongo_db_name
 from .content import StaticContent, ContentStore, StaticContentStream
 from xmodule.exceptions import NotFoundError
 from fs.osfs import OSFS
@@ -15,8 +16,6 @@ from bson.son import SON
 from opaque_keys.edx.keys import AssetKey
 from xmodule.modulestore.django import ASSET_IGNORE_REGEX
 
-from db_multitenant import utils
-from threadlocals.threadlocals import get_current_request
 
 class MongoContentStore(ContentStore):
 
@@ -32,10 +31,7 @@ class MongoContentStore(ContentStore):
         # Remove the replicaSet parameter.
         kwargs.pop('replicaSet', None)
 
-        req = get_current_request()
-        mapper = utils.get_mapper()
-        db = mapper.get_dbname(req)
-
+        db = get_mongo_db_name()
 
         _db = pymongo.database.Database(
             pymongo.MongoClient(

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -221,7 +221,7 @@ def modulestore():
             # wrappers and then uses that setting to wrap the modulestore in
             # appropriate wrappers depending on enabled features.
             from ccx.modulestore import CCXModulestoreWrapper  # pylint: disable=import-error
-            _MIXED_MODULESTORE = CCXModulestoreWrapper(_MIXED_MODULESTORE)
+            _MIXED_MODULESTORE[db] = CCXModulestoreWrapper(_MIXED_MODULESTORE[db])
 
     return _MIXED_MODULESTORE[db]
 
@@ -234,7 +234,7 @@ def clear_existing_modulestores():
     This is useful for flushing state between unit tests.
     """
     global _MIXED_MODULESTORE  # pylint: disable=global-statement
-    _MIXED_MODULESTORE = None
+    _MIXED_MODULESTORE = {}
 
 
 class ModuleI18nService(object):

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -14,6 +14,8 @@ from django.conf import settings
 
 # This configuration must be executed BEFORE any additional Django imports. Otherwise, the imports may fail due to
 # Django not being configured properly. This mostly applies to tests.
+from db_multitenant.utils import get_mongo_db_name
+
 if not settings.configured:
     settings.configure()
 
@@ -27,9 +29,6 @@ from xmodule.modulestore.draft_and_published import BranchSettingMixin
 from xmodule.modulestore.mixed import MixedModuleStore
 from xmodule.util.django import get_current_request_hostname
 import xblock.reference.plugins
-
-from db_multitenant import utils
-from threadlocals.threadlocals import get_current_request
 
 
 try:
@@ -205,9 +204,7 @@ def modulestore():
     Returns the Mixed modulestore
     """
     global _MIXED_MODULESTORE  # pylint: disable=global-statement
-    req = get_current_request()
-    mapper = utils.get_mapper()
-    db = mapper.get_dbname(req)
+    db = get_mongo_db_name()
     if db not in _MIXED_MODULESTORE:
         _MIXED_MODULESTORE[db] = create_modulestore_instance(
             settings.MODULESTORE['default']['ENGINE'],

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -28,6 +28,9 @@ from xmodule.modulestore.mixed import MixedModuleStore
 from xmodule.util.django import get_current_request_hostname
 import xblock.reference.plugins
 
+from db_multitenant import utils
+from threadlocals.threadlocals import get_current_request
+
 
 try:
     # We may not always have the request_cache module available
@@ -128,6 +131,7 @@ def create_modulestore_instance(
         fs_service=None,
         user_service=None,
         signal_handler=None,
+        db=None
 ):
     """
     This will return a new instance of a modulestore given an engine and options
@@ -136,6 +140,11 @@ def create_modulestore_instance(
 
     _options = {}
     _options.update(options)
+
+    if db:
+        _options['db'] = db
+        if 'db' in doc_store_config:
+            doc_store_config['db'] = db
 
     FUNCTION_KEYS = ['render_template']
     for key in FUNCTION_KEYS:
@@ -188,7 +197,7 @@ def create_modulestore_instance(
 
 
 # A singleton instance of the Mixed Modulestore
-_MIXED_MODULESTORE = None
+_MIXED_MODULESTORE = {}
 
 
 def modulestore():
@@ -196,12 +205,16 @@ def modulestore():
     Returns the Mixed modulestore
     """
     global _MIXED_MODULESTORE  # pylint: disable=global-statement
-    if _MIXED_MODULESTORE is None:
-        _MIXED_MODULESTORE = create_modulestore_instance(
+    req = get_current_request()
+    mapper = utils.get_mapper()
+    db = mapper.get_dbname(req)
+    if db not in _MIXED_MODULESTORE:
+        _MIXED_MODULESTORE[db] = create_modulestore_instance(
             settings.MODULESTORE['default']['ENGINE'],
-            contentstore(),
+            contentstore(db),
             settings.MODULESTORE['default'].get('DOC_STORE_CONFIG', {}),
-            settings.MODULESTORE['default'].get('OPTIONS', {})
+            settings.MODULESTORE['default'].get('OPTIONS', {}),
+            db=db
         )
 
         if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
@@ -213,7 +226,7 @@ def modulestore():
             from ccx.modulestore import CCXModulestoreWrapper  # pylint: disable=import-error
             _MIXED_MODULESTORE = CCXModulestoreWrapper(_MIXED_MODULESTORE)
 
-    return _MIXED_MODULESTORE
+    return _MIXED_MODULESTORE[db]
 
 
 def clear_existing_modulestores():

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -153,6 +153,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
                 fs_service=fs_service,
                 user_service=user_service,
                 signal_handler=signal_handler,
+                db=kwargs.get('db')
             )
             # replace all named pointers to the store into actual pointers
             for course_key, store_name in self.mappings.iteritems():

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -36,6 +36,8 @@ from opaque_keys.edx.locator import CourseLocator, LibraryLocator
 from xblock.core import XBlock
 from xblock.exceptions import InvalidScopeError
 from xblock.fields import Scope, ScopeIds, Reference, ReferenceList, ReferenceValueDict
+
+from db_multitenant.utils import get_mongo_db_name
 from xblock.runtime import KvsFieldData
 
 from xmodule.assetstore import AssetMetadata, CourseAssetsFromStorage
@@ -50,9 +52,6 @@ from xmodule.modulestore.exceptions import ItemNotFoundError, DuplicateCourseErr
 from xmodule.modulestore.inheritance import InheritanceMixin, inherit_metadata, InheritanceKeyValueStore
 from xmodule.modulestore.xml import CourseLocationManager
 from xmodule.services import SettingsService
-
-from db_multitenant import utils
-from threadlocals.threadlocals import get_current_request
 
 log = logging.getLogger(__name__)
 
@@ -564,9 +563,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             # Remove the replicaSet parameter.
             kwargs.pop('replicaSet', None)
 
-            req = get_current_request()
-            mapper = utils.get_mapper()
-            db = mapper.get_dbname(req)
+            db = get_mongo_db_name()
 
             self.database = MongoProxy(
                 pymongo.database.Database(

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -51,6 +51,9 @@ from xmodule.modulestore.inheritance import InheritanceMixin, inherit_metadata, 
 from xmodule.modulestore.xml import CourseLocationManager
 from xmodule.services import SettingsService
 
+from db_multitenant import utils
+from threadlocals.threadlocals import get_current_request
+
 log = logging.getLogger(__name__)
 
 new_contract('CourseKey', CourseKey)
@@ -560,6 +563,10 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             """
             # Remove the replicaSet parameter.
             kwargs.pop('replicaSet', None)
+
+            req = get_current_request()
+            mapper = utils.get_mapper()
+            db = mapper.get_dbname(req)
 
             self.database = MongoProxy(
                 pymongo.database.Database(

--- a/lms/envs/appsembler.py
+++ b/lms/envs/appsembler.py
@@ -9,7 +9,7 @@ CONFIG_PREFIX = SERVICE_VARIANT + "." if SERVICE_VARIANT else ""
 with open(CONFIG_ROOT / CONFIG_PREFIX + 'env.json') as env_file:
     ENV_TOKENS = json.load(env_file)
 
-APPSEMBLER_FEATURES = ENV_TOKENS.get('APPSEMBLER_FEATURES',None)
+APPSEMBLER_FEATURES = ENV_TOKENS.get('APPSEMBLER_FEATURES', {})
 
 # search APPSEMBLER_FEATURES first, env variables second, fallback to None
 GOOGLE_TAG_MANAGER_ID = APPSEMBLER_FEATURES.get('GOOGLE_TAG_MANAGER_ID',os.environ.get('GOOGLE_TAG_MANAGER_ID', None))

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -5,3 +5,13 @@ from .appsembler import *
 
 INSTALLED_APPS += ('appsembler',)
 TEMPLATE_CONTEXT_PROCESSORS += ('appsembler.context_processors.intercom',)
+
+MIDDLEWARE_CLASSES = (
+    'db_multitenant.middleware.MultiTenantMiddleware',
+    ) + MIDDLEWARE_CLASSES
+
+SOUTH_DATABASE_ADAPTERS = {
+    'default': 'south.db.mysql'
+}
+
+MULTITENANT_MAPPER_CLASS = 'appsembler.mapper.SimpleTenantMapper'

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -16,3 +16,5 @@ SOUTH_DATABASE_ADAPTERS = {
 }
 
 MULTITENANT_MAPPER_CLASS = 'appsembler.mapper.SimpleTenantMapper'
+
+DATABASES['default']['ENGINE'] = 'db_multitenant.db.backends.mysql'

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -8,6 +8,7 @@ TEMPLATE_CONTEXT_PROCESSORS += ('appsembler.context_processors.intercom',)
 
 MIDDLEWARE_CLASSES = (
     'db_multitenant.middleware.MultiTenantMiddleware',
+    'threadlocals.middleware.ThreadLocalMiddleware',
     ) + MIDDLEWARE_CLASSES
 
 SOUTH_DATABASE_ADAPTERS = {

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -1,2 +1,3 @@
 python-intercom==0.2.13
 -e file:///edx/django-db-multitenant
+django-threadlocals==0.8

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -1,1 +1,2 @@
 python-intercom==0.2.13
+-e file:///edx/django-db-multitenant


### PR DESCRIPTION
Simple proof of concept for multitenant edX using a separate MySQL and MongoDB databases for each customer, with dynamic switching between them based on the hostname/subdomain. Really simple and probably not fit for production use, I tried to change as little of the upstream edx-platform code as I could.

It uses as fork of django-db-multitenant, can be found here: https://github.com/appsembler/django-db-multitenant
