### PR TITLE
Enable CORS headers http referer replace and middleware

### DIFF
--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -105,13 +105,10 @@ elif 'appsembler_usage' in DATABASES:
     # removing the database alias
     del DATABASES['appsembler_usage']
 
-if FEATURES.get('ENABLE_CORS_HEADERS'):
+if FEATURES.get('ENABLE_CORS_HEADERS', False):
     # This middleware class and setting allows to run cross requests when we are
     # under https, CORS headers requests external referers are blocked under
     # https, there is a new setting in Django 1.9, but until we upgrade to that
     # version we need to use this.
     # Docs: https://github.com/ottoyiu/django-cors-headers#cors_replace_https_referer
     CORS_REPLACE_HTTPS_REFERER = True
-    MIDDLEWARE_CLASSES += (
-        'corsheaders.middleware.CorsPostCsrfMiddleware',
-    )

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -104,3 +104,14 @@ elif 'appsembler_usage' in DATABASES:
     # if the AppsemblerUsageRouter isn't enabled, then avoid mistakes by
     # removing the database alias
     del DATABASES['appsembler_usage']
+
+if FEATURES.get('ENABLE_CORS_HEADERS'):
+    # This middleware class and setting allows to run cross requests when we are
+    # under https, CORS headers requests external referers are blocked under
+    # https, there is a new setting in Django 1.9, but until we upgrade to that
+    # version we need to use this.
+    # Docs: https://github.com/ottoyiu/django-cors-headers#cors_replace_https_referer
+    CORS_REPLACE_HTTPS_REFERER = True
+    MIDDLEWARE_CLASSES += (
+        'corsheaders.middleware.CorsPostCsrfMiddleware',
+    )


### PR DESCRIPTION
This PR includes settings to allow us to use CORS headers requests when we're running under HTTPS. When we're using django-cors-headers properly configured, we're able to retrieve the csrf external cookie, but when we want to make a POST request from the external domain is working under HTTP but not under HTTPS since the referer is passed, and is blocked if it's external. 
See the [Django's docs](https://docs.djangoproject.com/en/1.11/ref/csrf/) (point 4)

In Django 1.9 a [new settings](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS) has been added to allow to set the white listed domains that can make request, but since this settings is not available until Django 1.9, we need to use the [django-cors-headers workaround](https://github.com/ottoyiu/django-cors-headers#cors_replace_https_referer).