### PR TITLE
don't automatically enable courseware discovery for devstack

### DIFF
--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -122,3 +122,5 @@ except ImportError:
     pass
 
 
+# override devstack.py automatic enabling of courseware discovery
+FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS.get('TPA_CLEAN_USERNAMES_KEEP_DOMAIN_PART', False)


### PR DESCRIPTION
Devstack enables a bunch of features by default.  Obey env_token for `enable_course_discovery`.