### PR TITLE
index course visibility and exclude none courses from course discovery

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -569,6 +569,7 @@ class CourseAboutSearchIndexer(object):
         AboutInfo("org", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("modes", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_MODE),
         AboutInfo("language", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("catalog_visibility", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
     ]
 
     @classmethod

--- a/lms/lib/courseware_search/lms_filter_generator.py
+++ b/lms/lib/courseware_search/lms_filter_generator.py
@@ -51,5 +51,5 @@ class LmsSearchFilterGenerator(SearchFilterGenerator):
             if org_filter_out_set:
                 exclude_dictionary['org'] = list(org_filter_out_set)
 
-        exclude_dictionary['catalog_visibility'] = 'none'
+        exclude_dictionary['catalog_visibility'] = ['none', 'about']
         return exclude_dictionary

--- a/lms/lib/courseware_search/lms_filter_generator.py
+++ b/lms/lib/courseware_search/lms_filter_generator.py
@@ -51,4 +51,5 @@ class LmsSearchFilterGenerator(SearchFilterGenerator):
             if org_filter_out_set:
                 exclude_dictionary['org'] = list(org_filter_out_set)
 
+        exclude_dictionary['catalog_visibility'] = 'none'
         return exclude_dictionary


### PR DESCRIPTION
This PR solves the visibility settings in course discovery for good. Is a better approach because we don't need to fork and update the search app. 