### PR TITLE
Conditionally enable Taxoman for Ficus

### DIFF
--- a/cms/djangoapps/search_api/__init__.py
+++ b/cms/djangoapps/search_api/__init__.py
@@ -1,0 +1,2 @@
+
+API_VERSION = 'v0'

--- a/cms/djangoapps/search_api/api.py
+++ b/cms/djangoapps/search_api/api.py
@@ -1,0 +1,24 @@
+
+from contentstore.courseware_index import CoursewareSearchIndexer
+from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
+
+def reindex_course(course_id):
+    """
+    Arguments:
+    	course_id - The course id for a course. This is the 'course_id' property
+    	            for the course as returend from:
+    	            	<lms-host>/api/courses/v1/courses/
+
+    Raises:
+    	InvalidKeyError - if the opaque course 
+    	SearchIndexingError - If the reindexing fails
+
+    References
+        course.py#reindex_course_and_check_access
+
+    """
+    course_key = CourseKey.from_string(course_id)
+    with modulestore().bulk_operations(course_key):
+	    return CoursewareSearchIndexer.do_course_reindex(modulestore(),
+	    	course_key)

--- a/cms/djangoapps/search_api/permissions.py
+++ b/cms/djangoapps/search_api/permissions.py
@@ -1,0 +1,10 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsStaffUser(BasePermission):
+    """
+    Allow access to only staff users
+    """
+    def has_permission(self, request, view):
+        return request.user and request.user.is_active and (
+            request.user.is_staff or request.user.is_superuser)

--- a/cms/djangoapps/search_api/urls.py
+++ b/cms/djangoapps/search_api/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from . import API_VERSION, views
+
+urlpatterns = [
+    url(r'^$', views.SearchIndex.as_view(), name='search_api_index'),
+    url(r'^{}/reindex-course'.format(API_VERSION),
+        views.CourseIndexer.as_view(), name='reindex-course'),
+]

--- a/cms/djangoapps/search_api/views.py
+++ b/cms/djangoapps/search_api/views.py
@@ -1,0 +1,97 @@
+
+import json
+
+from django.conf import settings 
+from django.http import HttpResponse
+
+from rest_framework.authentication import (
+    BasicAuthentication,
+    SessionAuthentication,
+    TokenAuthentication,
+)
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from opaque_keys import InvalidKeyError
+
+from . import api
+from .permissions import IsStaffUser
+
+# Restrict access to the LMS server
+ALLOWED_ORIGIN = settings.LMS_BASE
+
+description = """
+Appembler Open edX search api. 
+Opens up access to Open edX'sa search infrastructure via HTTP (REST) API interfaces.
+"""
+
+class SearchIndex(APIView):
+    authentication_classes = (
+        BasicAuthentication,
+        SessionAuthentication,
+        TokenAuthentication
+    )
+
+    permission_classes = ( IsAuthenticated, IsStaffUser, )
+    def get(self, request, format=None):
+        return Response({
+            'message': 'CMS Search API',
+            })
+
+
+class CourseIndexer(APIView):
+    authentication_classes = (
+        BasicAuthentication,
+        SessionAuthentication,
+        TokenAuthentication
+    )
+
+    permission_classes = ( IsAuthenticated, IsStaffUser, )
+    
+    def get(self, request, format=None):
+        return Response({
+            'message': 'Course Indexer',
+            })
+
+    def post(self, request, format=None):
+
+        request_data = json.loads(request.body)
+        course_id = request_data.get('course_id')
+        try:
+            results = api.reindex_course(course_id)
+            response_data = {
+                'course_id': course_id,
+                'status': 'OK',
+                'message': 'course reindex initiated',
+                'results': results,
+            }
+            response = Response(response_data)
+            response['Access-Control-Allow-Origin'] = ALLOWED_ORIGIN
+            response['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
+            response['Access-Control-Allow-Headers'] = '*'
+            return response
+        except Exception as e:
+            if isinstance(e, InvalidKeyError):
+                message = 'InvalidKeyError: Cannot find key for course string ' + \
+                    '"{}"'.format(course_id)
+                status = 400
+            else:
+                message = 'Exception "{}" msg: {}'.format(e.__class__, e.message)
+                status = 500
+            return Response(json.dumps({
+                    'course_id': course_id,
+                    'status': 'ERROR',
+                    'message': message,
+                }), status=status)
+
+    def options(self, request, format=None):
+        response = Response()
+        response['Access-Control-Allow-Origin'] = ALLOWED_ORIGIN
+        response['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
+        # Options do not allow wildcard for access-control-allow-headers
+        response['Access-Control-Allow-Headers'] = 'Content-Type'
+        return response

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -959,6 +959,11 @@ INSTALLED_APPS = (
 
     # Unusual migrations
     'database_fixups',
+
+    # Appsembler API Extensions
+    'rest_framework',
+    'rest_framework.authtoken',
+    'search_api',
 )
 
 

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -213,5 +213,5 @@ urlpatterns += (
 
 # Appsembler API extensions
 urlpatterns += (
-    url(r'^api/search/', include('serach_api.urls')),
+    url(r'^api/search/', include('search_api.urls')),
 )

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -210,3 +210,8 @@ urlpatterns += (
     url(r'^404$', handler404),
     url(r'^500$', handler500),
 )
+
+# Appsembler API extensions
+urlpatterns += (
+    url(r'^api/search/', include('serach_api.urls')),
+)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -104,6 +104,19 @@ except ImportError:
 
 log = logging.getLogger("edx.courseware")
 
+# Interim code to get courseware views to work with Taxoman
+if settings.TAXOMAN_ENABLED:
+    try:
+        from taxoman_api.models import Facet
+        using_taxoman = True
+    except ImportError:
+        log.error('Taxoman enabled, but unable to import taxoman_api package (ImportError')
+        using_taxoman = False
+else:
+    using_taxoman = False
+
+
+
 
 # Only display the requirements on learner dashboard for
 # credit and verified modes.
@@ -144,6 +157,11 @@ def courses(request):
     courses_list = []
     programs_list = []
     course_discovery_meanings = getattr(settings, 'COURSE_DISCOVERY_MEANINGS', {})
+    if using_taxoman:
+        for facet in Facet.objects.all():
+            if not course_discovery_meanings.get(facet.slug):
+                course_discovery_meanings[facet.slug] = { 'name': facet.name }
+
     if not settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
         courses_list = get_courses(request.user)
 

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -3,6 +3,16 @@
 from .aws import *
 from .appsembler import *
 
+if FEATURES.get('ENABLE_TAXOMAN', False):
+    try:
+        import taxoman.settings
+        TAXOMAN_ENABLED = True
+    except ImportError:
+        TAXOMAN_ENABLED = False
+else:
+    TAXOMAN_ENABLED = False
+
+
 ENV_APPSEMBLER_FEATURES = ENV_TOKENS.get('APPSEMBLER_FEATURES', {})
 for feature, value in ENV_APPSEMBLER_FEATURES.items():
     APPSEMBLER_FEATURES[feature] = value
@@ -132,3 +142,9 @@ try:
 except ImportError:
     pass
 
+
+if TAXOMAN_ENABLED:
+    WEBPACK_LOADER['TAXOMAN_APP'] = {
+        'BUNDLE_DIR_NAME': taxoman.settings.bundle_dir_name,
+        'STATS_FILE': taxoman.settings.stats_file,
+    }

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2024,6 +2024,7 @@ INSTALLED_APPS = (
 
     # User API
     'rest_framework',
+    'rest_framework.authtoken',
     'openedx.core.djangoapps.user_api',
 
     # Shopping cart
@@ -3042,3 +3043,5 @@ DOC_LINK_BASE_URL = None
 ############## Settings for the Enterprise App ######################
 
 ENTERPRISE_ENROLLMENT_API_URL = LMS_ROOT_URL + "/api/enrollment/v1/"
+
+WEBPACK_LOADER = {}

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -1,8 +1,23 @@
 # devstack_appsembler.py
 
 import os
+
 from .devstack import *
 from .appsembler import *
+
+
+if FEATURES.get('ENABLE_TAXOMAN', False):
+    try:
+        # Just a check, we don't need it for the settings
+        import taxoman_api
+        # We need this for webpack loader
+        import taxoman.settings
+        TAXOMAN_ENABLED = True
+    except ImportError:
+        TAXOMAN_ENABLED = False
+else:
+    TAXOMAN_ENABLED = False
+
 
 ENV_APPSEMBLER_FEATURES = ENV_TOKENS.get('APPSEMBLER_FEATURES', {})
 for feature, value in ENV_APPSEMBLER_FEATURES.items():
@@ -123,3 +138,9 @@ except ImportError:
 
 # override devstack.py automatic enabling of courseware discovery
 FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS['FEATURES'].get('ENABLE_COURSE_DISCOVERY', FEATURES['ENABLE_COURSE_DISCOVERY'])
+
+if TAXOMAN_ENABLED:
+    WEBPACK_LOADER['TAXOMAN_APP'] = {
+        'BUNDLE_DIR_NAME': taxoman.settings.bundle_dir_name,
+        'STATS_FILE': taxoman.settings.stats_file,
+    }


### PR DESCRIPTION
I didn't put effort into abstracting away taxoman inclusions since we need to figure out a much slimmer way to integrate Appsembler specific features into edx-platform, and we also need to march forward with Ginko then Hawthorne when it get released, 

What I *did* do was add conditionals and test that it works in a GCP staging server both with Taxoman enabled and with taxoman disabled and the taxoman and taxoman_api python packages not installed


The Search API app in CMS is mostly unchanged from Dogwood