### PR TITLE
Don't assume settings has custom Intercom-related attributes

### DIFF
--- a/common/djangoapps/appsembler/models.py
+++ b/common/djangoapps/appsembler/models.py
@@ -18,9 +18,9 @@ from course_action_state.models import CourseRerunState
 #     # `course_creators` app is included only in the Studio
 #     CourseCreator = None
 
-intercom.Intercom.app_id = settings.INTERCOM_APP_ID
-intercom.Intercom.api_key = settings.INTERCOM_API_KEY
-INTERCOM_USER_EMAIL = settings.INTERCOM_USER_EMAIL
+intercom.Intercom.app_id = getattr(settings, "INTERCOM_APP_ID", None)
+intercom.Intercom.api_key = getattr(settings, "INTERCOM_API_KEY", None)
+INTERCOM_USER_EMAIL = getattr(settings, "INTERCOM_USER_EMAIL", None)
 
 
 def intercom_update(custom_data, verbose):


### PR DESCRIPTION
This is a simple PR and I'm going to merge it myself, but wanted to point it out.  Metalogix is still on Dogwood, but this kind of change should probably be made up through our ficus releases.
It appears that at least for Metalogix, the task `contentstore.tasks.rerun_course` isn't getting called with `aws_appsembler` settings, but with `aws` only, so the Intercom settings are not set.  If somebody has a good understanding already of the way that task gets called would be great to know.  Ultimately we will want to make sure it is getting called with the correct settings, but for this case I just made a small commit for more defensive checking of the related settings.

@johnbaldwin @tkeemon @melvinsoft @amirtds   