### PR TITLE
Index and use display_org_with_default for course discovery

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -567,6 +567,7 @@ class CourseAboutSearchIndexer(object):
         AboutInfo("enrollment_start", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("enrollment_end", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("org", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("display_org_with_default", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("modes", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_MODE),
         AboutInfo("language", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("catalog_visibility", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),

--- a/lms/static/js/discovery/models/course_card.js
+++ b/lms/static/js/discovery/models/course_card.js
@@ -17,6 +17,7 @@ define(['backbone'], function (Backbone) {
             start: '',
             image_url: '',
             org: '',
+            display_org_with_default: '',
             id: ''
         }
     });

--- a/lms/templates/discovery/course_card.underscore
+++ b/lms/templates/discovery/course_card.underscore
@@ -8,7 +8,7 @@
         </header>
         <section class="course-info" aria-hidden="true">
             <h2 class="course-name">
-                <span class="course-organization"><%- org %></span>
+                <span class="course-organization"><%- display_org_with_default %></span>
                 <span class="course-code"><%- content.number %></span>
                 <span class="course-title"><%- content.display_name %></span>
             </h2>


### PR DESCRIPTION
Course discovery currently can only use the normal 'org' of the course, but Studio offers an Advanced Setting to override the display of the org with a different name.  
Add a new index property to the "course_info" document type of the "courseware_index".  Update underscore template and Backbone model to use it.