### PR TITLE
[Ficus] make custom redirect URL microsite aware

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -2596,13 +2596,16 @@ class LogoutView(TemplateView):
     oauth_client_ids = []
     template_name = 'logout.html'
 
-    # Keep track of the page to which the user should ultimately be redirected.
-    if settings.FEATURES.get('AUTH_USE_CAS'):
-        target = reverse_lazy('cas-logout')
-    elif hasattr(settings, 'CUSTOM_LOGOUT_REDIRECT_URL'):
-        target = settings.CUSTOM_LOGOUT_REDIRECT_URL
-    else:
-        target = '/'
+    def get_target(self):
+        # Keep track of the page to which the user should ultimately be redirected.
+        if settings.FEATURES.get('AUTH_USE_CAS'):
+            target = reverse_lazy('cas-logout')
+        elif configuration_helpers.get_value('CUSTOM_LOGOUT_REDIRECT_URL', settings.CUSTOM_LOGOUT_REDIRECT_URL):
+            target = configuration_helpers.get_value('CUSTOM_LOGOUT_REDIRECT_URL', settings.CUSTOM_LOGOUT_REDIRECT_URL)
+        else:
+            target = '/'
+
+        return target
 
     def dispatch(self, request, *args, **kwargs):  # pylint: disable=missing-docstring
         # We do not log here, because we have a handler registered to perform logging on successful logouts.
@@ -2617,7 +2620,7 @@ class LogoutView(TemplateView):
         if LogoutViewConfiguration.current().enabled and self.oauth_client_ids:
             response = super(LogoutView, self).dispatch(request, *args, **kwargs)
         else:
-            response = redirect(self.target)
+            response = redirect(self.get_target())
 
         # Clear the cookie used by the edx.org marketing site
         delete_logged_in_cookies(response)


### PR DESCRIPTION
Same as #146 but for Ficus.

This PR is a fix for our previous customization `CUSTOM_LOGOUT_REDIRECT_URL`.

The PR first, changes: 
`settings.CUSTOM_LOGOUT_REDIRECT_URL`
for:
`configuration_helpers.get_value('CUSTOM_LOGOUT_REDIRECT_URL', settings.CUSTOM_LOGOUT_REDIRECT_URL)`

So if we have an override on the microsite, will be used.

Also, sin the `target` is calculated on the `LogoutView` is only calculated one time, and even having a microsite override, isn't calculated every time that the logout view is called, so we're moving it to a method, to force it to be calculated every time, and pick the microsite override if exists.


