### PR TITLE
use AUTHENTICATION_BACKENDS from APPSEMBLER_FEATURES

### DIFF
--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -116,3 +116,8 @@ if FEATURES.get('ENABLE_CORS_HEADERS', False):
 CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})
 
 HTTPS = ENV_TOKENS.get('BASE_SCHEME', 'https').lower() == 'http' and 'off' or 'on'
+
+#configure auth backends
+if 'LMS_AUTHENTICATION_BACKENDS' in APPSEMBLER_FEATURES.keys():
+    #default behavior is to replace the existing backends with those in APPSEMBLER_FEATURES
+    AUTHENTICATION_BACKENDS = tuple(APPSEMBLER_FEATURES['LMS_AUTHENTICATION_BACKENDS'])

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -105,3 +105,8 @@ elif 'appsembler_usage' in DATABASES:
 CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})
 # to allow to run python-saml with custom port
 SP_SAML_RESTRICT_MODE = False
+
+#configure auth backends
+if 'LMS_AUTHENTICATION_BACKENDS' in APPSEMBLER_FEATURES.keys():
+    #default behavior is to replace the existing backends with those in APPSEMBLER_FEATURES
+    AUTHENTICATION_BACKENDS = tuple(APPSEMBLER_FEATURES['LMS_AUTHENTICATION_BACKENDS'])


### PR DESCRIPTION
If `LMS_AUTHENTICATION_BACKENDS` is set in `APPSEMBLER_FEATURES`, then nuke the existing `AUTHENTICATION_BACKENDS` and use the settings in lms.env.json.

This is done so NYIF can use a custom auth backend that prevents users from logging into microsites where their account wasn't originally registered. 

Related edx-configs PR:
https://github.com/noderabbit-team/edx-configs/pull/165