### PR TITLE
Appsembler/nxp/feature/dyna facets

### DIFF
--- a/cms/djangoapps/search_api/api.py
+++ b/cms/djangoapps/search_api/api.py
@@ -1,5 +1,9 @@
 
-from contentstore.courseware_index import CoursewareSearchIndexer
+from contentstore.courseware_index import (
+    CourseAboutSearchIndexer,
+    CoursewareSearchIndexer,
+)
+
 from opaque_keys.edx.keys import CourseKey
 from xmodule.modulestore.django import modulestore
 
@@ -20,5 +24,12 @@ def reindex_course(course_id):
     """
     course_key = CourseKey.from_string(course_id)
     with modulestore().bulk_operations(course_key):
-	    return CoursewareSearchIndexer.do_course_reindex(modulestore(),
-	    	course_key)
+        return CoursewareSearchIndexer.do_course_reindex(modulestore(),
+            course_key)
+
+def register_facet(facet_slug):
+    """This method is a simple wrapper to abstract the  call. We use the facet
+    slug instead of the facet id because new a new facet may not be in the
+    database when it needs to be registered
+    """
+    return  CourseAboutSearchIndexer.add_facet({ 'slug': facet_slug })

--- a/cms/djangoapps/search_api/urls.py
+++ b/cms/djangoapps/search_api/urls.py
@@ -6,4 +6,6 @@ urlpatterns = [
     url(r'^$', views.SearchIndex.as_view(), name='search_api_index'),
     url(r'^{}/reindex-course'.format(API_VERSION),
         views.CourseIndexer.as_view(), name='reindex-course'),
+    url(r'^{}/register-facet'.format(API_VERSION),
+        views.FacetRegister.as_view(), name='register-facet')
 ]

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -28,7 +28,6 @@ if FEATURES.get('ENABLE_TAXOMAN', False):
         'BUNDLE_DIR_NAME': taxoman.settings.bundle_dir_name,
         'STATS_FILE': taxoman.settings.stats_file,
     }
-    COURSE_DISCOVERY_FILTERS += list(Facet.objects.all().values_list('slug', flat=True))
 
 # SENTRY
 SENTRY_DSN = AUTH_TOKENS.get('SENTRY_DSN', False)

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -27,8 +27,6 @@ if FEATURES.get('ENABLE_TAXOMAN', False):
         'STATS_FILE': taxoman.settings.stats_file,
     }
 
-    COURSE_DISCOVERY_FILTERS += list(Facet.objects.all().values_list('slug', flat=True))
-
 if DISABLE_DJANGO_TOOLBAR:
     from .common import INSTALLED_APPS, MIDDLEWARE_CLASSES
 

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -86,7 +86,7 @@ git+https://github.com/edx/edx-oauth2-provider.git@0.5.8#egg=edx-oauth2-provider
 git+https://github.com/edx/edx-val.git@0.0.8#egg=edxval==0.0.8
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
--e git+https://github.com/edx/edx-search.git@release-2015-11-17#egg=edx-search==0.1.1
+-e git+https://github.com/appsembler/edx-search.git@appsembler/taxoman_integration#egg=edx-search
 -e git+https://github.com/edx/edx-milestones.git@release-2015-11-17#egg=edx-milestones==0.1.5
 git+https://github.com/edx/edx-lint.git@v0.3.2#egg=edx_lint==0.3.2
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2


### PR DESCRIPTION
I tested this in devstack. Haven't tested yet on GCP. Will integrate these changes to the dogwood branch 'taxman-integration' and test on the taxoman demo server.


But what we have here does dynamic facet additions (meaning no restart of the django apps). I have not yet implemented deletions or renaming. The indexing information in CMS is ephemeral, reboots reload the data data from the facets in the database. This means the only artifacts hanging around will be in elastic search. This is follow on work as I learn more about how edX uses elastic search

But I'll do deletions and renames when we move this functionality to eucalyptus
