### PR TITLE
add certificate status to the course api

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -71,7 +71,12 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     start_display = serializers.CharField()
     start_type = serializers.CharField()
     pacing = serializers.CharField()
-
+    certificates_display_behavior = serializers.CharField()
+    certificates_show_before_end = serializers.BooleanField()
+    cert_html_view_enabled = serializers.BooleanField()
+    has_any_active_web_certificate = serializers.BooleanField()
+    cert_name_short = serializers.CharField()
+    cert_name_long = serializers.CharField()
     # 'course_id' is a deprecated field, please use 'id' instead.
     course_id = serializers.CharField(source='id', read_only=True)
 

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -51,8 +51,13 @@ class CourseDetailView(DeveloperErrorViewMixin, RetrieveAPIView):
             * `"string"`: manually set by the course author
             * `"timestamp"`: generated from the `start` timestamp
             * `"empty"`: no start date is specified
-        * pacing: Course pacing. Possible values: instructor, self
-
+        * pacing: Course pacing. Possible values: instructor, self,
+	* certificates_display_behavior: end,
+        * certificates_show_before_end: false,
+        * cert_html_view_enabled': true,
+        * has_any_active_web_certificate': false,
+        * cert_name_short': '',
+        * cert_name_long': '',
         Deprecated fields:
 
         * blocks_url: Used to fetch the course blocks
@@ -96,7 +101,13 @@ class CourseDetailView(DeveloperErrorViewMixin, RetrieveAPIView):
                 "start": "2015-07-17T12:00:00Z",
                 "start_display": "July 17, 2015",
                 "start_type": "timestamp",
-                "pacing": "instructor"
+                "pacing": "instructor",
+		"certificates_display_behavior': "end",
+                "certificates_show_before_end': false,
+                "cert_html_view_enabled': true,
+                "has_any_active_web_certificate': false,
+                "cert_name_short': "",
+                "cert_name_long': "",
             }
     """
 


### PR DESCRIPTION
Added the certificate fields serializers for the instance of the course model.
Also changed the views (added the information about the cert fields in json) for be visible in the help text in DRF.