### PR TITLE
new API endpoint for registration without username and password

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1756,7 +1756,8 @@ def create_account_with_params(request, params):
         not (
             third_party_provider and third_party_provider.skip_email_verification and
             user.email == running_pipeline['kwargs'].get('details', {}).get('email')
-        )
+        ) and
+        params.get('send_activation_email', True) == True
     )
     if send_email:
         context = {

--- a/lms/djangoapps/appsembler_api/apidocs.md
+++ b/lms/djangoapps/appsembler_api/apidocs.md
@@ -62,6 +62,61 @@ Cache-Control: no-cache
 }
 ```
 
+### Create User Account Without Username And Password
+This endpoint has a different set of parameters and more complex workflow than `Create User Account`.
+This endpoint creates an user account with minimal parameters, the endpoint is capable to create an user account only with the email address and a person Name (not username).
+#### Workflow description:
+1. The endpoint is called with an email and a person name.
+2. The endpoint autogenerates a password and an username.
+3. After created the user in a non active state, an email is sent to the user, with a set password link.
+4. After the user follows the link and set a new password, the account becomes active, and the new password is save.
+
+* URL: `/appsembler_api/v0/accounts/user_without_password`
+* Method: `POST`
+* Data Params
+	* Required:
+		* 'email'
+		* 'name'
+	* Optional:
+	    * 'country'
+	    * 'city'
+	    * 'gender'
+	    * 'goals'
+	    * 'level_of_education'
+	    * 'year_of_birth'
+
+* Success Response
+	* Code: 200
+	* Content:
+```
+{
+    "username": "honor906", # the generated username
+    "user_id ": 65 # the id of the new user
+}
+```
+
+* Error Responses:
+	* Code: 400
+	* Content: `{"user_message": "Wrong parameters on user creation"}`
+	* Reason: Wrong parameters on user creation
+
+	* Code: 409
+	* Content: `{"user_message": "User already exists"}`
+	* Reason: User already exists
+
+* Example call:
+```
+POST /appsembler_api/v0/accounts/create
+Host: example.com
+Content-Type: application/json
+Authorization: Bearer cbf6a5de322cf6a4323c957a882xy1s321c954b86
+Cache-Control: no-cache
+{
+    "email": "staff58@example.com",
+    "name": "stafftest"
+}
+```
+
 ### Check Existing Username
 
 This endpoint is a tool to check if an user exists given the username.

--- a/lms/djangoapps/appsembler_api/apidocs.md
+++ b/lms/djangoapps/appsembler_api/apidocs.md
@@ -64,7 +64,7 @@ Cache-Control: no-cache
 
 ### Create User Account Without Username And Password
 This endpoint has a different set of parameters and more complex workflow than `Create User Account`.
-This endpoint creates an user account with minimal parameters, the endpoint is capable to create an user account only with the email address and a person Name (not username).
+This endpoint creates a user account with minimal parameters, the endpoint is capable to create an user account only with the email address and a person Name (not username).
 #### Workflow description:
 1. The endpoint is called with an email and a person name.
 2. The endpoint autogenerates a password and an username.

--- a/lms/djangoapps/appsembler_api/urls.py
+++ b/lms/djangoapps/appsembler_api/urls.py
@@ -6,6 +6,7 @@ from appsembler_api import views
 urlpatterns = patterns(
     '',
     # user API
+    url(r'^accounts/user_without_password', views.CreateUserAccountWithoutPasswordView.as_view(), name="create_user_account_without_password_api"),
     url(r'^accounts/create', views.CreateUserAccountView.as_view(), name="create_user_account_api"),
     url(r'^accounts/get-user/(?P<username>[\w.+-]+)', views.GetUserAccountView.as_view(), name="get_user_account_api"),
 

--- a/lms/djangoapps/appsembler_api/utils.py
+++ b/lms/djangoapps/appsembler_api/utils.py
@@ -20,7 +20,7 @@ def auto_generate_username(email):
     username = ''.join(e for e in email.split('@')[0] if e.isalnum())
 
     while check_account_exists(username=username):
-        username = email.split('@')[0] + str(randint(100,999))
+        username = ''.join(e for e in email.split('@')[0] if e.isalnum()) + str(randint(100,999))
 
     return username
 

--- a/lms/djangoapps/appsembler_api/utils.py
+++ b/lms/djangoapps/appsembler_api/utils.py
@@ -17,7 +17,7 @@ def auto_generate_username(email):
     if not re.match(r"^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$", email):
         raise ValueError("Email is a invalid format")
 
-    username = email.split('@')[0]
+    username = ''.join(e for e in email.split('@')[0] if e.isalnum())
 
     while check_account_exists(username=username):
         username = email.split('@')[0] + str(randint(100,999))

--- a/lms/djangoapps/appsembler_api/utils.py
+++ b/lms/djangoapps/appsembler_api/utils.py
@@ -3,6 +3,8 @@ import re
 from random import randint
 
 from django.conf import settings
+from django.core.validators import validate_email
+from django.core.exceptions import ValidationError
 
 from openedx.core.djangoapps.user_api.accounts.api import check_account_exists
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -14,7 +16,9 @@ def auto_generate_username(email):
     the username exists and adds a random 3 digit int at the end to warranty
     uniqueness.
     """
-    if not re.match(r"^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$", email):
+    try:
+        validate_email(email)
+    except ValidationError:
         raise ValueError("Email is a invalid format")
 
     username = ''.join(e for e in email.split('@')[0] if e.isalnum())

--- a/lms/djangoapps/appsembler_api/utils.py
+++ b/lms/djangoapps/appsembler_api/utils.py
@@ -1,0 +1,41 @@
+import re
+
+from random import randint
+
+from django.conf import settings
+
+from openedx.core.djangoapps.user_api.accounts.api import check_account_exists
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from student.forms import PasswordResetFormNoActive
+
+def auto_generate_username(email):
+    """
+    This functions generates a valid username based on the email, also checks if
+    the username exists and adds a random 3 digit int at the end to warranty
+    uniqueness.
+    """
+    if not re.match(r"^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$", email):
+        raise ValueError("Email is a invalid format")
+
+    username = email.split('@')[0]
+
+    while check_account_exists(username=username):
+        username = email.split('@')[0] + str(randint(100,999))
+
+    return username
+
+
+def send_activation_email(request):
+    form = PasswordResetFormNoActive(request.data)
+    if form.is_valid():
+        form.save(use_https=request.is_secure(),
+                  from_email=configuration_helpers.get_value(
+                      'email_from_address', settings.DEFAULT_FROM_EMAIL),
+                  request=request,
+                  domain_override=request.get_host(),
+                  subject_template_name='appsembler_api/set_password_subject.txt',
+                  email_template_name='appsembler_api/set_password_email.html'
+        )
+        return True
+    else:
+        return False

--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -134,14 +134,16 @@ class CreateUserAccountWithoutPasswordView(APIView):
             errors = {"user_message": "User already exists"}
             return Response(errors, status=409)
 
-        username = auto_generate_username(email)
-        password = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(32))
-
-        data['username'] = username
-        data['password'] = password
-        data['send_activation_email'] = False
-
         try:
+            username = auto_generate_username(email)
+            password = ''.join(random.choice(
+                string.ascii_uppercase + string.ascii_lowercase + string.digits)
+                               for _ in range(32))
+
+            data['username'] = username
+            data['password'] = password
+            data['send_activation_email'] = False
+
             user = create_account_with_params(request, data)
             # set the user as inactive
             user.is_active = False
@@ -153,6 +155,9 @@ class CreateUserAccountWithoutPasswordView(APIView):
             assert NON_FIELD_ERRORS not in err.message_dict
             # Only return first error for each field
             errors = {"user_message": "Wrong parameters on user creation"}
+            return Response(errors, status=400)
+        except ValueError as err:
+            errors = {"user_message": "Wrong email format"}
             return Response(errors, status=400)
 
         response = Response({'user_id': user_id, 'username': username}, status=200)

--- a/lms/templates/appsembler_api/set_password_email.html
+++ b/lms/templates/appsembler_api/set_password_email.html
@@ -1,0 +1,13 @@
+{% load i18n %}{% load url from future %}{% autoescape off %}
+{% blocktrans %}You're receiving this e-mail because an account has created to you on {{ site_name }}.{% endblocktrans %}
+
+{% trans "Please go to the following to choose a new password and activate your account:" %}
+{% block reset_link %}
+{{ protocol }}://{{ site_name }}{% url 'student.views.password_reset_confirm_wrapper' uidb36=uid token=token %}
+{% endblock %}
+
+{% trans "Thanks for using our site!" %}
+
+{% blocktrans %}The {{ platform_name }} Team{% endblocktrans %}
+
+{% endautoescape %}

--- a/lms/templates/appsembler_api/set_password_email.html
+++ b/lms/templates/appsembler_api/set_password_email.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% load url from future %}{% autoescape off %}
-{% blocktrans %}You're receiving this e-mail because an account has created to you on {{ site_name }}.{% endblocktrans %}
+{% blocktrans %}You're receiving this e-mail because an account has been created for you on {{ site_name }}.{% endblocktrans %}
 
-{% trans "Please go to the following to choose a new password and activate your account:" %}
+{% trans "Please click on the following link to choose a new password and activate your account:" %}
 {% block reset_link %}
 {{ protocol }}://{{ site_name }}{% url 'student.views.password_reset_confirm_wrapper' uidb36=uid token=token %}
 {% endblock %}

--- a/lms/templates/appsembler_api/set_password_subject.txt
+++ b/lms/templates/appsembler_api/set_password_subject.txt
@@ -1,0 +1,3 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Activate Your Account{% endblocktrans %}
+{% endautoescape %}


### PR DESCRIPTION
This PR introduces a new API endpoint in the Appsembler API. The endpoint allows to create an user account with only an email and a person name.

Check the new docs inside the PR for the full workflow.

The new endpoint is tested and all the other endpoint has been tested to ensure that is not affecting anything previous.