### PR TITLE
Appsembler/amc/fix fields

### DIFF
--- a/openedx/core/djangoapps/appsembler/tpa_admin/api.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/api.py
@@ -38,4 +38,4 @@ class SAMLProviderSiteDetail(generics.ListAPIView):
 
     def get_queryset(self):
         site_id = self.kwargs['site_id']
-        return SAMLProviderConfig.objects.current_set().filter(site__id=site_id)
+        return SAMLProviderConfig.objects.current_set().filter(site__id=site_id).order_by('-enabled')

--- a/openedx/core/djangoapps/appsembler/tpa_admin/serializers.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/serializers.py
@@ -1,27 +1,31 @@
 import json
 
 from third_party_auth.models import SAMLConfiguration, SAMLProviderConfig, SAMLProviderData
+from third_party_auth.models import clean_json
 
 from rest_framework import serializers
 
 
-class JSONSerializerField(serializers.Field):
-    """ Serializer for JSONField -- required to make field writable"""
-    def to_internal_value(self, data):
-        return json.dumps(data)
-
-    def to_representation(self, value):
-        return value
-
-
 class SAMLConfigurationSerializer(serializers.ModelSerializer):
-    other_config_str = JSONSerializerField()
 
     class Meta:
         model = SAMLConfiguration
         fields = (
             'id', 'site', 'enabled','entity_id', 'private_key', 'public_key', 'org_info_str', 'other_config_str'
         )
+
+    def validate_private_key(self, value):
+        return value.replace("-----BEGIN RSA PRIVATE KEY-----", "").replace("-----BEGIN PRIVATE KEY-----", "").replace(
+            "-----END RSA PRIVATE KEY-----", "").replace("-----END PRIVATE KEY-----", "").strip()
+
+    def validate_public_key(self, value):
+        return value.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").strip()
+
+    def validate_org_info_str(self, value):
+        return clean_json(value, dict)
+
+    def validate_other_config_str(self, value):
+        return clean_json(value, dict)
 
 
 class SAMLProviderConfigSerializer(serializers.ModelSerializer):
@@ -35,6 +39,9 @@ class SAMLProviderConfigSerializer(serializers.ModelSerializer):
             'attr_full_name', 'attr_first_name', 'attr_last_name', 'attr_username', 'attr_email', 'other_settings',
             'metadata_ready'
         )
+
+    def validate_other_settings(self, value):
+        return clean_json(value, dict)
 
     def get_metadata_ready(self, obj):
         """ Do we have cached metadata for this SAML provider? """


### PR DESCRIPTION
@bezidejni The PR includes two new changes:

1. Transformation of fields: JSON fields must are stored in CharFields in the model, but to be sure that they're going to work, I'm using the same method to validate them and parse them. Also, we're removing the header and footers in the SP cert and key, this is causing an error in all sites.
2. In Identity Provider per site, add ordering by `enabled` we should not allow the user to delete providers, but we can show the active first int the list.

