### PR TITLE
retrieve the default course mode for generate the enrollment codes

### DIFF
--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -180,7 +180,7 @@ class GenerateRegistrationCodesView(APIView):
                 float(request.data.get('total_registration_codes'))
             )
 
-        course_mode = 'audit'
+        course_mode = CourseMode.DEFAULT_MODE_SLUG
 
         registration_codes = []
         for __ in range(course_code_number):


### PR DESCRIPTION
The generate enrollment code is not working on sites with certificates enabled. 
When we enable certificates, the default course mode is honor, not audit, and audit is being set by default.
This fix sets the default course mode on the installation, for to generate the enrollment codes.