### PR TITLE
add results processor for course discovery

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2502,6 +2502,9 @@ SEARCH_INITIALIZER = "lms.lib.courseware_search.lms_search_initializer.LmsSearch
 SEARCH_RESULT_PROCESSOR = "lms.lib.courseware_search.lms_result_processor.LmsSearchResultProcessor"
 # Use the LMS specific filter generator
 SEARCH_FILTER_GENERATOR = "lms.lib.courseware_search.lms_filter_generator.LmsSearchFilterGenerator"
+# Use the LMS course discovery specific result processor
+COURSE_DISCOVERY_SEARCH_RESULT_PROCESSOR = "lms.lib.courseware_search.lms_course_discovery_results_processor.LmsCourseDiscoveryResultProcessor"
+
 # Override to skip enrollment start date filtering in course search
 SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING = False
 

--- a/lms/lib/courseware_search/lms_course_discovery_results_processor.py
+++ b/lms/lib/courseware_search/lms_course_discovery_results_processor.py
@@ -44,7 +44,11 @@ class LmsCourseDiscoveryResultProcessor(SearchResultProcessor):
             'COURSE_CATALOG_VISIBILITY_PERMISSION',
             settings.COURSE_CATALOG_VISIBILITY_PERMISSION
         )
-        course = get_course_by_id(self.get_course_key(), depth=0)
-        if not has_access(user, permission_name, course):
+        try:
+            course = get_course_by_id(self.get_course_key(), depth=0)
+            if not has_access(user, permission_name, course):
+                return True
+        except:
             return True
+
         return False

--- a/lms/lib/courseware_search/lms_course_discovery_results_processor.py
+++ b/lms/lib/courseware_search/lms_course_discovery_results_processor.py
@@ -1,0 +1,50 @@
+"""
+This file contains implementation override of SearchResultProcessor which will allow
+    * Blends in "location" property
+    * Confirms user access to object
+"""
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
+from search.result_processor import SearchResultProcessor
+from lms.djangoapps.courseware.access import has_access
+from microsite_configuration import microsite
+from courseware.courses import get_course_by_id
+
+
+class LmsCourseDiscoveryResultProcessor(SearchResultProcessor):
+    """ SearchResultProcessor for LMS Search """
+    _course_key = None
+
+    def get_course_key(self):
+        """ fetch course key object from string representation - retain result for subsequent uses """
+        if self._course_key is None:
+            self._course_key = SlashSeparatedCourseKey.from_deprecated_string(self._results_fields["course"])
+        return self._course_key
+
+    @property
+    def url(self):
+        """
+        Property to display the url for the given location, useful for allowing navigation
+        """
+        if "course" not in self._results_fields or "id" not in self._results_fields:
+            raise ValueError("Must have course and id in order to build url")
+
+        return reverse(
+            "jump_to",
+            kwargs={"course_id": self._results_fields["course"], "location": self._results_fields["id"]}
+        )
+
+    def should_remove(self, user):
+        """ Test to see if this result should be removed due to access restriction """
+        if has_access(user, 'staff', self.get_course_key()):
+            return False
+        permission_name = microsite.get_value(
+            'COURSE_CATALOG_VISIBILITY_PERMISSION',
+            settings.COURSE_CATALOG_VISIBILITY_PERMISSION
+        )
+        course = get_course_by_id(self.get_course_key(), depth=0)
+        if not has_access(user, permission_name, course):
+            return True
+        return False


### PR DESCRIPTION
This PR adds a new search results procesor for the course discovery, this PR only work with the new edx-search PR: https://github.com/appsembler/edx-search/pull/1

This PR adds a new setting definition in `lms/common.py`pointing to a new added file, that overrides the new class added in edx-search `CourseDiscoveryResultProcessor`for post processing the course discovery results. 

For now we are checking the course visibility settings and removing the hidden courses form the results. This adds the possibility to add more rules to the course discovery results.