### PR TITLE
[WIP] Add a "confirmation" listener to the XBlock runtime

### DIFF
--- a/common/static/common/templates/components/system-feedback.underscore
+++ b/common/static/common/templates/components/system-feedback.underscore
@@ -40,8 +40,8 @@
 
     <% if(obj.closeIcon) { %>
     <a href="#" rel="view" class="action action-close action-<%= type %>-close">
-      <span class="icon fa fa-times-circle" aria-hidden="true"></span>
-      <span class="label">close <%= type %></span>
+      <span class="icon fa fa-times" aria-hidden="true"></span>
+      <span class="label">close</span>
     </a>
     <% } %>
   </div>


### PR DESCRIPTION
This modifies studio's XBlock JavaScript runtime to enable a new "confirmation" alert. This is used in the launchcontainer XBlock. 

The relevant code that calls this is in an [open PR](https://github.com/appsembler/xblock-launchcontainer/pull/9/files#diff-835809c1c107deabab1c34b28d3daf4eR26) in the xblock-launchcontainer repo.