### PR TITLE
Change default certificate status for open-ended courses

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -349,7 +349,8 @@ def _cert_info(user, course_overview, cert_status, course_mode):  # pylint: disa
         CertificateStatuses.unverified: 'unverified',
     }
 
-    default_status = 'processing'
+    # open-ended courses should not display the 'processing' message
+    default_status = 'unavailable' if not course_overview.end else 'processing' 
 
     default_info = {
         'status': default_status,


### PR DESCRIPTION
Dashboard currently shows "Final course details are being wrapped up at this time. Your final standing will be available shortly." below courses for which a student has not requested or received a certificate.  This makes sense if the course has ended and grading is in progress, but not for open-ended courses (courses with no end date).  

The course advanced setting, `certificate_display_behavior` must be set to either `early_no_info` or `early_with_info` for open-ended courses to display anything at all on the dashboard, so changing that setting would not have solved this issue. 

This changes the default certificate status for these courses from 'processing' to 'unavailable', so that no message will be displayed.  

This one is probably a good candidate for upstreaming.