### PR TITLE
(WIP) Course Roles API

### DIFF
--- a/lms/djangoapps/appsembler_api/serializers.py
+++ b/lms/djangoapps/appsembler_api/serializers.py
@@ -2,10 +2,22 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import serializers
 
+from student.roles import (
+    REGISTERED_ACCESS_ROLES,
+    CourseRole,
+)
+
+
+COURSE_ROLES = [
+    role_class for role_class in REGISTERED_ACCESS_ROLES.values()
+    if issubclass(role_class, CourseRole)
+]
+
 
 class StringListField(serializers.ListField):
     def to_internal_value(self, data):
         return data.split(',')
+
 
 class BulkEnrollmentSerializer(serializers.Serializer):
     identifiers = serializers.CharField(required=True)
@@ -31,3 +43,21 @@ class BulkEnrollmentSerializer(serializers.Serializer):
             except InvalidKeyError:
                 raise serializers.ValidationError("Course key not valid: {}".format(course))
         return value
+
+
+class CourseRolesSerializer(serializers.Serializer):
+    roles = serializers.SerializerMethodField()
+
+    def get_roles(self, course):
+        users_by_role = {}
+
+        for role_cls in COURSE_ROLES:
+            role = role_cls(course.id)
+
+            users_by_role[role.ROLE] = [{
+                'id': user.id,
+                'email': user.email,
+                'username': user.username,
+            } for user in role.users_with_role()]
+
+        return users_by_role

--- a/lms/djangoapps/appsembler_api/tests/__init__.py
+++ b/lms/djangoapps/appsembler_api/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for the Appsembler API django app.
+"""

--- a/lms/djangoapps/appsembler_api/tests/test_views.py
+++ b/lms/djangoapps/appsembler_api/tests/test_views.py
@@ -1,0 +1,173 @@
+"""
+Tests for the Appsembler API views.
+"""
+from urllib import urlencode, quote
+
+from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
+from mock import patch
+from rest_framework import status
+import json
+import ddt
+from rest_framework.permissions import AllowAny
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from course_api.tests.test_views import CourseApiTestViewMixin
+from student.roles import REGISTERED_ACCESS_ROLES, CourseRole, CourseStaffRole, CourseInstructorRole
+from student.tests.factories import UserFactory
+from appsembler_api.views import CourseRolesView
+
+
+@ddt.ddt
+@patch.object(CourseRolesView, 'permission_classes', [AllowAny])  # Skip authentication for tests
+class CourseRolesViewTestCase(SharedModuleStoreTestCase):
+    COURSE_ROLES = [
+        role_class for role_class in REGISTERED_ACCESS_ROLES.values()
+        if issubclass(role_class, CourseRole)
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Course is created here and shared by all the class's tests.
+        """
+        super(CourseRolesViewTestCase, cls).setUpClass()
+        cls.course = CourseFactory.create()
+
+    def setUp(self):
+        super(CourseRolesViewTestCase, self).setUp()
+        self.api_url = reverse('course_roles_api', args=[unicode(self.course.id)])
+
+    @ddt.data(*COURSE_ROLES)
+    def test_ensure_empty_roles(self, role_class):
+        users = role_class(self.course.id).users_with_role()
+        self.assertFalse(users)  # Course should not have anyone in the roles by default
+
+    @ddt.data(*COURSE_ROLES)
+    def test_empty_roles(self, role_class):
+        res = self.client.get(self.api_url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        roles = res.data['roles']
+        self.assertFalse(roles[role_class.ROLE])  # The API should provide no roles when there isn't any
+
+    def test_basic_get(self):
+        staff_1 = UserFactory.create()
+        staff_2 = UserFactory.create()
+        instructor = UserFactory.create()
+
+        CourseInstructorRole(self.course.id).add_users(instructor)
+        CourseStaffRole(self.course.id).add_users(staff_1)
+        CourseStaffRole(self.course.id).add_users(staff_2)
+
+        res = self.client.get(self.api_url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+        roles = res.data['roles']
+
+        self.assertEqual(len(roles['instructor']), 1)  # Should have one instructor
+        self.assertEqual(len(roles['staff']), 2)  # Should have two staff
+
+        self.assertEqual(instructor.username, roles['instructor'][0]['username'])
+
+        staff_usernames = [user['username'] for user in roles['staff']]
+        self.assertIn(staff_1.username, staff_usernames)
+        self.assertIn(staff_2.username, staff_usernames)
+
+    def test_basic_put(self):
+        staff = UserFactory.create()
+        instructor_1 = UserFactory.create()
+        instructor_2 = UserFactory.create()
+
+        instructor_role = CourseInstructorRole(self.course.id)
+        staff_role = CourseStaffRole(self.course.id)
+
+        res = self.client.put(self.api_url, content_type='application/json', data=json.dumps({
+            'roles': {
+                'staff': [
+                    staff.username,
+                ],
+                'instructor': [
+                    instructor_1.username,
+                    instructor_2.email,
+                ],
+            },
+        }))
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+        self.assertTrue(staff_role.has_user(staff), 'Should be staff')
+        self.assertTrue(instructor_role.has_user(instructor_1), 'Should be instructor')
+        self.assertTrue(instructor_role.has_user(instructor_2), 'Should be instructor')
+
+    def test_delete(self):
+        instructor = UserFactory.create()
+        staff = UserFactory.create()
+
+        instructor_role = CourseInstructorRole(self.course.id)
+        staff_role = CourseStaffRole(self.course.id)
+
+        instructor_role.add_users(instructor)
+        staff_role.add_users(staff)
+
+        roles_to_delete = quote(json.dumps({
+            'staff': [staff.username],
+        }))
+
+        def assert_proper_deletion(res):
+            """
+            Make sure deletion is properly implemented and idempotent.
+            """
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+            self.assertTrue(instructor_role.has_user(instructor), 'Should stay as instructor')
+            self.assertFalse(staff_role.has_user(staff), 'Should be removed from the staff')
+
+        first_res = self.client.delete(u'{url}?roles={roles}'.format(
+            url=self.api_url,
+            roles=roles_to_delete,
+        ))
+
+        assert_proper_deletion(first_res)
+
+        second_res = self.client.delete(u'{url}?roles={roles}'.format(
+            url=self.api_url,
+            roles=roles_to_delete,
+        ))
+
+        assert_proper_deletion(second_res)
+
+    def test_put_de_duplication(self):
+        instructor = UserFactory.create()
+        instructor_to_be = UserFactory.create()
+
+        instructor_role = CourseInstructorRole(self.course.id)
+        staff_role = CourseStaffRole(self.course.id)
+
+        res = self.client.put(self.api_url, content_type='application/json', data=json.dumps({
+            'roles': {
+                'staff': [
+                    instructor_to_be.username,
+                ],
+                'instructor': [
+                    instructor.email,
+                ],
+            },
+        }))
+
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+        duplicate_res = self.client.put(self.api_url, content_type='application/json', data=json.dumps({
+            'roles': {
+                'instructor': [
+                    instructor_to_be.username,
+                ],
+            },
+        }))
+
+        self.assertEqual(duplicate_res.status_code, status.HTTP_200_OK)
+
+        # Make both are still instructors
+        self.assertTrue(instructor_role.has_user(instructor), 'Should be an instructor')
+        self.assertTrue(instructor_role.has_user(instructor_to_be), 'Should have become an instructor')
+        self.assertFalse(staff_role.has_user(instructor_to_be),
+                         'Should be removed from the staff, there should be no duplicates')

--- a/lms/djangoapps/appsembler_api/tests/test_views.py
+++ b/lms/djangoapps/appsembler_api/tests/test_views.py
@@ -1,10 +1,9 @@
 """
 Tests for the Appsembler API views.
 """
-from urllib import urlencode, quote
+from urllib import quote
 
 from django.core.urlresolvers import reverse
-from django.test.utils import override_settings
 from mock import patch
 from rest_framework import status
 import json
@@ -13,7 +12,6 @@ from rest_framework.permissions import AllowAny
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from course_api.tests.test_views import CourseApiTestViewMixin
 from student.roles import REGISTERED_ACCESS_ROLES, CourseRole, CourseStaffRole, CourseInstructorRole
 from student.tests.factories import UserFactory
 from appsembler_api.views import CourseRolesView

--- a/lms/djangoapps/appsembler_api/urls.py
+++ b/lms/djangoapps/appsembler_api/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import patterns, url
+from django.conf import settings
 
 from appsembler_api import views
 
@@ -22,5 +23,13 @@ urlpatterns = patterns(
     # enrollment analytics API
     url(r'^analytics/accounts/batch', views.GetBatchUserDataView.as_view(), name="get_batch_user_data"),
     url(r'^analytics/enrollment/batch', views.GetBatchEnrollmentDataView.as_view(), name="get_batch_enrollment_data"),
-)
 
+    # Course-level permissions API
+    url(
+        r'^courses/{course_id_pattern}/roles'.format(
+            course_id_pattern=settings.COURSE_ID_PATTERN,
+        ),
+        views.CourseRolesView.as_view(),
+        name='course_roles_api',
+    ),
+)

--- a/lms/djangoapps/appsembler_api/urls.py
+++ b/lms/djangoapps/appsembler_api/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import patterns, url
 from django.conf import settings
+from django.conf.urls import patterns, url
 
 from appsembler_api import views
 

--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -5,29 +5,36 @@ import random
 
 from dateutil import parser
 
-from django.http import Http404
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.core.urlresolvers import reverse
-from django.core.validators import validate_email
 from django.contrib.auth.models import User
 from django.db.models import Q
+from django.http import Http404
+from django.core.validators import validate_email
 
+from rest_framework.views import APIView
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from util.bad_request_rate_limiter import BadRequestRateLimiter
 from util.disable_rate_limit import can_disable_rate_limit
 
 from openedx.core.djangoapps.user_api.accounts.api import check_account_exists
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import (
+    OAuth2AuthenticationAllowInactiveUser,
+)
 from openedx.core.lib.api.permissions import (
     IsStaffOrOwner, ApiKeyHeaderPermissionIsAuthenticated
 )
 
 from student.views import create_account_with_params
-from student.models import CourseEnrollment, EnrollmentClosedError, \
-    CourseFullError, AlreadyEnrolledError, CourseAccessRole
+from student.models import (
+    CourseEnrollment,
+    EnrollmentClosedError,
+    CourseFullError,
+    AlreadyEnrolledError,
+    CourseAccessRole,
+)
 from student.roles import CourseRole
 
 from course_modes.models import CourseMode
@@ -35,7 +42,8 @@ from courseware.courses import get_course_by_id
 from enrollment.views import EnrollmentCrossDomainSessionAuth, \
     EnrollmentUserThrottle, ApiKeyPermissionMixIn
 
-from instructor.views.api import save_registration_code, students_update_enrollment
+from instructor.views.api import save_registration_code, \
+    students_update_enrollment, require_level
 
 from shoppingcart.exceptions import RedemptionCodeError
 from shoppingcart.models import (


### PR DESCRIPTION
An API to manage course roles for a specific course. This API offers three idempotent REST verbs to manage the roles: GET, PUT and DELETE. The API attempts to provide a consistent behavior with the Studio interface whenever possible.

### Manual Testing
I'm writing some tests for the view, but in the meantime, the commands below should work (the OAuth details have been omitted).

```
BASE='http://localhost:8000/appsembler_api/v0/courses/course-v1:edX+DemoX+Demo_Course/roles'

# Who's there?
curl "$BASE"

# Add someone else
curl -X PUT "$BASE" --header "Content-Type: application/json" --data '{"roles": {"sales_admin": ["staff"]}}'
curl "$BASE"

# Remove 'em
curl -G -X DELETE "$BASE" --data-urlencode 'roles={"sales_admin": ["staff"]}'
curl "$BASE"
```

### Automated Integration Tests
Tests should take less than a minute to run.

```
sudo su edxap
paver test_system --disable-migrations --nologcapture --fasttest -t lms/djangoapps/appsembler_api/tests/test_views.py
```

### TODO's
- [x] Check if the `CourseInstructorRole` is the same as `Course Admin` in studio.
- [x] Tests!
- [ ] Add documentation 
- [ ] Ensure the permissions and authentication is correctly installed (ask a reviewer)
- [ ] Perform an actual authenticated test via both `curl` and a mini gui test client
- [x] Use a serializer!
- [x] ~~Add a full name?~
- [x] De-duplicate roles
- [x] Consider ~verbosely~ silently ignore missing users
- [x] Refactor copypasta for DELETE and PUT methods
- [x] Make sure write operations are guarded i.e. transactional ([it's an Ops thing](https://docs.djangoproject.com/en/1.11/topics/db/transactions/) that edX has by default)
