### PR TITLE
Allow importing arbitrary urlpatterns from Python modules

### DIFF
--- a/common/djangoapps/appsembler/README.md
+++ b/common/djangoapps/appsembler/README.md
@@ -1,0 +1,30 @@
+# URL pattern inclusion from environment config.
+
+Add to `lms.env.config` or `cms.env.config`, in the key 
+`APPSEMBLER_FEATURES`, e.g., :
+
+```
+"APPSEMBLER_FEATURES": {
+    "LMS_URLS_INCLUDE": [
+        ["^reporting/", "appsembler_reporting.urls"]
+    ] 
+}
+```
+
+where `"^reporting/"` is the regex for the URL prefix for the included URLs, 
+and `"appsembler_reporting.urls"` is the dotted path string to the module containing the urls.  URLs for the LMS should be added to the `LMS_URLS_INCLUDE`key; for the CMS, to `CMS_URLS_INCLUDE`.
+
+The module must contain a `urlpatterns` tuple, and should resemble:
+
+```
+from django.conf import settings
+from django.conf.urls import include, patterns, url
+
+urlpatterns = patterns(
+    'appsembler_reporting.views',
+    url(r'^$','index', name='index'),
+    url(r'^download$','download', name='download'),
+)
+```
+
+If the module cannot be imported, the URLs will be skipped and a warning message will be logged.  

--- a/common/djangoapps/appsembler/urls.py
+++ b/common/djangoapps/appsembler/urls.py
@@ -1,0 +1,33 @@
+import os 
+import logging
+
+
+from django.conf import settings
+from django.conf.urls import include, url
+
+
+SERVICE_URLS_INCLUDES = {'lms': 'LMS_URLS_INCLUDE',
+                         'cms': 'CMS_URLS_INCLUDE'
+                        }
+
+service_variant = os.environ.get('SERVICE_VARIANT', None)
+urls_include_conf = SERVICE_URLS_INCLUDES[service_variant]
+urlpatterns = ()
+
+if hasattr(settings, 'APPSEMBLER_FEATURES') and \
+        settings.APPSEMBLER_FEATURES.get(urls_include_conf, False):
+
+    for url_include in settings.APPSEMBLER_FEATURES[urls_include_conf]:
+        try:
+            # members of *_URLS_INCLUDE should be a list
+            # of format regex, dotted path
+            if type(url_include).__name__ == 'list':
+                regex = url_include[0]
+                dotted_path = url_include[1]
+                urlpatterns += ( url(regex, include(dotted_path)), )
+            else:
+                raise TypeError
+            
+        except (ImportError, TypeError):
+            logger = logging.getLogger(__name__)
+            logger.warn('lms.urls Could not import urls from {}.  Ignoring.'.format(dotted_path))

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1028,6 +1028,7 @@ if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
 # as specified in ENV config.
 if hasattr(settings, 'APPSEMBLER_FEATURES') and 
         settings.APPSEMBLER_FEATURES.get('LMS_URLS_INCLUDE', []):
+    import importlib
     for dotted_path in LMS_URLS_INCLUDE:
         try:
             urls_module = importlib.import_module(dotted_path) 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -17,6 +17,7 @@ from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from student.views import LogoutView
 
+
 # Uncomment the next two lines to enable the admin:
 if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     admin.autodiscover()
@@ -1026,14 +1027,7 @@ if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
 
 # allow inclusion of urls from arbitrary packages
 # as specified in ENV config.
-if hasattr(settings, 'APPSEMBLER_FEATURES') and \
-        settings.APPSEMBLER_FEATURES.get('LMS_URLS_INCLUDE', []):
-    import importlib
-    for dotted_path in settings.APPSEMBLER_FEATURES.get('LMS_URLS_INCLUDE'):
-        try:
-            urls_module = importlib.import_module(dotted_path) 
-            urlpatterns += urls_module.urlpatterns
-        except (ImportError, AttributeError):
-            import logging
-            logger = logging.getLogger(__name__)
-            logger.warn('lms.urls Could not import urls from {}.  Ignoring.'.format(dotted_path))
+if 'appsembler' in settings.INSTALLED_APPS:
+    urlpatterns += ( 
+        url('', include('appsembler.urls')),
+    )

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1026,10 +1026,10 @@ if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
 
 # allow inclusion of urls from arbitrary packages
 # as specified in ENV config.
-if hasattr(settings, 'APPSEMBLER_FEATURES') and 
+if hasattr(settings, 'APPSEMBLER_FEATURES') and \
         settings.APPSEMBLER_FEATURES.get('LMS_URLS_INCLUDE', []):
     import importlib
-    for dotted_path in LMS_URLS_INCLUDE:
+    for dotted_path in settings.APPSEMBLER_FEATURES.get('LMS_URLS_INCLUDE'):
         try:
             urls_module = importlib.import_module(dotted_path) 
             urlpatterns += urls_module.urlpatterns

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1023,3 +1023,16 @@ if settings.FEATURES.get('ENABLE_FINANCIAL_ASSISTANCE_FORM'):
             name='submit_financial_assistance_request'
         )
     )
+
+# allow inclusion of urls from arbitrary packages
+# as specified in ENV config.
+if hasattr(settings, 'APPSEMBLER_FEATURES') and 
+        settings.APPSEMBLER_FEATURES.get('LMS_URLS_INCLUDE', []):
+    for dotted_path in LMS_URLS_INCLUDE:
+        try:
+            urls_module = importlib.import_module(dotted_path) 
+            urlpatterns += urls_module.urlpatterns
+        except (ImportError, AttributeError):
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warn('lms.urls Could not import urls from {}.  Ignoring.'.format(dotted_path))


### PR DESCRIPTION
Looks for a new `APPSEMBLER_FEATURES` setting, `LMS_URLS_INCLUDE` which will hold a list of Python dotted paths.  Will try to import `urlpatterns` from the dotted path module and add these patterns to LMS `urls.py`'s `urlpatterns`.  It will log a warning if it can't import the module or find `urlpatterns`, otherwise ignores the error.

The purpose is to avoid having to branch edx-platform just to add some additional URLs from an independently deployed app.  My immediate purpose is to include `trinityeduedx` package's URLs instead of carrying forward changes to that client's Dogwood edx-platform into the Eucalyptus deployment.  

