### PR TITLE
third party auth update email and full name on login

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0002_auto_20160827_2046.py
+++ b/common/djangoapps/third_party_auth/migrations/0002_auto_20160827_2046.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='update_email_on_login',
+            field=models.BooleanField(default=False, help_text="If this option is selected, user's full name will be compared against the IdP on every login, and if is different, will be updated with IdP's new one"),
+        ),
+        migrations.AddField(
+            model_name='ltiproviderconfig',
+            name='update_full_name_on_login',
+            field=models.BooleanField(default=False, help_text="If this option is selected, user's full name will be compared against the IdP on every login, and if is different, will be updated with IdP's new one"),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='update_email_on_login',
+            field=models.BooleanField(default=False, help_text="If this option is selected, user's full name will be compared against the IdP on every login, and if is different, will be updated with IdP's new one"),
+        ),
+        migrations.AddField(
+            model_name='oauth2providerconfig',
+            name='update_full_name_on_login',
+            field=models.BooleanField(default=False, help_text="If this option is selected, user's full name will be compared against the IdP on every login, and if is different, will be updated with IdP's new one"),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='update_email_on_login',
+            field=models.BooleanField(default=False, help_text="If this option is selected, user's full name will be compared against the IdP on every login, and if is different, will be updated with IdP's new one"),
+        ),
+        migrations.AddField(
+            model_name='samlproviderconfig',
+            name='update_full_name_on_login',
+            field=models.BooleanField(default=False, help_text="If this option is selected, user's full name will be compared against the IdP on every login, and if is different, will be updated with IdP's new one"),
+        ),
+        migrations.AlterField(
+            model_name='oauth2providerconfig',
+            name='backend_name',
+            field=models.CharField(help_text=b'Which python-social-auth OAuth2 provider backend to use. The list of backend choices is determined by the THIRD_PARTY_AUTH_BACKENDS setting.', max_length=50, db_index=True, choices=[(b'dummy', b'dummy'), (b'google-oauth2', b'google-oauth2'), (b'linkedin-oauth2', b'linkedin-oauth2'), (b'facebook', b'facebook')]),
+        ),
+        migrations.AlterField(
+            model_name='samlproviderconfig',
+            name='backend_name',
+            field=models.CharField(default=b'tpa-saml', help_text=b"Which python-social-auth provider backend to use. 'tpa-saml' is the standard edX SAML backend.", max_length=50, choices=[(b'tpa-saml', b'tpa-saml')]),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -99,6 +99,22 @@ class ProviderConfig(ConfigurationModel):
             "email, and their account will be activated immediately upon registration."
         ),
     )
+    update_full_name_on_login = models.BooleanField(
+        default=False,
+        help_text=_(
+            "If this option is selected, user's full name will be compared "
+            "against the IdP on every login, and if is different, will be "
+            "updated with IdP's new one"
+        ),
+    )
+    update_email_on_login = models.BooleanField(
+        default=False,
+        help_text=_(
+            "If this option is selected, user's full name will be compared "
+            "against the IdP on every login, and if is different, will be "
+            "updated with IdP's new one"
+        ),
+    )
     prefix = None  # used for provider_id. Set to a string value in subclass
     backend_name = None  # Set to a field or fixed value in subclass
     accepts_logins = True  # Whether to display a sign-in button when the provider is enabled

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -672,3 +672,21 @@ def associate_by_email_if_login_api(auth_entry, backend, details, user, *args, *
             # email address and the legitimate user would now login to the illegitimate
             # account.
             return association_response
+
+@partial.partial
+def update_user_attributes(backend=None, user=None, strategy=None, auth_entry=None, *args, **kwargs):
+    """
+    This behaviour is controled in the ProviderConfig, if the update_full_name_on_login
+    attr=True and the user's full_name is different from the IdP's full_name will be updated,
+    if the update_email_on_login attr =True and the user's email is different from the IdP's
+    email will be updated too.
+    """
+    if user:
+        current_provider = provider.Registry.get_from_pipeline({'backend': backend.name, 'kwargs': kwargs})
+        provier_user_data = kwargs['details']
+        if current_provider.update_full_name_on_login and user.profile.name != provier_user_data['fullname']:
+            user.profile.name = provier_user_data['fullname']
+            user.profile.save()
+        if current_provider.update_email_on_login and user.email != provier_user_data['email']:
+            user.email = provier_user_data['email']
+            user.save()

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -52,6 +52,7 @@ def apply_settings(django_settings):
         'social.pipeline.social_auth.load_extra_data',
         'social.pipeline.user.user_details',
         'third_party_auth.pipeline.set_logged_in_cookies',
+        'third_party_auth.pipeline.update_user_attributes',
         'third_party_auth.pipeline.login_analytics',
     )
 


### PR DESCRIPTION
This PR add twu new boolean fields to the ProviderConfig class:
- update_full_name_on_login
- update_email_on_login

Also adds a new function to the third_party_auth pipeline stack, the new functions check this fields where the provider is running, and if are True, updates the user attribute in the login process. This add the ability to keep the email and full name update against the IdP.

Instructions for test:
- checkout the code
- with the edxapp user load the edxapp env
- python manage.py lms --settings=devstack makemigrations
- python manage.py lms --settings=devstack migrate
- paver i18n_extract

Then create or select and IdP (SAML or OAuth) and check this two attributes. Create a test user in edX using the IdP, then change the user info in edX and logout. Login again, the data must be changed with the IdP attributes.
