### PR TITLE
(Fix) don't automatically enable courseware discovery for devstack

### DIFF
--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -121,6 +121,5 @@ try:
 except ImportError:
     pass
 
-
 # override devstack.py automatic enabling of courseware discovery
-FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS.get('TPA_CLEAN_USERNAMES_KEEP_DOMAIN_PART', False)
+FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS['FEATURES'].get('ENABLE_COURSE_DISCOVERY', FEATURES['ENABLE_COURSE_DISCOVERY'])


### PR DESCRIPTION
This is a fix to a previous PR which had an error (#191).

Closes #197
  