### PR TITLE
check settings for 'APPSEMBLER_FEATURES'

### DIFF
--- a/lms/djangoapps/branding/decorators.py
+++ b/lms/djangoapps/branding/decorators.py
@@ -15,8 +15,10 @@ def courses_login_required(function=None, redirect_field_name=REDIRECT_FIELD_NAM
         redirect_field_name=redirect_field_name
     )
     if function:
-        if settings.APPSEMBLER_FEATURES.get(
-                'ENABLE_COURSES_LOGIN_REQUIRED', False
+        if hasattr(
+            settings, 'APPSEMBLER_FEATURES'
+        ) and settings.APPSEMBLER_FEATURES.get(
+            'ENABLE_COURSES_LOGIN_REQUIRED', False
         ):
             return actual_decorator(function)
         else:


### PR DESCRIPTION
In my devstack, running `$ paver test_system -t lms/djangoapps/course_api/tests/test_views.py:CourseListViewTestCaseMultipleCourses.test_filter_by_org` in appsembler/eucalyptus/develop results in error:
```
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/branding/decorators.py", line 18, in courses_login_required
    if settings.APPSEMBLER_FEATURES.get(


AttributeError: 'Settings' object has no attribute 'APPSEMBLER_FEATURES'
```
Looks like decorators.py was added recently in 6ef35072

Fix by checking for 'APPSEMBLER_FEATURE'