### PR TITLE
HTML Certs changes for Tahoe

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -48,6 +48,8 @@ from django.core.exceptions import PermissionDenied
 from course_modes.models import CourseMode
 from contentstore.utils import get_lms_link_for_certificate_web_view
 
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
 CERTIFICATE_SCHEMA_VERSION = 1
 CERTIFICATE_MINIMUM_ID = 100
 
@@ -394,7 +396,12 @@ def certificates_list_handler(request, course_key_string):
                 certificate_web_view_url = None
             certificates = None
             is_active = False
-            if settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+            current_organization = request.user.organizations.first()
+            if configuration_helpers.get_value_for_org(
+                current_organization.name,
+                "CERTIFICATES_HTML_VIEW",
+                False
+            ):
                 certificates = CertificateManager.get_certificates(course)
                 # we are assuming only one certificate in certificates collection.
                 for certificate in certificates:

--- a/cms/envs/amc.py
+++ b/cms/envs/amc.py
@@ -1,6 +1,8 @@
 from .aws import *
 import dj_database_url
 
+from django.utils.translation import ugettext_lazy as _
+
 APPSEMBLER_AMC_API_BASE = AUTH_TOKENS.get('APPSEMBLER_AMC_API_BASE')
 APPSEMBLER_FIRST_LOGIN_API = '/logged_into_edx'
 
@@ -9,6 +11,7 @@ APPSEMBLER_SECRET_KEY = AUTH_TOKENS.get("APPSEMBLER_SECRET_KEY")
 INSTALLED_APPS += (
     'openedx.core.djangoapps.appsembler.sites',
  #   'openedx.core.djangoapps.appsembler.msft_lp',
+    'openedx.core.djangoapps.appsembler.html_certificates',
 )
 
 APPSEMBLER_FEATURES = ENV_TOKENS.get('APPSEMBLER_FEATURES', {})
@@ -97,3 +100,6 @@ XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5
 CLONE_COURSE_FOR_NEW_SIGNUPS = False
 HIJACK_ALLOW_GET_REQUESTS = True
 HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'
+
+DEFAULT_COURSE_MODE_SLUG = ENV_TOKENS.get('EDXAPP_DEFAULT_COURSE_MODE_SLUG', 'audit')
+DEFAULT_MODE_NAME_FROM_SLUG = _(DEFAULT_COURSE_MODE_SLUG.capitalize())

--- a/cms/envs/devstack_appsembler.py
+++ b/cms/envs/devstack_appsembler.py
@@ -4,9 +4,12 @@ from .devstack import *
 from .appsembler import *
 import dj_database_url
 
+from django.utils.translation import ugettext_lazy as _
+
 INSTALLED_APPS += (
     'django_extensions',
     'openedx.core.djangoapps.appsembler.sites',
+    'openedx.core.djangoapps.appsembler.html_certificates',
 )
 
 OAUTH_ENFORCE_SECURE = False
@@ -88,6 +91,9 @@ CELERY_QUEUES.update(
 CLONE_COURSE_FOR_NEW_SIGNUPS = False
 HIJACK_ALLOW_GET_REQUESTS = True
 HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'
+
+DEFAULT_COURSE_MODE_SLUG = ENV_TOKENS.get('EDXAPP_DEFAULT_COURSE_MODE_SLUG', 'audit')
+DEFAULT_MODE_NAME_FROM_SLUG = _(DEFAULT_COURSE_MODE_SLUG.capitalize())
 
 try:
     from .private import *

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -5,6 +5,7 @@
   from django.core.urlresolvers import reverse
   from django.utils.translation import ugettext as _
   from contentstore.context_processors import doc_url
+  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <div class="wrapper-header wrapper" id="view-top">
   <header class="primary" role="banner">
@@ -19,6 +20,7 @@
       % if context_course:
       <%
             course_key = context_course.id
+            current_organization = request.user.organizations.first()
             index_url = reverse('contentstore.views.course_handler', kwargs={'course_key_string': unicode(course_key)})
             course_team_url = reverse('contentstore.views.course_team_handler', kwargs={'course_key_string': unicode(course_key)})
             assets_url = reverse('contentstore.views.assets_handler', kwargs={'course_key_string': unicode(course_key)})
@@ -32,7 +34,7 @@
             advanced_settings_url = reverse('contentstore.views.advanced_settings_handler', kwargs={'course_key_string': unicode(course_key)})
             tabs_url = reverse('contentstore.views.tabs_handler', kwargs={'course_key_string': unicode(course_key)})
             certificates_url = ''
-            if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
+            if configuration_helpers.get_value_for_org(current_organization.name, "CERTIFICATES_HTML_VIEW", False) and context_course.cert_html_view_enabled:
                 certificates_url = reverse('contentstore.views.certificates.certificates_list_handler', kwargs={'course_key_string': unicode(course_key)})
       %>
       <h2 class="info-course">

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -16,6 +16,7 @@ from branding import api as branding_api
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from xmodule.modulestore.django import modulestore
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from util.organizations_helpers import get_course_organizations
 
 from certificates.models import (
@@ -363,7 +364,7 @@ def has_html_certificates_enabled(course_key, course=None):
         course (CourseDescriptor|CourseOverview): A course.
     """
     # If the feature is disabled, then immediately return a False
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not configuration_helpers.get_value("CERTIFICATES_HTML_VIEW", False):
         return False
 
     # If we don't have a course object, we'll need to assemble one

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -825,9 +825,7 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
                     cert_web_view_url=None
                 )
 
-        return CertData(
-            cert_status, title, msg, download_url=cert_downloadable_status['download_url'], cert_web_view_url=None
-        )
+        return None
 
     if cert_downloadable_status['is_generating']:
         return CertData(
@@ -859,13 +857,16 @@ def _get_cert_data(student, course, course_key, is_active, enrollment_mode):
             cert_web_view_url=None
         )
 
-    return CertData(
-        CertificateStatuses.requesting,
-        _('Congratulations, you qualified for a certificate!'),
-        _('You can keep working for a higher grade, or request your certificate now.'),
-        download_url=None,
-        cert_web_view_url=None
-    )
+    if certs_api.has_html_certificates_enabled(course_key, course) and certs_api.get_active_web_certificate(course) is not None:
+        return CertData(
+            CertificateStatuses.requesting,
+            _('Congratulations, you qualified for a certificate!'),
+            _('You can keep working for a higher grade, or request your certificate now.'),
+            download_url=None,
+            cert_web_view_url=None
+        )
+
+    return None
 
 
 def _credit_course_requirements(course_key, student):

--- a/lms/envs/amc.py
+++ b/lms/envs/amc.py
@@ -1,6 +1,8 @@
 from .aws import *
 import dj_database_url
 
+from django.utils.translation import ugettext_lazy as _
+
 APPSEMBLER_AMC_API_BASE = AUTH_TOKENS.get('APPSEMBLER_AMC_API_BASE')
 APPSEMBLER_FIRST_LOGIN_API = '/logged_into_edx'
 
@@ -13,6 +15,7 @@ INSTALLED_APPS += (
     'openedx.core.djangoapps.appsembler.sites',
     #'openedx.core.djangoapps.appsembler.msft_lp',
     'openedx.core.djangoapps.appsembler.tpa_admin',
+    'openedx.core.djangoapps.appsembler.html_certificates',
 )
 
 GOOGLE_ANALYTICS_APP_ID = AUTH_TOKENS.get('GOOGLE_ANALYTICS_APP_ID')
@@ -133,3 +136,6 @@ HIJACK_ALLOW_GET_REQUESTS = True
 HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'
 
 USE_S3_FOR_CUSTOMER_THEMES = True
+
+DEFAULT_COURSE_MODE_SLUG = ENV_TOKENS.get('EDXAPP_DEFAULT_COURSE_MODE_SLUG', 'audit')
+DEFAULT_MODE_NAME_FROM_SLUG = _(DEFAULT_COURSE_MODE_SLUG.capitalize())

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -4,6 +4,8 @@ from .devstack import *
 from .appsembler import *
 import dj_database_url
 
+from django.utils.translation import ugettext_lazy as _
+
 OAUTH_ENFORCE_SECURE = False
 
 # disable caching in dev environment
@@ -17,6 +19,7 @@ INSTALLED_APPS += (
     'openedx.core.djangoapps.appsembler.sites',
     'openedx.core.djangoapps.appsembler.msft_lp',
     'openedx.core.djangoapps.appsembler.tpa_admin',
+    'openedx.core.djangoapps.appsembler.html_certificates',
 )
 
 # those are usually hardcoded in devstack.py for some reason
@@ -130,6 +133,9 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
              'third_party_auth.lti.LTIAuthBackend',
         ])
     )
+
+DEFAULT_COURSE_MODE_SLUG = ENV_TOKENS.get('EDXAPP_DEFAULT_COURSE_MODE_SLUG', 'audit')
+DEFAULT_MODE_NAME_FROM_SLUG = _(DEFAULT_COURSE_MODE_SLUG.capitalize())
 
 try:
     from .private import *

--- a/openedx/core/djangoapps/appsembler/html_certificates/__init__.py
+++ b/openedx/core/djangoapps/appsembler/html_certificates/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'openedx.core.djangoapps.appsembler.html_certificates.apps.HtmlCertificatesAppConfig'

--- a/openedx/core/djangoapps/appsembler/html_certificates/apps.py
+++ b/openedx/core/djangoapps/appsembler/html_certificates/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class HtmlCertificatesAppConfig(AppConfig):
+
+    name = 'openedx.core.djangoapps.appsembler.html_certificates'
+    label = 'html_certificates'
+
+    def ready(self):
+        from . import signals  # pylint: disable=unused-variable

--- a/openedx/core/djangoapps/appsembler/html_certificates/signals.py
+++ b/openedx/core/djangoapps/appsembler/html_certificates/signals.py
@@ -1,0 +1,29 @@
+"""
+Appsembler's signals to customize certificates and course behaviour
+"""
+
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.dispatch.dispatcher import receiver
+from xmodule.modulestore.django import modulestore, SignalHandler
+
+from course_modes.models import CourseMode
+
+@receiver(SignalHandler.course_published)
+def set_default_mode_on_course_publish(sender, course_key, **kwargs): # pylint: disable=unused-argument
+    """
+    Catches the signal that a course has been published in Studio and
+    creates a CourseMode in the default mode
+    """
+    try:
+        default_mode = CourseMode.objects.get(
+            course_id=course_key,
+            mode_slug=settings.DEFAULT_COURSE_MODE_SLUG
+        )
+    except ObjectDoesNotExist:
+        default_mode = CourseMode(
+            course_id=course_key,
+            mode_slug=settings.DEFAULT_COURSE_MODE_SLUG,
+            mode_display_name=settings.DEFAULT_MODE_NAME_FROM_SLUG
+        )
+    default_mode.save()

--- a/openedx/core/djangoapps/appsembler/html_certificates/signals.py
+++ b/openedx/core/djangoapps/appsembler/html_certificates/signals.py
@@ -5,7 +5,7 @@ Appsembler's signals to customize certificates and course behaviour
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.dispatch.dispatcher import receiver
-from xmodule.modulestore.django import modulestore, SignalHandler
+from xmodule.modulestore.django import SignalHandler
 
 from course_modes.models import CourseMode
 

--- a/openedx/core/djangoapps/appsembler/html_certificates/signals.py
+++ b/openedx/core/djangoapps/appsembler/html_certificates/signals.py
@@ -15,15 +15,8 @@ def set_default_mode_on_course_publish(sender, course_key, **kwargs): # pylint: 
     Catches the signal that a course has been published in Studio and
     creates a CourseMode in the default mode
     """
-    try:
-        default_mode = CourseMode.objects.get(
-            course_id=course_key,
-            mode_slug=settings.DEFAULT_COURSE_MODE_SLUG
-        )
-    except ObjectDoesNotExist:
-        default_mode = CourseMode(
-            course_id=course_key,
-            mode_slug=settings.DEFAULT_COURSE_MODE_SLUG,
-            mode_display_name=settings.DEFAULT_MODE_NAME_FROM_SLUG
-        )
-    default_mode.save()
+    default_mode, created = CourseMode.objects.get_or_create(
+        course_id=course_key,
+        mode_slug=settings.DEFAULT_COURSE_MODE_SLUG,
+        mode_display_name=settings.DEFAULT_MODE_NAME_FROM_SLUG
+    )


### PR DESCRIPTION
The three main part of the PR are:
1. Creates a signal to set `honor` as default course enrollment mode in all new courses. This is because the edX default mode is `audit` and this enrollment mode doesn't allow certification. In the future we can support to let AMC admins to set the one or more courses modes in a course, mostly used when e-commerce is enabled.
2. Fix a view that return certificates available, that fallbacks automatically to PDF certs if the enrollment mode is honor. Since we aren't going to use PDF certs, we can return None.
3. Makes the feature flag `CERTIFICATES_HTML_VIEW` microsite aware, so we can enabled it per microsite.