### PR TITLE
Use site_configuration helper to get url base for activation email

### DIFF
--- a/lms/templates/emails/activation_email.txt
+++ b/lms/templates/emails/activation_email.txt
@@ -1,5 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
+
 ${_("Thank you for creating an account with {platform_name}!").format(
     platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
 )}
@@ -11,10 +12,11 @@ ${_("There's just one more step before you can enroll in a course: "
         platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
     )}
 
+<% base_url=configuration_helpers.get_value('SITE_NAME', settings.SITE_NAME) %>
 % if is_secure:
-  https://${ site }/activate/${ key }
+  https://${ base_url }/activate/${ key }
 % else:
-  http://${ site }/activate/${ key }
+  http://${ base_url }/activate/${ key }
 % endif
 ${_("If you didn't create an account, you don't need to do anything; you "
       "won't receive any more email from us. If you need assistance, please "


### PR DESCRIPTION
Student account activation email was not respecting SITE_NAME (which is actually a domain name) from `openedx.core.djangoapps.site_configuration.helpers`.  This PR fixes that.