### PR TITLE
sync custom forms fields on SSO registration

### DIFF
--- a/cms/envs/aws_appsembler.py
+++ b/cms/envs/aws_appsembler.py
@@ -88,4 +88,4 @@ elif 'appsembler_usage' in DATABASES:
     # removing the database alias
     del DATABASES['appsembler_usage']
 
-CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', False)
+CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})

--- a/cms/envs/aws_appsembler.py
+++ b/cms/envs/aws_appsembler.py
@@ -87,3 +87,5 @@ elif 'appsembler_usage' in DATABASES:
     # if the AppsemblerUsageRouter isn't enabled, then avoid mistakes by
     # removing the database alias
     del DATABASES['appsembler_usage']
+
+CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', False)

--- a/cms/envs/devstack_appsembler.py
+++ b/cms/envs/devstack_appsembler.py
@@ -79,3 +79,5 @@ elif 'appsembler_usage' in DATABASES:
 
 # to allow to run python-saml with custom port
 SP_SAML_RESTRICT_MODE = False
+
+CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', False)

--- a/cms/envs/devstack_appsembler.py
+++ b/cms/envs/devstack_appsembler.py
@@ -80,4 +80,4 @@ elif 'appsembler_usage' in DATABASES:
 # to allow to run python-saml with custom port
 SP_SAML_RESTRICT_MODE = False
 
-CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', False)
+CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -227,11 +227,17 @@ class ProviderConfig(ConfigurationModel):
             suggester_personal_name = "%s %s" % (details.get('first_name', ''), details.get('last_name', ''))
         else:
             suggester_personal_name = details.get('fullname', '')
-        return {
+        registration_sso_overrides = {
             'email': details.get('email', ''),
             'name': suggester_personal_name,
             'username': suggested_username,
         }
+
+        if settings.CUSTOM_SSO_FIELDS_SYNC:
+            for field in settings.CUSTOM_SSO_FIELDS_SYNC:
+                registration_sso_overrides[field] = details.get(field)
+
+        return registration_sso_overrides
 
     def get_authentication_backend(self):
         """Gets associated Django settings.AUTHENTICATION_BACKEND string."""

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -113,4 +113,4 @@ if FEATURES.get('ENABLE_CORS_HEADERS', False):
     # Docs: https://github.com/ottoyiu/django-cors-headers#cors_replace_https_referer
     CORS_REPLACE_HTTPS_REFERER = True
 
-CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', False)
+CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -112,3 +112,5 @@ if FEATURES.get('ENABLE_CORS_HEADERS', False):
     # version we need to use this.
     # Docs: https://github.com/ottoyiu/django-cors-headers#cors_replace_https_referer
     CORS_REPLACE_HTTPS_REFERER = True
+
+CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', False)

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -104,3 +104,5 @@ elif 'appsembler_usage' in DATABASES:
 
 # to allow to run python-saml with custom port
 SP_SAML_RESTRICT_MODE = False
+
+CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', False)

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -105,4 +105,4 @@ elif 'appsembler_usage' in DATABASES:
 # to allow to run python-saml with custom port
 SP_SAML_RESTRICT_MODE = False
 
-CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', False)
+CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -18,7 +18,7 @@
             } %>
             <% if ( required ) { %> aria-required="true" required<% } %>>
         <% _.each(options, function(el) { %>
-            <option value="<%= el.value%>"<% if ( el.default ) { %> data-isdefault="true"<% } %>><%= el.name %></option>
+            <option value="<%= el.value%>"<% if ( el.default ) { %> data-isdefault="true"<% } %><% if (el.value === defaultValue ) { %> selected="selected" <% } %>><%= el.name %></option>
         <% }); %>
         </select>
         <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -875,6 +875,14 @@ class RegistrationView(APIView):
                                 field_name, default=field_overrides[field_name]
                             )
 
+                    if settings.CUSTOM_SSO_FIELDS_SYNC:
+                        for field_name in settings.CUSTOM_SSO_FIELDS_SYNC:
+                            if field_name in field_overrides:
+                                form_desc.override_field_properties(
+                                    field_name,
+                                    default=field_overrides[field_name]
+                                )
+
                     # Hide the password field
                     form_desc.override_field_properties(
                         "password",


### PR DESCRIPTION
This solution was designed for Trinity initially, but I could be useful for any customer using registration fields.

The problem:
When we are using SSO, in most of the cases, customers wants to use auto-registration, this means when a user clicks on sign in or register, is redirected to the Identity Provider (OAuth or SAML), after the user successfully logs in, is redirected back to edX with the auth request, and the user attributes. By default edX automatically populate only default registration fields. So when we are using Extra registration fields, there is no way to sync those attributes. Besides the problem of not have this fields in our database, if some of the extra fields are required, the auto-registration workflow will break.

The solution:
This PR adds a new settings: `CUSTOM_SSO_FIELDS_SYNC` by default in False, but is expected to be a dictionary, when we can list all the extra registration form fields that we want to map. The code changes are pretty small, basically they check if this dict isn't false, and maps the attributes using the same default logic.