### PR TITLE
Support Django Webpack Loader and edx-figures

### DIFF
--- a/lms/envs/appsembler.py
+++ b/lms/envs/appsembler.py
@@ -1,3 +1,4 @@
+
 import os
 import json
 
@@ -19,8 +20,21 @@ INTERCOM_API_KEY = APPSEMBLER_FEATURES.get('INTERCOM_API_KEY', os.environ.get('I
 INTERCOM_USER_EMAIL = APPSEMBLER_FEATURES.get('INTERCOM_USER_EMAIL', os.environ.get('INTERCOM_USER_EMAIL', ''))
 
 
+# We keep  'APPSEMBLER_REPORTING' until after we've deployed edx-figure to 
+# production and proven it
 if APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_REPORTING', False):
     from appsembler_reporting.settings import APPSEMBLER_REPORTING
 
+    # This will just merge and update top level keys/values
     APPSEMBLER_REPORTING.update(APPSEMBLER_FEATURES.get(
         'APPSEMBLER_REPORTING', {} ))
+
+# Monkeypatch edx_figures settings from env/json
+if ENV_TOKENS.get('EDX_FIGURES', {}).get('ENABLED', False):
+    try:
+        from edx_figures.settings import EDX_FIGURES
+
+        # This will just merge and update top level keys/values
+        EDX_FIGURES.update(ENV_TOKENS.get('EDX_FIGURES',{}))
+    except ImportError:
+        pass

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -1,4 +1,5 @@
 # aws_appsembler.py
+import sys
 
 from .aws import *
 from .appsembler import *
@@ -132,3 +133,21 @@ try:
 except ImportError:
     pass
 
+
+
+# Anticipate edX supporting webpack loader (it is in their development pipeline)
+this = sys.modules[__name__]
+if not hasattr(this, 'WEBPACK_LOADER'):
+    setattr(this, 'WEBPACK_LOADER', {})
+
+# Initial implementation hardcodes edx_figures. Upcoming, plan to dynamically
+# load modules that are registered in lms.env.json.
+try:
+    from edx_figures import settings as edx_figures_settings
+
+    WEBPACK_LOADER['EDX_FIGURES_APP'] = {
+        'BUNDLE_DIR_NAME': edx_figures_settings.webpack_bundle_dir_name,
+        'STATS_FILE': edx_figures_settings.webpack_stats_file
+    }
+except ImportError:
+    pass

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -1,6 +1,8 @@
 # devstack_appsembler.py
 
 import os
+import sys
+
 from .devstack import *
 from .appsembler import *
 
@@ -121,4 +123,22 @@ try:
 except ImportError:
     pass
 
+# Support django-webpack-loader
 
+# Anticipate edX supporting webpack loader (it is in their development pipeline)
+this = sys.modules[__name__]
+if not hasattr(this, 'WEBPACK_LOADER'):
+    setattr(this, 'WEBPACK_LOADER', {})
+
+# Initial implementation hardcodes edx_figures. Upcoming, plan to dynamically
+# load modules that are registered in lms.env.json.
+try:
+    from edx_figures import settings as edx_figures_settings
+
+    WEBPACK_LOADER['EDX_FIGURES_APP'] = {
+        'BUNDLE_DIR_NAME': edx_figures_settings.webpack_bundle_dir_name,
+        'STATS_FILE': edx_figures_settings.webpack_stats_file
+    }
+except ImportError:
+    print('ImportError, unable to import edx_figures settings')
+    pass


### PR DESCRIPTION
Added hooks to LMS envs to support Django Webpack Loader and edx-figures

appsembler.py now loads `EDX_FIGURES` settings

aws_appsembler.py and devstack_appsembler.py contain duplicate code to
declare `WEBPACK_LOADER`, try importing from edx_figures and load its
settings.