### PR TITLE
nyif course access workflows

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -131,7 +131,7 @@ from openedx.core.djangoapps.catalog.utils import get_programs_data
 
 # try to import appsembler fork of edx-organizations (if it's installed)
 try: 
-    from organizations.models import UserOrganizationMapping
+    from organizations.models import Organization, UserOrganizationMapping
     from hr_management.views import send_microsite_request_email_to_managers
 except ImportError:
     pass
@@ -1866,10 +1866,11 @@ def create_account_with_params(request, params):
     
     #if using custom Appsembler backend from edx-organizations
     if u'organizations.backends.OrganizationMemberBackend' in settings.AUTHENTICATION_BACKENDS:
-        organization = request.site.organizations.first()
+        org = configuration_helpers.get_value('course_org_filter')
+        organization = Organization.objects.filter(name=org).first()
         if organization: 
             UserOrganizationMapping.objects.get_or_create(user=user, organization=organization, is_active=False)
-            send_microsite_request_email_to_managers(request, new_user)
+            send_microsite_request_email_to_managers(request, user)
 
     # Immediately after a user creates an account, we log them in. They are only
     # logged in until they close the browser. They can't log in again until they click

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -132,6 +132,7 @@ from openedx.core.djangoapps.catalog.utils import get_programs_data
 # try to import appsembler fork of edx-organizations (if it's installed)
 try: 
     from organizations.models import UserOrganizationMapping
+    from hr_management.views import send_microsite_request_email_to_managers
 except ImportError:
     pass
 
@@ -1868,6 +1869,7 @@ def create_account_with_params(request, params):
         organization = request.site.organizations.first()
         if organization: 
             UserOrganizationMapping.objects.get_or_create(user=user, organization=organization, is_active=False)
+            send_microsite_request_email_to_managers(request, new_user)
 
     # Immediately after a user creates an account, we log them in. They are only
     # logged in until they close the browser. They can't log in again until they click

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -96,6 +96,12 @@ from xmodule.x_module import STUDENT_VIEW
 from ..entrance_exams import user_must_complete_entrance_exam
 from ..module_render import get_module_for_descriptor, get_module, get_module_by_usage_id
 
+#specific to our hr_management app
+try:
+    from hr_management.models import CourseCCASettings
+except ImportException:
+    pass
+
 log = logging.getLogger("edx.courseware")
 
 
@@ -667,6 +673,14 @@ def course_about(request, course_id):
             'course_image_urls': overview.image_urls,
         }
         inject_coursetalk_keys_into_context(context, course_key)
+
+        # check hr_management access request settings
+        try:
+            course_cca_settings, created = CourseCCASettings.objects.get_or_create(course_id=course_key)
+        except NameError:
+            pass
+        else: 
+            context['require_access_request'] = course_cca_settings.require_access_request
 
         return render_to_response('courseware/course_about.html', context)
 


### PR DESCRIPTION
There are two updates here:

First, I'm changing the method used to determine the Organization during a user registration. AMC relies on modifying the Site object to include a foreign key relationship with an Organization. Instead of taking that change, we're going to grab the `course_org_filter` from the SiteConfiguration. 

Second, the course about page has been updated to include the course access request workflow. This ties in with the microsite theme changes here: 
https://github.com/appsembler/edx-theme-customers/commit/37667b18f3018d607fa857737cc68075e6c606c9

If a manager indicates that a course requires special permission to access, a student can visit the course's about page, click on the "Enroll in COURSE_NAME" button, then a request will be sent to the manager. 