### PR TITLE
unenroll and enroll users when cancel and restore codes

### DIFF
--- a/lms/djangoapps/appsembler/enrollment_api/views.py
+++ b/lms/djangoapps/appsembler/enrollment_api/views.py
@@ -130,20 +130,15 @@ class EnrollmentCodeStatusView(APIView):
                 status=400
             )
 
+        redemption = RegistrationCodeRedemption.get_registration_code_redemption(registration_code.code,
+                                                                                 registration_code.course_id)
         if action == 'cancel':
-            if not RegistrationCodeRedemption.is_registration_code_redeemed(code):
-                registration_code.is_valid = False
-                registration_code.save()
-            else:
-                return Response(
-                    data={
-                        'reason': 'Code already used',
-                        'success': False
-                    },
-                    status=status.HTTP_400_BAD_REQUEST
-                )
+            CourseEnrollment.unenroll(redemption.course_enrollment.user, registration_code.course_id)
+            registration_code.is_valid = False
+            registration_code.save()
 
         if action == 'restore':
+            CourseEnrollment.enroll(redemption.course_enrollment.user, registration_code.course_id)
             registration_code.is_valid = True
             registration_code.save()
         return Response(data={'success': True})

--- a/lms/djangoapps/appsembler/enrollment_api/views.py
+++ b/lms/djangoapps/appsembler/enrollment_api/views.py
@@ -133,12 +133,14 @@ class EnrollmentCodeStatusView(APIView):
         redemption = RegistrationCodeRedemption.get_registration_code_redemption(registration_code.code,
                                                                                  registration_code.course_id)
         if action == 'cancel':
-            CourseEnrollment.unenroll(redemption.course_enrollment.user, registration_code.course_id)
+            if redemption:
+                CourseEnrollment.unenroll(redemption.course_enrollment.user, registration_code.course_id)
             registration_code.is_valid = False
             registration_code.save()
 
         if action == 'restore':
-            CourseEnrollment.enroll(redemption.course_enrollment.user, registration_code.course_id)
+            if redemption:
+                CourseEnrollment.enroll(redemption.course_enrollment.user, registration_code.course_id)
             registration_code.is_valid = True
             registration_code.save()
         return Response(data={'success': True})


### PR DESCRIPTION
@bezidejni IWD has request this change for the cancel restore codes.

From IWD:
To confirm our expectations, the cancel/restore functionality should work as follows
- cancel code: the code is unavailable to use and the student is unenrolled from the course.
- restore code: the code is available and the student is enrolled again in the course.

Let me know!