### PR TITLE
Enable CMS HTML certificates URLs by default

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -160,17 +160,16 @@ if settings.FEATURES.get('ENTRANCE_EXAMS'):
     )
 
 # Enable Web/HTML Certificates
-if settings.FEATURES.get('CERTIFICATES_HTML_VIEW'):
-    urlpatterns += (
-        url(r'^certificates/activation/{}/'.format(settings.COURSE_KEY_PATTERN),
-            'contentstore.views.certificates.certificate_activation_handler'),
-        url(r'^certificates/{}/(?P<certificate_id>\d+)/signatories/(?P<signatory_id>\d+)?$'.format(
-            settings.COURSE_KEY_PATTERN), 'contentstore.views.certificates.signatory_detail_handler'),
-        url(r'^certificates/{}/(?P<certificate_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
-            'contentstore.views.certificates.certificates_detail_handler'),
-        url(r'^certificates/{}$'.format(settings.COURSE_KEY_PATTERN),
-            'contentstore.views.certificates.certificates_list_handler')
-    )
+urlpatterns += (
+    url(r'^certificates/activation/{}/'.format(settings.COURSE_KEY_PATTERN),
+        'contentstore.views.certificates.certificate_activation_handler'),
+    url(r'^certificates/{}/(?P<certificate_id>\d+)/signatories/(?P<signatory_id>\d+)?$'.format(
+        settings.COURSE_KEY_PATTERN), 'contentstore.views.certificates.signatory_detail_handler'),
+    url(r'^certificates/{}/(?P<certificate_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
+        'contentstore.views.certificates.certificates_detail_handler'),
+    url(r'^certificates/{}$'.format(settings.COURSE_KEY_PATTERN),
+        'contentstore.views.certificates.certificates_list_handler')
+)
 
 # Maintenance Dashboard
 urlpatterns += patterns(


### PR DESCRIPTION
Since this is loaded in the app start up, we cannot rely on a feature flag if is going to be available only for some customers.

I don't see any harm into have the URLs available for all customers, since they cannot access without the feature flag anyway.