### PR TITLE
Fix HTML certs issues with unicode characters in names

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -56,7 +56,7 @@ def get_certificate_description(mode, certificate_type, platform_name):
     certificate_type_description = None
     if mode == 'honor':
         # Translators:  This text describes the 'Honor' course certificate type.
-        certificate_type_description = _("An {cert_type} certificate signifies that a "
+        certificate_type_description = _(u"An {cert_type} certificate signifies that a "
                                          "learner has agreed to abide by the honor code established by {platform_name} "
                                          "and has completed all of the required tasks for this course under its "
                                          "guidelines.").format(cert_type=certificate_type,
@@ -64,7 +64,7 @@ def get_certificate_description(mode, certificate_type, platform_name):
     elif mode == 'verified':
         # Translators:  This text describes the 'ID Verified' course certificate type, which is a higher level of
         # verification offered by edX.  This type of verification is useful for professional education/certifications
-        certificate_type_description = _("A {cert_type} certificate signifies that a "
+        certificate_type_description = _(u"A {cert_type} certificate signifies that a "
                                          "learner has agreed to abide by the honor code established by {platform_name} "
                                          "and has completed all of the required tasks for this course under its "
                                          "guidelines. A {cert_type} certificate also indicates that the "
@@ -74,7 +74,7 @@ def get_certificate_description(mode, certificate_type, platform_name):
     elif mode == 'xseries':
         # Translators:  This text describes the 'XSeries' course certificate type.  An XSeries is a collection of
         # courses related to each other in a meaningful way, such as a specific topic or theme, or even an organization
-        certificate_type_description = _("An {cert_type} certificate demonstrates a high level of "
+        certificate_type_description = _(u"An {cert_type} certificate demonstrates a high level of "
                                          "achievement in a program of study, and includes verification of "
                                          "the student's identity.").format(cert_type=certificate_type)
     return certificate_type_description
@@ -104,7 +104,7 @@ def _update_certificate_context(context, user_certificate, platform_name):
     )
 
     # Translators:  This text represents the verification of the certificate
-    context['document_meta_description'] = _('This is a valid {platform_name} certificate for {user_name}, '
+    context['document_meta_description'] = _(u'This is a valid {platform_name} certificate for {user_name}, '
                                              'who participated in {partner_short_name} {course_number}').format(
         platform_name=platform_name,
         user_name=context['accomplishment_copy_name'],
@@ -113,7 +113,7 @@ def _update_certificate_context(context, user_certificate, platform_name):
     )
 
     # Translators:  This text is bound to the HTML 'title' element of the page and appears in the browser title bar
-    context['document_title'] = _("{partner_short_name} {course_number} Certificate | {platform_name}").format(
+    context['document_title'] = _(u"{partner_short_name} {course_number} Certificate | {platform_name}").format(
         partner_short_name=context['organization_short_name'],
         course_number=context['course_number'],
         platform_name=platform_name
@@ -121,7 +121,7 @@ def _update_certificate_context(context, user_certificate, platform_name):
 
     # Translators:  This text fragment appears after the student's name (displayed in a large font) on the certificate
     # screen.  The text describes the accomplishment represented by the certificate information displayed to the user
-    context['accomplishment_copy_description_full'] = _("successfully completed, received a passing grade, and was "
+    context['accomplishment_copy_description_full'] = _(u"successfully completed, received a passing grade, and was "
                                                         "awarded this {platform_name} {certificate_type} "
                                                         "Certificate of Completion in ").format(
         platform_name=platform_name,
@@ -132,7 +132,7 @@ def _update_certificate_context(context, user_certificate, platform_name):
         context['certificate_type_description'] = certificate_type_description
 
     # Translators: This text describes the purpose (and therefore, value) of a course certificate
-    context['certificate_info_description'] = _("{platform_name} acknowledges achievements through "
+    context['certificate_info_description'] = _(u"{platform_name} acknowledges achievements through "
                                                 "certificates, which are awarded for course activities "
                                                 "that {platform_name} students complete.").format(
         platform_name=platform_name,
@@ -173,7 +173,7 @@ def _update_context_with_basic_info(context, course_id, platform_name, configura
     context['logo_subtitle'] = _("Certificate Validation")
 
     # Translators: Accomplishments describe the awards/certifications obtained by students on this platform
-    context['accomplishment_copy_about'] = _('About {platform_name} Accomplishments').format(
+    context['accomplishment_copy_about'] = _(u'About {platform_name} Accomplishments').format(
         platform_name=platform_name
     )
 
@@ -183,16 +183,16 @@ def _update_context_with_basic_info(context, course_id, platform_name, configura
     # Translators:  The Certificate ID Number is an alphanumeric value unique to each individual certificate
     context['certificate_id_number_title'] = _('Certificate ID Number')
 
-    context['certificate_info_title'] = _('About {platform_name} Certificates').format(
+    context['certificate_info_title'] = _(u'About {platform_name} Certificates').format(
         platform_name=platform_name
     )
 
-    context['certificate_verify_title'] = _("How {platform_name} Validates Student Certificates").format(
+    context['certificate_verify_title'] = _(u"How {platform_name} Validates Student Certificates").format(
         platform_name=platform_name
     )
 
     # Translators:  This text describes the validation mechanism for a certificate file (known as GPG security)
-    context['certificate_verify_description'] = _('Certificates issued by {platform_name} are signed by a gpg key so '
+    context['certificate_verify_description'] = _(u'Certificates issued by {platform_name} are signed by a gpg key so '
                                                   'that they can be validated independently by anyone with the '
                                                   '{platform_name} public key. For independent verification, '
                                                   '{platform_name} uses what is called a '
@@ -201,21 +201,21 @@ def _update_context_with_basic_info(context, course_id, platform_name, configura
     context['certificate_verify_urltext'] = _("Validate this certificate for yourself")
 
     # Translators:  This text describes (at a high level) the mission and charter the edX platform and organization
-    context['company_about_description'] = _("{platform_name} offers interactive online classes and MOOCs.").format(
+    context['company_about_description'] = _(u"{platform_name} offers interactive online classes and MOOCs.").format(
         platform_name=platform_name)
 
-    context['company_about_title'] = _("About {platform_name}").format(platform_name=platform_name)
+    context['company_about_title'] = _(u"About {platform_name}").format(platform_name=platform_name)
 
-    context['company_about_urltext'] = _("Learn more about {platform_name}").format(platform_name=platform_name)
+    context['company_about_urltext'] = _(u"Learn more about {platform_name}").format(platform_name=platform_name)
 
-    context['company_courselist_urltext'] = _("Learn with {platform_name}").format(platform_name=platform_name)
+    context['company_courselist_urltext'] = _(u"Learn with {platform_name}").format(platform_name=platform_name)
 
-    context['company_careers_urltext'] = _("Work at {platform_name}").format(platform_name=platform_name)
+    context['company_careers_urltext'] = _(u"Work at {platform_name}").format(platform_name=platform_name)
 
-    context['company_contact_urltext'] = _("Contact {platform_name}").format(platform_name=platform_name)
+    context['company_contact_urltext'] = _(u"Contact {platform_name}").format(platform_name=platform_name)
 
     # Translators:  This text appears near the top of the certficate and describes the guarantee provided by edX
-    context['document_banner'] = _("{platform_name} acknowledges the following student accomplishment").format(
+    context['document_banner'] = _(u"{platform_name} acknowledges the following student accomplishment").format(
         platform_name=platform_name
     )
 
@@ -232,7 +232,7 @@ def _update_course_context(request, context, course, platform_name):
     context['course_number'] = course_number
     if context['organization_long_name']:
         # Translators:  This text represents the description of course
-        context['accomplishment_copy_course_description'] = _('a course of study offered by {partner_short_name}, '
+        context['accomplishment_copy_course_description'] = _(u'a course of study offered by {partner_short_name}, '
                                                               'an online learning initiative of '
                                                               '{partner_long_name}.').format(
             partner_short_name=context['organization_short_name'],
@@ -240,7 +240,7 @@ def _update_course_context(request, context, course, platform_name):
             platform_name=platform_name)
     else:
         # Translators:  This text represents the description of course
-        context['accomplishment_copy_course_description'] = _('a course of study offered by '
+        context['accomplishment_copy_course_description'] = _(u'a course of study offered by '
                                                               '{partner_short_name}.').format(
             partner_short_name=context['organization_short_name'],
             platform_name=platform_name)
@@ -255,7 +255,7 @@ def _update_social_context(request, context, course, user, user_certificate, pla
     context['facebook_app_id'] = configuration_helpers.get_value("FACEBOOK_APP_ID", settings.FACEBOOK_APP_ID)
     context['facebook_share_text'] = share_settings.get(
         'CERTIFICATE_FACEBOOK_TEXT',
-        _("I completed the {course_title} course on {platform_name}.").format(
+        _(u"I completed the {course_title} course on {platform_name}.").format(
             course_title=context['accomplishment_copy_course_name'],
             platform_name=platform_name
         )
@@ -263,7 +263,7 @@ def _update_social_context(request, context, course, user, user_certificate, pla
     context['twitter_share_enabled'] = share_settings.get('CERTIFICATE_TWITTER', False)
     context['twitter_share_text'] = share_settings.get(
         'CERTIFICATE_TWITTER_TEXT',
-        _("I completed a course at {platform_name}. Take a look at my certificate.").format(
+        _(u"I completed a course at {platform_name}. Take a look at my certificate.").format(
             platform_name=platform_name
         )
     )
@@ -303,11 +303,11 @@ def _update_context_with_user_info(context, user, user_certificate):
     context['accomplishment_copy_name'] = user_fullname
     context['accomplishment_copy_username'] = user.username
 
-    context['accomplishment_more_title'] = _("More Information About {user_name}'s Certificate:").format(
+    context['accomplishment_more_title'] = _(u"More Information About {user_name}'s Certificate:").format(
         user_name=user_fullname
     )
     # Translators: This line is displayed to a user who has completed a course and achieved a certification
-    context['accomplishment_banner_opening'] = _("{fullname}, you earned a certificate!").format(
+    context['accomplishment_banner_opening'] = _(u"{fullname}, you earned a certificate!").format(
         fullname=user_fullname
     )
 
@@ -317,7 +317,7 @@ def _update_context_with_user_info(context, user, user_certificate):
                                                   "in your social and professional networks.")
 
     # Translators: This line leads the reader to understand more about the certificate that a student has been awarded
-    context['accomplishment_copy_more_about'] = _("More about {fullname}'s accomplishment").format(
+    context['accomplishment_copy_more_about'] = _(u"More about {fullname}'s accomplishment").format(
         fullname=user_fullname
     )
 


### PR DESCRIPTION
 Use Unicode pattern for string.format.
Cherry-picked changes from our Eucalyptus hotfix branch.  No conflicts though `webview.py` has minor changes.  
