### PR TITLE
read SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING from env tokens

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -662,6 +662,8 @@ if FEATURES.get('ENABLE_COURSEWARE_SEARCH') or \
     # Use ElasticSearch as the search engine herein
     SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
 
+SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING = ENV_TOKENS.get('SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING', False)
+
 ELASTIC_SEARCH_CONFIG = ENV_TOKENS.get('ELASTIC_SEARCH_CONFIG', [{}])
 
 # Facebook app


### PR DESCRIPTION
by default `SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING` is hardcoded to False in common.py, so we cannot change it. This add the ability to add it and has a fall back to false.