### PR TITLE
SLO support for edx-platform

### DIFF
--- a/cms/envs/devstack_appsembler.py
+++ b/cms/envs/devstack_appsembler.py
@@ -76,3 +76,6 @@ elif 'appsembler_usage' in DATABASES:
     # if the AppsemblerUsageRouter isn't enabled, then avoid mistakes by
     # removing the database alias
     del DATABASES['appsembler_usage']
+
+# to allow to run python-saml with custom port
+SP_SAML_RESTRICT_MODE = False

--- a/common/djangoapps/third_party_auth/migrations/0003_samlproviderdata_slo_url.py
+++ b/common/djangoapps/third_party_auth/migrations/0003_samlproviderdata_slo_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0002_schema__provider_icon_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='samlproviderdata',
+            name='slo_url',
+            field=models.URLField(null=True, verbose_name=b'SLO URL'),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/migrations/0004_samlconfiguration_slo_redirect_url.py
+++ b/common/djangoapps/third_party_auth/migrations/0004_samlconfiguration_slo_redirect_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0003_samlproviderdata_slo_url'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='samlconfiguration',
+            name='slo_redirect_url',
+            field=models.CharField(default=b'/logout', help_text=b'The url to redirect the user after process the SLO response', max_length=255, verbose_name=b'SLO post redirect URL', blank=True),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -399,6 +399,7 @@ class SAMLProviderConfig(ProviderConfig):
             raise AuthNotConfigured(provider_name=self.name)
         conf['x509cert'] = data.public_key
         conf['url'] = data.sso_url
+        conf['slo_url'] = data.slo_url
         return SAMLIdentityProvider(self.idp_slug, **conf)
 
 
@@ -440,6 +441,13 @@ class SAMLConfiguration(ConfigurationModel):
             "JSON object defining advanced settings that are passed on to python-saml. "
             "Valid keys that can be set here include: SECURITY_CONFIG and SP_EXTRA"
         ),
+    )
+    slo_redirect_url = models.CharField(
+        max_length=255,
+        default='/logout',
+        verbose_name="SLO post redirect URL",
+        help_text="The url to redirect the user after process the SLO response",
+        blank=True
     )
 
     class Meta(object):
@@ -494,6 +502,8 @@ class SAMLConfiguration(ConfigurationModel):
             }
             contact.update(other_config.get(name, {}))
             return contact
+        if name == "LOGOUT_REDIRECT_URL":
+            return self.slo_redirect_url
         return other_config[name]  # SECURITY_CONFIG, SP_EXTRA, or similar extra settings
 
 
@@ -509,6 +519,7 @@ class SAMLProviderData(models.Model):
 
     entity_id = models.CharField(max_length=255, db_index=True)  # This is the key for lookups in this table
     sso_url = models.URLField(verbose_name="SSO URL")
+    slo_url = models.URLField(verbose_name="SLO URL", null=True)
     public_key = models.TextField()
 
     class Meta(object):

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -504,6 +504,8 @@ class SAMLConfiguration(ConfigurationModel):
             return contact
         if name == "LOGOUT_REDIRECT_URL":
             return self.slo_redirect_url
+        if name == "SP_SAML_RESTRICT_MODE":
+            return getattr(settings, 'SP_SAML_RESTRICT_MODE', True)
         return other_config[name]  # SECURITY_CONFIG, SP_EXTRA, or similar extra settings
 
 

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -336,6 +336,34 @@ def get_login_url(provider_id, auth_entry, redirect_url=None):
         extra_params=enabled_provider.get_url_params(),
     )
 
+def get_logout_url(provider_id, auth_entry, redirect_url=None):
+    """Gets URL for the endpoint that starts the SLO process.
+
+    Args:
+        provider_id: string identifier of the models.ProviderConfig child you want
+            to disconnect from.
+        auth_entry: string. Query argument specifying the desired entry point
+            for the auth pipeline. Used by the pipeline for later branching.
+            Must be one of _AUTH_ENTRY_CHOICES.
+
+    Keyword Args:
+        redirect_url (string): If provided, redirect to this URL at the end
+            of the authentication process.
+
+    Returns:
+        String. URL that starts the SLO process.
+
+    Raises:
+        ValueError: if no provider is enabled with the given ID.
+    """
+    enabled_provider = _get_enabled_provider(provider_id)
+    return _get_url(
+        'social:end',
+        enabled_provider.backend_name,
+        auth_entry=auth_entry,
+        redirect_url=redirect_url,
+        extra_params=enabled_provider.get_url_params(),
+    )
 
 def get_duplicate_provider(messages):
     """Gets provider from message about social account already in use.

--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -137,7 +137,6 @@ def _parse_metadata_xml(xml, entity_id):
     except KeyError:
         slo_url = ""
         log.info("Unable to find SLO URL with HTTP-Redirect binding.")
-    log.info(slo_url)
     return public_key, sso_url, slo_url, expires_at
 
 

--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -70,8 +70,8 @@ def fetch_saml_metadata():
 
             for entity_id in entity_ids:
                 log.info(u"Processing IdP with entityID %s", entity_id)
-                public_key, sso_url, expires_at = _parse_metadata_xml(xml, entity_id)
-                changed = _update_data(entity_id, public_key, sso_url, expires_at)
+                public_key, sso_url, slo_url, expires_at = _parse_metadata_xml(xml, entity_id)
+                changed = _update_data(entity_id, public_key, sso_url, slo_url, expires_at)
                 if changed:
                     log.info(u"→ Created new record for SAMLProviderData")
                     num_changed += 1
@@ -123,16 +123,25 @@ def _parse_metadata_xml(xml, entity_id):
         raise MetadataParseError("Public Key missing. Expected an <X509Certificate>")
     public_key = public_key.replace(" ", "")
     binding_elements = sso_desc.iterfind("./{}".format(etree.QName(SAML_XML_NS, "SingleSignOnService")))
+    binding_elements_slo = sso_desc.iterfind("./{}".format(etree.QName(SAML_XML_NS, "SingleLogoutService")))
     sso_bindings = {element.get('Binding'): element.get('Location') for element in binding_elements}
+    slo_bindings = {element.get('Binding'): element.get('Location') for element in binding_elements_slo}
     try:
         # The only binding supported by python-saml and python-social-auth is HTTP-Redirect:
         sso_url = sso_bindings['urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']
     except KeyError:
         raise MetadataParseError("Unable to find SSO URL with HTTP-Redirect binding.")
-    return public_key, sso_url, expires_at
+    try:
+        # The only binding supported by python-saml and python-social-auth is HTTP-Redirect:
+        slo_url = slo_bindings['urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']
+    except KeyError:
+        slo_url = ""
+        log.info("Unable to find SLO URL with HTTP-Redirect binding.")
+    log.info(slo_url)
+    return public_key, sso_url, slo_url, expires_at
 
 
-def _update_data(entity_id, public_key, sso_url, expires_at):
+def _update_data(entity_id, public_key, sso_url, slo_url, expires_at):
     """
     Update/Create the SAMLProviderData for the given entity ID.
     Return value:
@@ -141,7 +150,7 @@ def _update_data(entity_id, public_key, sso_url, expires_at):
     """
     data_obj = SAMLProviderData.current(entity_id)
     fetched_at = datetime.datetime.now()
-    if data_obj and (data_obj.public_key == public_key and data_obj.sso_url == sso_url):
+    if data_obj and (data_obj.public_key == public_key and data_obj.sso_url == sso_url and data_obj.slo_url == slo_url):
         data_obj.expires_at = expires_at
         data_obj.fetched_at = fetched_at
         data_obj.save()
@@ -152,6 +161,7 @@ def _update_data(entity_id, public_key, sso_url, expires_at):
             fetched_at=fetched_at,
             expires_at=expires_at,
             sso_url=sso_url,
+            slo_url=slo_url,
             public_key=public_key,
         )
         return True

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -101,3 +101,6 @@ elif 'appsembler_usage' in DATABASES:
     # if the AppsemblerUsageRouter isn't enabled, then avoid mistakes by
     # removing the database alias
     del DATABASES['appsembler_usage']
+
+# to allow to run python-saml with custom port
+SP_SAML_RESTRICT_MODE = False


### PR DESCRIPTION
This PR is a follow up of https://github.com/appsembler/python-social-auth/pull/1

The PR adds support for SLO, using our fork of python-social-auth.

The PR includes changes for:
* set `SP_SAML_RESTRICT_MODE` in devstack, so we can run the entire SAML backend and pipeline.
* New field to store the SAML SLO url on the SAMLProvidersData Model.
* New field to store the post logout redirect url on the SAMLProvidersData Model, default is `/logout` the edx default logout URL.
* Migrations for those fields.
* Modofication on the IdP metadata retrieving task to store the SLO url on the new fields.
* New Pipeline method to retrieve the SLO url.