### PR TITLE
specify media root in CMS and allow http scheme in aws_appsembler by env token

### DIFF
--- a/cms/envs/aws_appsembler.py
+++ b/cms/envs/aws_appsembler.py
@@ -89,3 +89,7 @@ elif 'appsembler_usage' in DATABASES:
     del DATABASES['appsembler_usage']
 
 CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})
+
+# set media values for SCORM upload
+MEDIA_ROOT = '/edx/var/edxapp/media'
+MEDIA_URL = '/media/'

--- a/cms/envs/aws_appsembler.py
+++ b/cms/envs/aws_appsembler.py
@@ -93,3 +93,5 @@ CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})
 # set media values for SCORM upload
 MEDIA_ROOT = '/edx/var/edxapp/media'
 MEDIA_URL = '/media/'
+
+HTTPS = ENV_TOKENS.get('BASE_SCHEME', 'https').lower() == 'http' and 'off' or 'on'

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -114,3 +114,5 @@ if FEATURES.get('ENABLE_CORS_HEADERS', False):
     CORS_REPLACE_HTTPS_REFERER = True
 
 CUSTOM_SSO_FIELDS_SYNC = ENV_TOKENS.get('CUSTOM_SSO_FIELDS_SYNC', {})
+
+HTTPS = ENV_TOKENS.get('BASE_SCHEME', 'https').lower() == 'http' and 'off' or 'on'


### PR DESCRIPTION
SCORM XBlock using filestorage requires specifying `MEDIA_ROOT` in cms as well as lms.  
Also, allow specifying HTTPS setting to off via `BASE_SCHEME` env token from server-vars, for situations where we are using `aws_appsembler` env on a staging server w/o SSL certs set up.  Normally only devstack envs has HTTPS settings off