### PR TITLE
appsembler/ficus/feature/saml slo

### DIFF
--- a/cms/envs/devstack_appsembler.py
+++ b/cms/envs/devstack_appsembler.py
@@ -78,3 +78,5 @@ elif 'appsembler_usage' in DATABASES:
     del DATABASES['appsembler_usage']
 
 CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})
+# to allow to run python-saml with custom port
+SP_SAML_RESTRICT_MODE = False

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -2597,7 +2597,12 @@ class LogoutView(TemplateView):
     template_name = 'logout.html'
 
     # Keep track of the page to which the user should ultimately be redirected.
-    target = reverse_lazy('cas-logout') if settings.FEATURES.get('AUTH_USE_CAS') else '/'
+    if settings.FEATURES.get('AUTH_USE_CAS'):
+        target = reverse_lazy('cas-logout')
+    elif hasattr(settings, 'CUSTOM_LOGOUT_REDIRECT_URL'):
+        target = settings.CUSTOM_LOGOUT_REDIRECT_URL
+    else:
+        target = '/'
 
     def dispatch(self, request, *args, **kwargs):  # pylint: disable=missing-docstring
         # We do not log here, because we have a handler registered to perform logging on successful logouts.

--- a/common/djangoapps/third_party_auth/migrations/0003_samlproviderdata_slo_url.py
+++ b/common/djangoapps/third_party_auth/migrations/0003_samlproviderdata_slo_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0002_schema__provider_icon_image'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='samlproviderdata',
+            name='slo_url',
+            field=models.URLField(null=True, verbose_name=b'SLO URL'),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/migrations/0006_merge.py
+++ b/common/djangoapps/third_party_auth/migrations/0006_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0003_samlproviderdata_slo_url'),
+        ('third_party_auth', '0005_add_site_field'),
+    ]
+
+    operations = [
+    ]

--- a/common/djangoapps/third_party_auth/migrations/0007_samlconfiguration_slo_redirect_url.py
+++ b/common/djangoapps/third_party_auth/migrations/0007_samlconfiguration_slo_redirect_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('third_party_auth', '0006_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='samlconfiguration',
+            name='slo_redirect_url',
+            field=models.CharField(default=b'/logout', help_text=b'The url to redirect the user after process the SLO response', max_length=255, verbose_name=b'SLO post redirect URL', blank=True),
+        ),
+    ]

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -5,6 +5,9 @@ Models used to implement SAML SSO support in third_party_auth
 """
 from __future__ import absolute_import
 
+import re
+from random import randrange
+
 from config_models.models import ConfigurationModel, cache
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -457,6 +460,7 @@ class SAMLProviderConfig(ProviderConfig):
             raise AuthNotConfigured(provider_name=self.name)
         conf['x509cert'] = data.public_key
         conf['url'] = data.sso_url
+        conf['slo_url'] = data.slo_url
         return SAMLIdentityProvider(self.idp_slug, **conf)
 
 
@@ -508,6 +512,13 @@ class SAMLConfiguration(ConfigurationModel):
             "Valid keys that can be set here include: SECURITY_CONFIG and SP_EXTRA"
         ),
     )
+    slo_redirect_url = models.CharField(
+        max_length=255,
+        default='/logout',
+        verbose_name="SLO post redirect URL",
+        help_text="The url to redirect the user after process the SLO response",
+        blank=True
+    )
 
     class Meta(object):
         app_label = "third_party_auth"
@@ -551,6 +562,10 @@ class SAMLConfiguration(ConfigurationModel):
                 return self.private_key
             # To allow instances to avoid storing keys in the DB, the private key can also be set via Django:
             return getattr(settings, 'SOCIAL_AUTH_SAML_SP_PRIVATE_KEY', '')
+        if name == "LOGOUT_REDIRECT_URL":
+            return self.slo_redirect_url
+        if name == "SP_SAML_RESTRICT_MODE":
+            return getattr(settings, 'SP_SAML_RESTRICT_MODE', True)
         other_config = {
             # These defaults can be overriden by self.other_config_str
             "EXTRA_DATA": ["attributes"],  # Save all attribute values the IdP sends into the UserSocialAuth table
@@ -573,6 +588,7 @@ class SAMLProviderData(models.Model):
 
     entity_id = models.CharField(max_length=255, db_index=True)  # This is the key for lookups in this table
     sso_url = models.URLField(verbose_name="SSO URL")
+    slo_url = models.URLField(verbose_name="SLO URL", null=True)
     public_key = models.TextField()
 
     class Meta(object):

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -369,6 +369,34 @@ def get_login_url(provider_id, auth_entry, redirect_url=None):
         extra_params=enabled_provider.get_url_params(),
     )
 
+def get_logout_url(provider_id, auth_entry, redirect_url=None):
+    """Gets URL for the endpoint that starts the SLO process.
+
+    Args:
+        provider_id: string identifier of the models.ProviderConfig child you want
+            to disconnect from.
+        auth_entry: string. Query argument specifying the desired entry point
+            for the auth pipeline. Used by the pipeline for later branching.
+            Must be one of _AUTH_ENTRY_CHOICES.
+
+    Keyword Args:
+        redirect_url (string): If provided, redirect to this URL at the end
+            of the authentication process.
+
+    Returns:
+        String. URL that starts the SLO process.
+
+    Raises:
+        ValueError: if no provider is enabled with the given ID.
+    """
+    enabled_provider = _get_enabled_provider(provider_id)
+    return _get_url(
+        'social:end',
+        enabled_provider.backend_name,
+        auth_entry=auth_entry,
+        redirect_url=redirect_url,
+        extra_params=enabled_provider.get_url_params(),
+    )
 
 def get_duplicate_provider(messages):
     """Gets provider from message about social account already in use.

--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -71,8 +71,8 @@ def fetch_saml_metadata():
 
             for entity_id in entity_ids:
                 log.info(u"Processing IdP with entityID %s", entity_id)
-                public_key, sso_url, expires_at = _parse_metadata_xml(xml, entity_id)
-                changed = _update_data(entity_id, public_key, sso_url, expires_at)
+                public_key, sso_url, slo_url, expires_at = _parse_metadata_xml(xml, entity_id)
+                changed = _update_data(entity_id, public_key, sso_url, slo_url, expires_at)
                 if changed:
                     log.info(u"→ Created new record for SAMLProviderData")
                     num_changed += 1
@@ -153,16 +153,24 @@ def _parse_metadata_xml(xml, entity_id):
         raise MetadataParseError("Public Key missing. Expected an <X509Certificate>")
     public_key = public_key.replace(" ", "")
     binding_elements = sso_desc.iterfind("./{}".format(etree.QName(SAML_XML_NS, "SingleSignOnService")))
+    binding_elements_slo = sso_desc.iterfind("./{}".format(etree.QName(SAML_XML_NS, "SingleLogoutService")))
     sso_bindings = {element.get('Binding'): element.get('Location') for element in binding_elements}
+    slo_bindings = {element.get('Binding'): element.get('Location') for element in binding_elements_slo}
     try:
         # The only binding supported by python-saml and python-social-auth is HTTP-Redirect:
         sso_url = sso_bindings['urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']
     except KeyError:
         raise MetadataParseError("Unable to find SSO URL with HTTP-Redirect binding.")
-    return public_key, sso_url, expires_at
+    try:
+        # The only binding supported by python-saml and python-social-auth is HTTP-Redirect:
+        slo_url = slo_bindings['urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']
+    except KeyError:
+        slo_url = ""
+        log.info("Unable to find SLO URL with HTTP-Redirect binding.")
+    return public_key, sso_url, slo_url, expires_at
 
 
-def _update_data(entity_id, public_key, sso_url, expires_at):
+def _update_data(entity_id, public_key, sso_url, slo_url, expires_at):
     """
     Update/Create the SAMLProviderData for the given entity ID.
     Return value:
@@ -171,7 +179,7 @@ def _update_data(entity_id, public_key, sso_url, expires_at):
     """
     data_obj = SAMLProviderData.current(entity_id)
     fetched_at = datetime.datetime.now()
-    if data_obj and (data_obj.public_key == public_key and data_obj.sso_url == sso_url):
+    if data_obj and (data_obj.public_key == public_key and data_obj.sso_url == sso_url and data_obj.slo_url == slo_url):
         data_obj.expires_at = expires_at
         data_obj.fetched_at = fetched_at
         data_obj.save()
@@ -182,6 +190,7 @@ def _update_data(entity_id, public_key, sso_url, expires_at):
             fetched_at=fetched_at,
             expires_at=expires_at,
             sso_url=sso_url,
+            slo_url=slo_url,
             public_key=public_key,
         )
         return True

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -103,3 +103,5 @@ elif 'appsembler_usage' in DATABASES:
     del DATABASES['appsembler_usage']
 
 CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})
+# to allow to run python-saml with custom port
+SP_SAML_RESTRICT_MODE = False


### PR DESCRIPTION
This PR is a follow up of appsembler/python-social-auth#1 and #104 

The PR adds support for SLO, using our fork of python-social-auth.

This PR has been already approved and merged for appsembler/eucalyptus #104 

The PR includes changes for:

* set SP_SAML_RESTRICT_MODE in devstack, so we can run the entire SAML backend and pipeline.
* New field to store the SAML SLO url on the SAMLProvidersData Model.
* New field to store the post logout redirect url on the SAMLProvidersData Model, default is /logout * the edx default logout URL.
* Migrations for those fields.
* Modification on the IdP metadata retrieving task to store the SLO url on the new fields.
* New Pipeline method to retrieve the SLO url.
* New setting `CUSTOM_LOGOUT_REDIRECT_URL` in case that we need to redirect the user back the IdP