### PR TITLE
Handle imports from cms.djangoapps.contentstore to fix search re-indexing after course deletion from sysadmin dashboard

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -7,7 +7,7 @@ import logging
 from util.db import generate_int_id, MYSQL_MAX_INT
 
 from django.utils.translation import ugettext as _
-from contentstore.utils import reverse_usage_url
+from cms.djangoapps.contentstore.utils import reverse_usage_url
 from xmodule.partitions.partitions import UserPartition
 from xmodule.split_test_module import get_split_user_partitions
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition

--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -10,7 +10,8 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy, ugettext as _
 from django.core.urlresolvers import resolve
 
-from contentstore.course_group_config import GroupConfiguration
+# use absolute import since this gets imported from LMS for signal handling
+from cms.djangoapps.contentstore.course_group_config import GroupConfiguration
 from course_modes.models import CourseMode
 from eventtracking import tracker
 from openedx.core.lib.courses import course_image_url


### PR DESCRIPTION
Generalizing this change from a fix done for Metalogix