### PR TITLE
custom decorater for courses page relying on feature flag

### DIFF
--- a/lms/djangoapps/branding/decorators.py
+++ b/lms/djangoapps/branding/decorators.py
@@ -1,0 +1,24 @@
+"""
+Decorators that can be used to interact with branding.
+"""
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.decorators import user_passes_test, login_required
+from django.conf import settings
+
+def courses_login_required(function=None, redirect_field_name=REDIRECT_FIELD_NAME, login_url=None):
+    """
+    This decorator relies on the feature flag ENABLE_COURSES_LOGIN_REQUIRED
+    """
+    actual_decorator = user_passes_test(
+        lambda u: u.is_authenticated(),
+        login_url=login_url,
+        redirect_field_name=redirect_field_name
+    )
+    if function:
+        if settings.APPSEMBLER_FEATURES.get(
+                'ENABLE_COURSES_LOGIN_REQUIRED', False
+        ):
+            return actual_decorator(function)
+        else:
+            return function
+    return actual_decorator

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -20,6 +20,7 @@ from edxmako.shortcuts import marketing_link
 from util.cache import cache_if_anonymous
 from util.json_request import JsonResponse
 import branding.api as branding_api
+from branding.decorators import courses_login_required
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 log = logging.getLogger(__name__)
@@ -90,6 +91,7 @@ def index(request):
     return student.views.index(request, user=request.user)
 
 
+@courses_login_required
 @ensure_csrf_cookie
 @cache_if_anonymous()
 def courses(request):


### PR DESCRIPTION
This new feature adds the option to hide the courses page behind login required.

The new decorator checks if the `APPSEMBLER_FEATURES` setting `ENABLE_COURSES_LOGIN_REQUIRED` exists and is True, if it's, the courses page will redirect to login if the user isn't authenticated. 