### PR TITLE
add the ability to merge first an last name in SSO process

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -223,9 +223,13 @@ class ProviderConfig(ConfigurationModel):
             else:
                 suggested_username = suggested_username[:30] if len(suggested_username) > 30 else suggested_username
         #
+        if settings.APPSEMBLER_FEATURES.get('ENABLE_THIRD_PARTY_AUTH_MERGE_FIRST_LAST_NAME', False):
+            suggester_personal_name = "%s %s" % (details.get('first_name', ''), details.get('last_name', ''))
+        else:
+            suggester_personal_name = details.get('fullname', '')
         return {
             'email': details.get('email', ''),
-            'name': details.get('fullname', ''),
+            'name': suggester_personal_name,
             'username': suggested_username,
         }
 


### PR DESCRIPTION
This PR is really useful for SSO customers, that are using an IdP that releases the First and Last name separately only.