### PR TITLE
add pacing filter to course API

### DIFF
--- a/lms/djangoapps/course_api/forms.py
+++ b/lms/djangoapps/course_api/forms.py
@@ -75,14 +75,14 @@ class CourseListGetForm(UsernameValidatorMixin, Form):
             if cleaned_data.get(supported_filter.param_name) is not None:
                 filter_[supported_filter.field_name] = cleaned_data[supported_filter.param_name]
 
-        # adapt pacing to filter on self_paced
-        if 'pacing' in self.cleaned_data and self.cleaned_data['pacing']:
+        # adapt pacing to filter on self_paced boolean field
+        if 'pacing' in self.cleaned_data:
             pacing = self.cleaned_data['pacing']
             if pacing == CourseOverview.PACING_SELF:
                 filter_['self_paced'] = True
             elif pacing == CourseOverview.PACING_INSTRUCTOR:
                 filter_['self_paced'] = False
-            # else ignore, do not filter on self_paced
+            # else ignore since adapting to boolean field
 
         cleaned_data['filter_'] = filter_ or None
 

--- a/lms/djangoapps/course_api/forms.py
+++ b/lms/djangoapps/course_api/forms.py
@@ -57,17 +57,33 @@ class CourseListGetForm(UsernameValidatorMixin, Form):
     ]
     mobile = ExtendedNullBooleanField(required=False)
 
+    pacing = CharField(required=False)
+
     def clean(self):
         """
         Return cleaned data, including additional filters.
         """
+        from openedx.core.djangoapps.content.course_overviews.models import \
+            CourseOverview
+
         cleaned_data = super(CourseListGetForm, self).clean()
 
         # create a filter for all supported filter fields
         filter_ = dict()
+
         for supported_filter in self.supported_filters:
             if cleaned_data.get(supported_filter.param_name) is not None:
                 filter_[supported_filter.field_name] = cleaned_data[supported_filter.param_name]
+
+        # adapt pacing to filter on self_paced
+        if 'pacing' in self.cleaned_data and self.cleaned_data['pacing']:
+            pacing = self.cleaned_data['pacing']
+            if pacing == CourseOverview.PACING_SELF:
+                filter_['self_paced'] = True
+            elif pacing == CourseOverview.PACING_INSTRUCTOR:
+                filter_['self_paced'] = False
+            # else ignore, do not filter on self_paced
+
         cleaned_data['filter_'] = filter_ or None
 
         return cleaned_data

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -152,6 +152,10 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             If specified, only visible `CourseOverview` objects that are
             designated as mobile_available are returned.
 
+        pacing (optional):
+            If specified, only visible `CourseOverview` objects with provided
+            pacing "self" or "instructor" are returned.
+
     **Returns**
 
         * 200 on success, with a list of course discovery objects as returned
@@ -182,6 +186,7 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
                 "name": "Example Course",
                 "number": "example",
                 "org": "edX",
+                "pacing": "instructor",
                 "start": "2015-07-17T12:00:00Z",
                 "start_display": "July 17, 2015",
                 "start_type": "timestamp"

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -48,6 +48,13 @@ class CourseOverview(TimeStampedModel):
     # IMPORTANT: Bump this whenever you modify this model and/or add a migration.
     VERSION = 4
 
+    PACING_SELF = 'self'
+    PACING_INSTRUCTOR = 'instructor'
+    PACING_CHOICES = [
+        (PACING_SELF, PACING_SELF),
+        (PACING_INSTRUCTOR, PACING_INSTRUCTOR),
+    ]
+
     # Cache entry versioning.
     version = IntegerField()
 
@@ -565,7 +572,7 @@ class CourseOverview(TimeStampedModel):
             self: Self-paced courses
             instructor: Instructor-led courses
         """
-        return 'self' if self.self_paced else 'instructor'
+        return self.PACING_SELF if self.self_paced else self.PACING_INSTRUCTOR
 
     def apply_cdn_to_urls(self, image_urls):
         """


### PR DESCRIPTION
Add pacing filter to course API.

Note in existing code CourseOverview model self_paced is boolean field but course API presents pacing as 'self' or 'instructor' string. 

I maintained that in pacing filter, accepting 'self' or 'instructor' in course endpoint and adapting to boolean self_paced for filtering CourseOverview. I'd prefer to see pacing field with PACING_CHOICES on CourseOverview or self_pacing boolean on API course serializer.

You can run test with this command:
```
paver test_system -t lms/djangoapps/course_api/tests/test_views.py:CourseListViewTestCaseMultipleCourses.test_filter_by_pacing
```
If you get `AttributeError: 'Settings' object has no attribute 'APPSEMBLER_FEATURES'` error running that test, see https://github.com/appsembler/edx-platform/pull/78