### PR TITLE
modify user connect endpoint to allow to change password, email and name

### DIFF
--- a/lms/djangoapps/appsembler_api/apidocs.md
+++ b/lms/djangoapps/appsembler_api/apidocs.md
@@ -120,14 +120,17 @@ Cache-Control: no-cache
 
 
 ### Connect User Account
-This endpoint connects an existing Open edX user account to one in an external system. The endpoint basically set a new password for the user.
+This endpoint connects an existing Open edX user account to one in an external system. The endpoint basically has the ability to given a username, change the user email, password and name.
 
 * URL: `/appsembler_api/v0/accounts/connect`
 * Method: `POST`
 * Data Params
     * Required:
-        * `password`
+        * `username`
+    * Optional:
         * `email`
+        * `password`
+        * `name`
 
 * Success Response
     * Code: 200
@@ -148,6 +151,14 @@ This endpoint connects an existing Open edX user account to one in an external s
     * Content: {"user_message": "User not found"}
     * Reason: No user exists with the provided email address.
 
+    * Code: 409
+    * Content: ["user_message": "The email test@example.com is already in user"}
+    * Reason: The email that you're trying to set, already exist for other user.
+
+    * Code: 409
+    * Content: ["user_message": "Invalid email format"}
+    * Reason: Error in the email format.
+
 * Example call:
 ```
 POST /appsembler_api/v0/accounts/connect
@@ -156,8 +167,10 @@ Content-Type: application/json
 Authorization: Bearer cbf6a5de322cf6a4323c957a882xy1s321c954b86
 Cache-Control: no-cache
 {
-    "password": "edx",
-    "email": "staff55@example.com",
+    "username": "test_user",
+	"name": "Test User",
+	"email": "test_user@example.com",
+	"password": "new@pass"
 }
 ```
 

--- a/lms/djangoapps/appsembler_api/apidocs.md
+++ b/lms/djangoapps/appsembler_api/apidocs.md
@@ -120,7 +120,7 @@ Cache-Control: no-cache
 
 
 ### Connect User Account
-This endpoint connects an existing Open edX user account to one in an external system. The endpoint basically has the ability to given a username, change the user email, password and name.
+This endpoint connects an existing Open edX user account to one in an external system. Given a username, the endpoint has the ability to change the user email, password and name.
 
 * URL: `/appsembler_api/v0/accounts/connect`
 * Method: `POST`
@@ -152,8 +152,8 @@ This endpoint connects an existing Open edX user account to one in an external s
     * Reason: No user exists with the provided email address.
 
     * Code: 409
-    * Content: ["user_message": "The email test@example.com is already in user"}
-    * Reason: The email that you're trying to set, already exist for other user.
+    * Content: ["user_message": "The email test@example.com is in use by another user"}
+    * Reason: The email that you're trying to set is in use by another user.
 
     * Code: 409
     * Content: ["user_message": "Invalid email format"}

--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -172,7 +172,7 @@ class UserAccountConnect(APIView):
     def post(self, request):
         """
         Connects an existing Open edX user account to one in an external system
-        changing the user password, email or Full Name.
+        changing the user password, email or full name.
 
         URL: /appsembler_api/v0/accounts/connect
         Arguments:
@@ -209,7 +209,7 @@ class UserAccountConnect(APIView):
 
                     if check_account_exists(email=new_email):
                         errors = {
-                            "user_message": "The email %s is already in user" % (
+                            "user_message": "The email %s is in use by another user" % (
                             new_email)}
                         return Response(errors, status=409)
 

--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -9,6 +9,7 @@ from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.http import Http404
+from django.core.validators import validate_email
 
 from rest_framework.views import APIView
 from rest_framework import status
@@ -171,15 +172,17 @@ class UserAccountConnect(APIView):
     def post(self, request):
         """
         Connects an existing Open edX user account to one in an external system
-        changing the user password.
+        changing the user password, email or Full Name.
 
         URL: /appsembler_api/v0/accounts/connect
         Arguments:
             request (HttpRequest)
             JSON (application/json)
             {
-                "email": "staff4@example.com",
+                "username": "staff4@example.com", # mandatory, the lookup param
                 "password": "edx",
+                "email": staff@example.com,
+                "name": "Staff edX"
             }
         Returns:
             HttpResponse: 200 on success, {"user_id ": 60}
@@ -189,16 +192,36 @@ class UserAccountConnect(APIView):
         """
         data = request.data
 
-        email = data.get('email', '')
+        username = data.get('username', '')
+        new_email = data.get('email', '')
         new_password = data.get('password', '')
+        new_name = data.get('name', '')
 
         try:
-            user = User.objects.get(email=email)
+            user = User.objects.get(username=username)
 
-            if not new_password.strip():
-                raise ValidationError('Password is empty')
+            if new_password.strip() != "":
+                user.set_password(new_password)
 
-            user.set_password(new_password)
+            if new_email.strip() != "":
+                try:
+                    validate_email(new_email)
+
+                    if check_account_exists(email=new_email):
+                        errors = {
+                            "user_message": "The email %s is already in user" % (
+                            new_email)}
+                        return Response(errors, status=409)
+
+                    user.email = new_email
+                except ValidationError:
+                    errors = {"user_message": "Invalid email format"}
+                    return Response(errors, status=409)
+
+            if new_name.strip() != "":
+                user.profile.name = new_name
+                user.profile.save()
+
             user.save()
 
         except User.DoesNotExist:


### PR DESCRIPTION
Here are the requested changes on the user connect endpoint, previously the endpoint only allowed to change password, receiving the email as a parameter.

Now the endpoint receives the username (the only not changeable param) and receives name and/or password and/or email to change. 