### PR TITLE
Fix XBLOCK_SETTINGS in CMS devstack

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -96,11 +96,7 @@ FEATURES['ENTRANCE_EXAMS'] = True
 ################################ COURSE LICENSES ################################
 FEATURES['LICENSING'] = True
 # Needed to enable licensing on video modules
-XBLOCK_SETTINGS = {
-    "VideoDescriptor": {
-        "licensing_enabled": True
-    }
-}
+XBLOCK_SETTINGS.update({'VideoDescriptor': {'licensing_enabled': True}})
 
 ################################ SEARCH INDEX ################################
 FEATURES['ENABLE_COURSEWARE_INDEX'] = True


### PR DESCRIPTION
This fixes an issue in CMS devstack env where all JSON-defined XBLOCK_SETTINGS get removed 