### PR TITLE
add editable field for custom course duration

### DIFF
--- a/openedx/core/djangoapps/appsembler/external_courses/admin.py
+++ b/openedx/core/djangoapps/appsembler/external_courses/admin.py
@@ -1,0 +1,16 @@
+from django.contrib import admin
+
+from openedx.core.djangoapps.appsembler.external_courses.models import ExternalCourseTile
+
+@admin.register(ExternalCourseTile)
+class ExternalCourseTileAdmin(admin.ModelAdmin):
+
+    fields = ('course_duration', 'course_key', 'title', 'org', 'course_link', 'image_url', 'starts', 'ends', 'pacing_type', 'is_credit_eligible', 'is_verified_eligible')
+    readonly_fields = ('course_key', 'title', 'org', 'course_link', 'image_url', 'starts', 'ends', 'pacing_type', 'is_credit_eligible', 'is_verified_eligible')
+
+
+    class Meta:
+        verbose_name = "External Course"
+        verbose_name_plural = "External Courses"
+
+#admin.site.register(ExternalCourseTile)

--- a/openedx/core/djangoapps/appsembler/external_courses/admin.py
+++ b/openedx/core/djangoapps/appsembler/external_courses/admin.py
@@ -12,5 +12,3 @@ class ExternalCourseTileAdmin(admin.ModelAdmin):
     class Meta:
         verbose_name = "External Course"
         verbose_name_plural = "External Courses"
-
-#admin.site.register(ExternalCourseTile)

--- a/openedx/core/djangoapps/appsembler/external_courses/migrations/0002_externalcoursetile_course_duration.py
+++ b/openedx/core/djangoapps/appsembler/external_courses/migrations/0002_externalcoursetile_course_duration.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('external_courses', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='externalcoursetile',
+            name='course_duration',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/openedx/core/djangoapps/appsembler/external_courses/models.py
+++ b/openedx/core/djangoapps/appsembler/external_courses/models.py
@@ -18,6 +18,7 @@ class ExternalCourseTile(models.Model):
     pacing_type = models.CharField(max_length=255, null=False, blank=False)
     is_credit_eligible = models.BooleanField(default=False)
     is_verified_eligible = models.BooleanField(default=False)
+    course_duration = models.CharField(max_length=255, null=True, blank=True)
 
     def __unicode__(self):
         return "%s (%s)" % (self.title, self.org)


### PR DESCRIPTION
Currently the edu.org API doesn’t release the field “course duration”. We’re calculating the value based on the start and end date. But for some courses isn’t 100% accurate, this allows to edit a course duration fields, on the stored external courses, and in the theme, only display this value if is set.