### PR TITLE
add conditional to read boolean for email sending on user creation

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1829,7 +1829,8 @@ def create_account_with_params(request, params):
         not (
             third_party_provider and third_party_provider.skip_email_verification and
             user.email == running_pipeline['kwargs'].get('details', {}).get('email')
-        )
+        ) and
+        params.get('send_activation_email', True) == True
     )
     if send_email:
         dest_addr = user.email


### PR DESCRIPTION
Looks like we lost this change on the Ficus merge, this extra conditional, allows to our API to send validation email, when the user is being created throw the API.