### PR TITLE
First implementation to fix MSFT LP certifications issues

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -7,6 +7,7 @@ from xmodule.modulestore.django import modulestore
 
 from django.utils.translation import ugettext as _
 from django.conf import settings
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 class CourseMetadata(object):
@@ -99,6 +100,16 @@ class CourseMetadata(object):
         # display the "Allow Unsupported XBlocks" setting.
         if not XBlockStudioConfigurationFlag.is_enabled():
             filtered_list.append('allow_unsupported_xblocks')
+
+        # Appsembler specfic, we don't display the field if the site doesn't
+        # belong to a MSFT LP
+        if not configuration_helpers.get_value(
+            "CUSTOMER_IS_MICROSOFT_LEARNING_PARTNER",
+            settings.APPSEMBLER_FEATURES.get(
+               "CUSTOMER_IS_MICROSOFT_LEARNING_PARTNER"
+           )
+        ):
+            filtered_list.append('is_microsoft_course')
 
         return filtered_list
 

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -7,7 +7,7 @@ from xmodule.modulestore.django import modulestore
 
 from django.utils.translation import ugettext as _
 from django.conf import settings
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.site_configuration.helpers import get_value_for_org
 
 
 class CourseMetadata(object):
@@ -60,7 +60,7 @@ class CourseMetadata(object):
     ]
 
     @classmethod
-    def filtered_list(cls):
+    def filtered_list(cls, org=None):
         """
         Filter fields based on feature flag, i.e. enabled, disabled.
         """
@@ -103,7 +103,8 @@ class CourseMetadata(object):
 
         # Appsembler specfic, we don't display the field if the site doesn't
         # belong to a MSFT LP
-        if not configuration_helpers.get_value(
+        if org and not get_value_for_org(
+            org,
             "CUSTOMER_IS_MICROSOFT_LEARNING_PARTNER",
             settings.APPSEMBLER_FEATURES.get(
                "CUSTOMER_IS_MICROSOFT_LEARNING_PARTNER"
@@ -122,7 +123,7 @@ class CourseMetadata(object):
         result = {}
         metadata = cls.fetch_all(descriptor)
         for key, value in metadata.iteritems():
-            if key in cls.filtered_list():
+            if key in cls.filtered_list(org=descriptor.org):
                 continue
             result[key] = value
         return result
@@ -151,7 +152,7 @@ class CourseMetadata(object):
 
         Ensures none of the fields are in the blacklist.
         """
-        filtered_list = cls.filtered_list()
+        filtered_list = cls.filtered_list(org=descriptor.org)
         # Don't filter on the tab attribute if filter_tabs is False.
         if not filter_tabs:
             filtered_list.remove("tabs")
@@ -187,7 +188,7 @@ class CourseMetadata(object):
             errors: list of error objects
             result: the updated course metadata or None if error
         """
-        filtered_list = cls.filtered_list()
+        filtered_list = cls.filtered_list(org=descriptor.org)
         if not filter_tabs:
             filtered_list.remove("tabs")
 

--- a/cms/envs/amc.py
+++ b/cms/envs/amc.py
@@ -8,6 +8,7 @@ APPSEMBLER_SECRET_KEY = AUTH_TOKENS.get("APPSEMBLER_SECRET_KEY")
 
 INSTALLED_APPS += (
     'openedx.core.djangoapps.appsembler.sites',
+    'openedx.core.djangoapps.appsembler.msft_lp',
 )
 
 GOOGLE_ANALYTICS_APP_ID = AUTH_TOKENS.get('GOOGLE_ANALYTICS_APP_ID')

--- a/cms/envs/devstack_appsembler.py
+++ b/cms/envs/devstack_appsembler.py
@@ -36,6 +36,7 @@ INSTALLED_APPS += (
     'hijack',
     'compat',
     'hijack_admin',
+    'openedx.core.djangoapps.appsembler.msft_lp',
 )
 MIDDLEWARE_CLASSES += (
     'organizations.middleware.OrganizationMiddleware',

--- a/common/djangoapps/enrollment/urls.py
+++ b/common/djangoapps/enrollment/urls.py
@@ -11,6 +11,9 @@ from .views import (
     EnrollmentCourseDetailView
 )
 
+from openedx.core.djangoapps.appsembler.msft_lp.views import AppsemblerEnrollmentListView
+
+# import API views here
 
 urlpatterns = patterns(
     'enrollment.views',
@@ -26,7 +29,11 @@ urlpatterns = patterns(
         EnrollmentView.as_view(),
         name='courseenrollment'
     ),
-    url(r'^enrollment$', EnrollmentListView.as_view(), name='courseenrollments'),
+    # url(r'^enrollment$', EnrollmentListView.as_view(), name='courseenrollments'),
+    # Appsembler specific: Original view commented in favor of our override of
+    # the view, that changes the org to Microsoft if the course is set as
+    # Microsoft course in advanced settings. Feature for MSFT LP only.
+    url(r'^enrollment$', AppsemblerEnrollmentListView.as_view(), name='courseenrollments'),
     url(
         r'^course/{course_key}$'.format(course_key=settings.COURSE_ID_PATTERN),
         EnrollmentCourseDetailView.as_view(),

--- a/lms/envs/amc.py
+++ b/lms/envs/amc.py
@@ -9,6 +9,7 @@ LMS_BASE = ENV_TOKENS.get('LMS_BASE')
 
 INSTALLED_APPS += (
     'openedx.core.djangoapps.appsembler.sites',
+    'openedx.core.djangoapps.appsembler.msft_lp',
 )
 
 GOOGLE_ANALYTICS_APP_ID = AUTH_TOKENS.get('GOOGLE_ANALYTICS_APP_ID')

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -15,6 +15,7 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 INSTALLED_APPS += (
     'django_extensions',
     'openedx.core.djangoapps.appsembler.sites',
+    'openedx.core.djangoapps.appsembler.msft_lp',
 )
 
 LMS_BASE = ENV_TOKENS.get('LMS_BASE')

--- a/openedx/core/djangoapps/appsembler/msft_lp/__init__.py
+++ b/openedx/core/djangoapps/appsembler/msft_lp/__init__.py
@@ -1,0 +1,1 @@
+from . import monkeypatch

--- a/openedx/core/djangoapps/appsembler/msft_lp/mixins.py
+++ b/openedx/core/djangoapps/appsembler/msft_lp/mixins.py
@@ -1,0 +1,19 @@
+"""
+Reusable mixins for XBlocks and/or XModules
+"""
+
+from xblock.fields import Scope, String, Float, Boolean, XBlockMixin
+
+# Make '_' a no-op so we can scrape strings
+_ = lambda text: text
+
+class MsftLPMixin(XBlockMixin):
+
+    # Marks if the course is a Microsft course. This advanced settings only will
+    # be available if the feature flag CUSTOMER_IS_MICROSOFT_LEARNING_PARTNER is
+    # set to True
+    is_microsoft_course = Boolean(
+        display_name=_("Is a Microsoft Course"),
+        help=_("Set to true if is a microsoft course, so the learners can get access to MSFT certification"),
+        default=False,
+        scope=Scope.settings)

--- a/openedx/core/djangoapps/appsembler/msft_lp/models.py
+++ b/openedx/core/djangoapps/appsembler/msft_lp/models.py
@@ -1,0 +1,1 @@
+from django.db import models

--- a/openedx/core/djangoapps/appsembler/msft_lp/monkeypatch.py
+++ b/openedx/core/djangoapps/appsembler/msft_lp/monkeypatch.py
@@ -1,0 +1,18 @@
+from xmodule import course_module
+
+from . import mixins
+
+import logging
+logger = logging.getLogger(__name__)
+
+def get_CourseDescriptor_mixins():
+
+    new_mixins = []
+    new_mixins.append(mixins.MsftLPMixin)
+
+    return tuple(new_mixins)
+
+logger.warn('Monkeypatching course_module.CourseDescriptor to add Appsembler Mixins')
+orig_CourseDescriptor = course_module.CourseDescriptor
+CDbases = course_module.CourseDescriptor.__bases__
+course_module.CourseDescriptor.__bases__ = get_CourseDescriptor_mixins() + CDbases

--- a/openedx/core/djangoapps/appsembler/msft_lp/views.py
+++ b/openedx/core/djangoapps/appsembler/msft_lp/views.py
@@ -1,0 +1,73 @@
+import re
+
+from django.utils.decorators import method_decorator
+from rest_framework import status
+from rest_framework.response import Response
+from cors_csrf.decorators import ensure_csrf_cookie_cross_domain
+from enrollment import api
+from enrollment.errors import (
+    CourseEnrollmentError,
+    CourseModeNotFoundError,
+    CourseEnrollmentExistsError
+)
+from student.auth import user_has_role
+from student.roles import CourseStaffRole, GlobalStaff
+from xmodule.modulestore.django import modulestore
+from opaque_keys.edx.keys import CourseKey
+
+from enrollment.views import EnrollmentListView
+
+class AppsemblerEnrollmentListView(EnrollmentListView):
+
+    @method_decorator(ensure_csrf_cookie_cross_domain)
+    def get(self, request):
+        """Gets a list of all course enrollments for a user.
+
+        Returns a list for the currently logged in user, or for the user named by the 'user' GET
+        parameter. If the username does not match that of the currently logged in user, only
+        courses for which the currently logged in user has the Staff or Admin role are listed.
+        As a result, a course team member can find out which of his or her own courses a particular
+        learner is enrolled in.
+
+        Only the Staff or Admin role (granted on the Django administrative console as the staff
+        or instructor permission) in individual courses gives the requesting user access to
+        enrollment data. Permissions granted at the organizational level do not give a user
+        access to enrollment data for all of that organization's courses.
+
+        Users who have the global staff permission can access all enrollment data for all
+        courses.
+
+        Appsembler specific changes: We're inheriting the View and the GET method
+        to tweak the JSON response and override the course org, in the course key, if the
+        advanced setting is_microsoft_course is True.
+        """
+        username = request.GET.get('user', request.user.username)
+        try:
+            enrollment_data = api.get_enrollments(username)
+        except CourseEnrollmentError:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": (
+                        u"An error occurred while retrieving enrollments for user '{username}'"
+                    ).format(username=username)
+                }
+            )
+        if username == request.user.username or GlobalStaff().has_user(
+                request.user) or \
+                self.has_api_key_permissions(request):
+            for enrollment in enrollment_data:
+                course_id = CourseKey.from_string(
+                    enrollment['course_details']['course_id'])
+                course_obj = modulestore().get_course(course_id, depth=0)
+                if course_obj.is_microsoft_course:
+                    enrollment['course_details']['course_id'] = re.sub('\:.*?\+', ':Microsoft+', enrollment['course_details']['course_id'])
+            return Response(enrollment_data)
+        filtered_data = []
+        for enrollment in enrollment_data:
+            course_key = CourseKey.from_string(
+                enrollment["course_details"]["course_id"])
+            if user_has_role(request.user, CourseStaffRole(course_key)):
+                enrollment['course_details']['course_id'] = re.sub('\:.*?\+', ':Microsoft+', enrollment['course_details']['course_id'])
+                filtered_data.append(enrollment)
+        return Response(filtered_data)

--- a/openedx/core/djangoapps/appsembler/msft_lp/views.py
+++ b/openedx/core/djangoapps/appsembler/msft_lp/views.py
@@ -3,7 +3,7 @@ import re
 from django.utils.decorators import method_decorator
 from rest_framework import status
 from rest_framework.response import Response
-from cors_csrf.decorators import ensure_csrf_cookie_cross_domain
+from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from enrollment import api
 from enrollment.errors import (
     CourseEnrollmentError,


### PR DESCRIPTION
## Problem 
The MSFT certification API, when the user finish a course, and requests the MSFT certification, first checks the enrollment API and retrieve all the enrollments for the user, then filters the courses with the `Microsoft` organization, and checks if the user is enrolled in the given course, and then makes the request agaist the grading API.

In Tahoe we hardcode the course org with the site name, so this isn't going to work.

## Solution

1. Add a new advanced settings in course, `is_microsoft_course`, this settings is in False by default, and relies on a site FEATURE flag `CUSTOMER_IS_MICROSOFT_LEARNING_PARTNER`, so the settings is only displayed if the customer is a MSFT LP.
2. Modify the enrollment API, and if the course settings `is_microsoft_course` is True, we alter the JSON response, to change the org to Microsoft.

## How to test this PR
1. checkout the branch
2. pick a microsite and add the the folowing var/val to the site configurations in Django admin: "CUSTOMER_IS_MICROSOFT_LEARNING_PARTNER": "true"
3. Go to studio, and check that the new settings `Is a Microsoft Course` is available.
4. Change the value of `Is a Microsoft Course` to true.
5. Enroll an user into the course.
6. Check the enrollments for that user using the API endpoint: `/api/enrollment/v1/enrollment`
7. Verify that the enrollment for the given course, has Microsoft as organisation in the course ID.
