### PR TITLE
Handle imports from cms.djangoapps.contentstore to fix search re-indexing after course deletion from sysadmin dashboard

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -6,7 +6,7 @@ import logging
 
 from django.utils.translation import ugettext as _
 
-from contentstore.utils import reverse_usage_url
+from cms.djangoapps.contentstore.utils import reverse_usage_url
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition
 from util.db import MYSQL_MAX_INT, generate_int_id
 from xmodule.partitions.partitions import MINIMUM_STATIC_PARTITION_ID, UserPartition

--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -13,7 +13,8 @@ from django.utils.translation import ugettext_lazy
 from search.search_engine_base import SearchEngine
 from six import add_metaclass
 
-from contentstore.course_group_config import GroupConfiguration
+# use absolute import since this gets imported from LMS for signal handling
+from cms.djangoapps.contentstore.course_group_config import GroupConfiguration
 from course_modes.models import CourseMode
 from eventtracking import tracker
 from openedx.core.lib.courses import course_image_url


### PR DESCRIPTION
…and, for Ginkgo

Fixed conflicts:
	cms/djangoapps/contentstore/course_group_config.py