### PR TITLE
push matplotlib to post requirements

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -13,7 +13,6 @@ numpy==1.6.2
 networkx==1.7
 sympy==0.7.1
 pyparsing==2.0.7
-matplotlib==1.3.1
 
 # We forked NLTK just to make it work with setuptools instead of distribute
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6

--- a/requirements/edx-sandbox/post.txt
+++ b/requirements/edx-sandbox/post.txt
@@ -7,3 +7,4 @@
 # Packages to install in the Python sandbox for secured execution.
 scipy==0.14.0
 lxml==3.4.4
+matplotlib==1.3.1


### PR DESCRIPTION
This commit currently exists upstream in:
 
https://github.com/edx/edx-platform/tree/open-release/ficus.master 

Here's my understanding of the situation:

- a new version of numpy was released recently
- matplotlib tries to pull in the newest version of numpy as a dependency 
- the newest version of numpy doesn't correctly build inside the edxapp_sandbox venv

Here's the discussion: 

https://groups.google.com/d/msg/openedx-ops/XB86A6MaCOs/NvcSwR0KAQAJ