### PR TITLE
Skip login after registration (mostly for NYIF)

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1867,17 +1867,20 @@ def create_account_with_params(request, params):
     if u'organizations.backends.OrganizationMemberBackend' in settings.AUTHENTICATION_BACKENDS:
         try:
             organization = request.site.organizations.first()
+        except AttributeError:
+            #can't find 'organizations' in Site obj
+            pass
+        else:
             if organization: 
                 UserOrganizationMapping.objects.get_or_create(user=user, organization=organization, is_active=False)
-        except:
-            pass
+
 
     # Immediately after a user creates an account, we log them in. They are only
     # logged in until they close the browser. They can't log in again until they click
     # the activation link from the email.
     new_user = authenticate(username=user.username, password=params['password'])
     
-    if not settings.APPSEMBLER_FEATURES.get('SKIP_LOGIN_AFTER_REGISTRATION',False):
+    if not settings.APPSEMBLER_FEATURES.get('SKIP_LOGIN_AFTER_REGISTRATION', False):
         login(request, new_user)
         request.session.set_expiry(0)
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -132,7 +132,7 @@ from openedx.core.djangoapps.catalog.utils import get_programs_data
 # try to import appsembler fork of edx-organizations (if it's installed)
 try: 
     from organizations.models import UserOrganizationMapping
-except ImportException:
+except ImportError:
     pass
 
 log = logging.getLogger("edx.student")

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1865,15 +1865,9 @@ def create_account_with_params(request, params):
     
     #if using custom Appsembler backend from edx-organizations
     if u'organizations.backends.OrganizationMemberBackend' in settings.AUTHENTICATION_BACKENDS:
-        try:
-            organization = request.site.organizations.first()
-        except AttributeError:
-            #can't find 'organizations' in Site obj
-            pass
-        else:
-            if organization: 
-                UserOrganizationMapping.objects.get_or_create(user=user, organization=organization, is_active=False)
-
+        organization = request.site.organizations.first()
+        if organization: 
+            UserOrganizationMapping.objects.get_or_create(user=user, organization=organization, is_active=False)
 
     # Immediately after a user creates an account, we log them in. They are only
     # logged in until they close the browser. They can't log in again until they click

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1876,8 +1876,10 @@ def create_account_with_params(request, params):
     # logged in until they close the browser. They can't log in again until they click
     # the activation link from the email.
     new_user = authenticate(username=user.username, password=params['password'])
-    login(request, new_user)
-    request.session.set_expiry(0)
+    
+    if not settings.APPSEMBLER_FEATURES.get('SKIP_LOGIN_AFTER_REGISTRATION',False):
+        login(request, new_user)
+        request.session.set_expiry(0)
 
     try:
         record_registration_attributions(request, new_user)

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -121,3 +121,14 @@ HTTPS = ENV_TOKENS.get('BASE_SCHEME', 'https').lower() == 'http' and 'off' or 'o
 if 'LMS_AUTHENTICATION_BACKENDS' in APPSEMBLER_FEATURES.keys():
     #default behavior is to replace the existing backends with those in APPSEMBLER_FEATURES
     AUTHENTICATION_BACKENDS = tuple(APPSEMBLER_FEATURES['LMS_AUTHENTICATION_BACKENDS'])
+
+#attempt to import model from our custom fork of edx-organizations
+# if it works, then also add the middleware
+try:
+    from organizations.models import UserOrganizationMapping
+    MIDDLEWARE_CLASSES += (
+        'organizations.middleware.OrganizationMiddleware',
+    )
+except ImportError:
+    pass
+

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -110,3 +110,8 @@ SP_SAML_RESTRICT_MODE = False
 if 'LMS_AUTHENTICATION_BACKENDS' in APPSEMBLER_FEATURES.keys():
     #default behavior is to replace the existing backends with those in APPSEMBLER_FEATURES
     AUTHENTICATION_BACKENDS = tuple(APPSEMBLER_FEATURES['LMS_AUTHENTICATION_BACKENDS'])
+
+MIDDLEWARE_CLASSES += (
+    'organizations.middleware.OrganizationMiddleware',
+)
+

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -111,7 +111,14 @@ if 'LMS_AUTHENTICATION_BACKENDS' in APPSEMBLER_FEATURES.keys():
     #default behavior is to replace the existing backends with those in APPSEMBLER_FEATURES
     AUTHENTICATION_BACKENDS = tuple(APPSEMBLER_FEATURES['LMS_AUTHENTICATION_BACKENDS'])
 
-MIDDLEWARE_CLASSES += (
-    'organizations.middleware.OrganizationMiddleware',
-)
+#attempt to import model from our custom fork of edx-organizations
+# if it works, then also add the middleware
+try: 
+    from organizations.models import UserOrganizationMapping
+    MIDDLEWARE_CLASSES += (
+        'organizations.middleware.OrganizationMiddleware',
+    )
+except ImportError:
+    pass
+
 


### PR DESCRIPTION
I've added two major changes to the account registration workflow here:
1. Try to import a custom model from our fork of edx-organizations, then create an object from that model if the account registration happens within a microsite.
2. Add a new flag `APPSEMBLER_FEATURES['SKIP_LOGIN_AFTER_REGISTRATION']`. If set to `True`, users aren't automatically redirected to /dashboard after creating a new account. 

The default behavior for each change is:
1. If edx-organizations isn't installed, then the import fails gracefully.
2. If `SKIP_LOGIN_AFTER_REGISTRATION` doesn't exist, then the normal registration workflow takes place and the user is logged in and redirected to /dashboard after registration. 

Related commits: 
https://github.com/noderabbit-team/edx-configs/commit/6df426793ef349659e503bf05aea95a9ed6d19d7