### PR TITLE
Fixes for Badgr.io badges integration

### DIFF
--- a/lms/djangoapps/badges/events/course_complete.py
+++ b/lms/djangoapps/badges/events/course_complete.py
@@ -1,11 +1,9 @@
 """
 Helper functions for the course complete event that was originally included with the Badging MVP.
 """
-import hashlib
 import logging
 
 from django.core.urlresolvers import reverse
-from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
 
 from badges.models import CourseCompleteImageConfiguration, BadgeClass, BadgeAssertion
@@ -17,21 +15,6 @@ LOGGER = logging.getLogger(__name__)
 
 # NOTE: As these functions are carry-overs from the initial badging implementation, they are used in
 # migrations. Please check the badge migrations when changing any of these functions.
-
-
-def course_slug(course_key, mode):
-    """
-    Legacy: Not to be used as a model for constructing badge slugs. Included for compatibility with the original badge
-    type, awarded on course completion.
-
-    Slug ought to be deterministic and limited in size so it's not too big for Badgr.
-
-    Badgr's max slug length is 255.
-    """
-    # Seven digits should be enough to realistically avoid collisions. That's what git services use.
-    digest = hashlib.sha256(u"{}{}".format(unicode(course_key), unicode(mode))).hexdigest()[:7]
-    base_slug = slugify(unicode(course_key) + u'_{}_'.format(mode))[:248]
-    return base_slug + digest
 
 
 def badge_description(course, mode):
@@ -85,8 +68,6 @@ def get_completion_badge(course_id, user):
     if not course.issue_badges:
         return None
     return BadgeClass.get_badge_class(
-        slug=course_slug(course_id, mode),
-        issuing_component='',
         criteria=criteria(course_id),
         description=badge_description(course, mode),
         course_id=course_id,

--- a/lms/djangoapps/badges/events/course_meta.py
+++ b/lms/djangoapps/badges/events/course_meta.py
@@ -23,7 +23,7 @@ def award_badge(config, count, user):
     if not slug:
         return
     badge_class = BadgeClass.get_badge_class(
-        slug=slug, issuing_component='openedx__course', create=False,
+        slug=slug, create=False,
     )
     if not badge_class:
         return
@@ -72,10 +72,9 @@ def course_group_check(user, course_key):
             )
             if len(certs) == len(keys):
                 awards.append(slug)
-
     for slug in awards:
         badge_class = BadgeClass.get_badge_class(
-            slug=slug, issuing_component='openedx__course', create=False,
+            slug=slug, create=False,
         )
         if badge_class and not badge_class.get_for_user(user):
             badge_class.award(user)


### PR DESCRIPTION
Badgr.io changed their backend so these `badges` app changes are now necessary for the integration to work.  Also includes a custom change allowing course certificate URLs as evidence URLs on single-course 'course group' completion event badges.