### PR TITLE
Two enhancements to API endpoints

### DIFF
--- a/lms/djangoapps/appsembler_api/tests/test_views.py
+++ b/lms/djangoapps/appsembler_api/tests/test_views.py
@@ -14,6 +14,7 @@ from django.test.utils import override_settings
 
 from search.tests.test_course_discovery import DemoCourse
 
+import ddt
 
 ### for this endpoint test
 from mock import patch
@@ -27,10 +28,11 @@ from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from xmodule.modulestore.tests.factories import CourseFactory
 from certificates.models import GeneratedCertificate
 
-from appsembler_api.views import GetBatchEnrollmentDataView
+# from appsembler_api.views import GetBatchEnrollmentDataView
 
-# @patch('appsembler_api.views.GetBatchEnrollmentDataView.permission_classes', [AllowAny])
+# @patch.object(GetBatchEnrollmentDataView, 'permission_classes', [AllowAny])
 # @patch('appsembler_api.views.GetBatchEnrollmentDataView.authentication_classes', [])
+@ddt.ddt
 @patch('appsembler_api.views.GetBatchEnrollmentDataView.authentication_classes', [])
 @patch('appsembler_api.views.GetBatchEnrollmentDataView.permission_classes', [AllowAny])
 class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase):
@@ -45,7 +47,7 @@ class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCa
     def setUp(self):
         super(AnalyticsEnrollmentBatchViewTest, self).setUp()
         
-        self.view = GetBatchEnrollmentDataView.as_view()
+        # self.view = GetBatchEnrollmentDataView.as_view()
 
         self.staff = UserFactory.create(
             username=self.USERNAME,
@@ -77,17 +79,20 @@ class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCa
                                 for ce in self.enrollments
                         ]
 
-        self.url = reverse('get_batch_user_data')
+        self.url = reverse('get_batch_enrollment_data')
 
-    def test_analytics_enrollment_endpoint_alone(self):
-        request = self.request_factory.get(self.url, content_type='application/json')
-        force_authenticate(request, user=self.staff)
-        res = self.view(request)
-        res.render()
+    @ddt.unpack
+    @ddt.data(  {'course_str': 'course1', 'num_enrollments': 3},
+                {'course_str': 'course2', 'num_enrollments': 1},)
+    def test_analytics_enrollment_endpoint_with_only_course_id(self, course_str, num_enrollments):
 
-        # res = self.client.get(self.url)
-        print res.content
+        course = getattr(self, course_str)
+        course_id = str(course.id)
+
+        res = self.client.get(test_url + '?course_id={}'.format(course_id))
+
+        self.asserIn('enrollment', res.content)
         self.assertEqual(res.status_code, 200)
-        # self.assertEqual(res.status_code,4)
-        # self.assertEqual(len(self.certificates),4)
 
+        data = res.data
+        self.assertEqual(len(data), num_enrollments)

--- a/lms/djangoapps/appsembler_api/tests/test_views.py
+++ b/lms/djangoapps/appsembler_api/tests/test_views.py
@@ -2,37 +2,24 @@
 Tests for the Appsembler API views.
 """
 
-from urllib import quote, urlencode
-
 from django.core.urlresolvers import reverse
 
 from lms.djangoapps.course_api.tests.test_views import CourseApiTestViewMixin
-import json
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
-from django.test.utils import override_settings
-
-from search.tests.test_course_discovery import DemoCourse
 
 import ddt
 
-### for this endpoint test
 from mock import patch
 from datetime import datetime
 import pytz
 from rest_framework.permissions import AllowAny
-from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
-# from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from rest_framework.test import APIRequestFactory
 
-
-from student.tests.factories import UserFactory, CourseEnrollmentFactory
+from student.tests.factories import CourseEnrollmentFactory
 from xmodule.modulestore.tests.factories import CourseFactory
 from certificates.models import GeneratedCertificate
 
-# from appsembler_api.views import GetBatchEnrollmentDataView
-
-# @patch.object(GetBatchEnrollmentDataView, 'permission_classes', [AllowAny])
-# @patch('appsembler_api.views.GetBatchEnrollmentDataView.authentication_classes', [])
 @ddt.ddt
 @patch('appsembler_api.views.GetBatchEnrollmentDataView.authentication_classes', [])
 @patch('appsembler_api.views.GetBatchEnrollmentDataView.permission_classes', [AllowAny])
@@ -40,22 +27,9 @@ class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCa
     """
     Tests for the endpoint: /analytics/enrollment/batch
     """
-
-    USERNAME = "Bob"
-    EMAIL = "bob@example.com"
-    PASSWORD = "edx"
-
     def setUp(self):
         super(AnalyticsEnrollmentBatchViewTest, self).setUp()
         
-        # self.view = GetBatchEnrollmentDataView.as_view()
-
-        self.staff = UserFactory.create(
-            username=self.USERNAME,
-            email=self.EMAIL,
-            password=self.PASSWORD,
-            is_staff=True,
-        )
         self.request_factory = APIRequestFactory()
 
         self.course1 = CourseFactory()
@@ -81,28 +55,23 @@ class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCa
             GeneratedCertificate(
                             course_id=ce.course_id, 
                             user=ce.user, 
-                            # created_date=ce.created.replace(year=ce.created.year+5)
                         ).save()
                                 
         self.certificates = list(GeneratedCertificate.objects.all())
         # certificate issue dates at years 2005, 2015, 2025 (five years after each enrollment)
         #   likewise, these values need to be updated after GeneratedCertificates are saved to db
-        print len(self.enrollments), len(self.certificates)
-        print type(self.enrollments), type(self.enrollments[0])
-        print type(self.certificates), type(self.certificates[0])
         for enrollment, certificate in zip(self.enrollments, self.certificates):
-            #get matching CourseEnrollment object
             certificate.created_date = enrollment.created.replace(enrollment.created.year + 5)
             certificate.save()
 
         self.url = reverse('get_batch_enrollment_data')
 
     @ddt.unpack
-    @ddt.data(  {'course_str': 'course1', 'num_enrollments': 3},
-                {'course_str': 'course2', 'num_enrollments': 1},)
-    def test_analytics_enrollment_endpoint_with_only_course_id(self, course_str, num_enrollments):
+    @ddt.data(  {'course_varname': 'course1', 'num_enrollments': 3},
+                {'course_varname': 'course2', 'num_enrollments': 1},)
+    def test_analytics_enrollment_endpoint_with_only_course_id(self, course_varname, num_enrollments):
 
-        course = getattr(self, course_str)
+        course = getattr(self, course_varname)
         course_id = str(course.id)
 
         res = self.client.get(self.url + '?course_id={}'.format(course_id))
@@ -114,20 +83,18 @@ class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCa
         self.assertEqual(len(data), num_enrollments)
 
     @ddt.unpack
-    @ddt.data(  {'course_str': 'course1', 'query_string': 'updated_min=2030-01-01T00:00:00', 'num_enrollments': 0}, # outside range
-                {'course_str': 'course1', 'query_string': 'updated_min=2001-01-01T00:00:00', 'num_enrollments': 3}, # one cert, two enrollments
-                {'course_str': 'course1', 'query_string': 'updated_max=2011-01-01T00:00:00', 'num_enrollments': 2}, # two enrollments
-                {'course_str': 'course1', 'query_string': 'updated_min=2001-01-01T00:00:00&updated_max=2021-01-01T00:00:00', 'num_enrollments': 3},) # one cert, two enrollments
-    def test_analytics_enrollment_endpoint_with_query_strings(self, course_str, query_string, num_enrollments):
+    @ddt.data(  {'course_varname': 'course1', 'query_string': 'updated_min=2030-01-01T00:00:00', 'num_enrollments': 0}, # outside range
+                {'course_varname': 'course1', 'query_string': 'updated_min=2001-01-01T00:00:00', 'num_enrollments': 3}, # one cert, two enrollments
+                {'course_varname': 'course1', 'query_string': 'updated_max=2011-01-01T00:00:00', 'num_enrollments': 2}, # two enrollments
+                {'course_varname': 'course1', 'query_string': 'updated_min=2001-01-01T00:00:00&updated_max=2021-01-01T00:00:00', 'num_enrollments': 3},) # one cert, two enrollments
+    def test_analytics_enrollment_endpoint_with_query_strings(self, course_varname, query_string, num_enrollments):
 
-        course = getattr(self, course_str)
+        course = getattr(self, course_varname)
         course_id = str(course.id)
 
         res = self.client.get(self.url + '?course_id={}&{}'.format(course_id, query_string))
 
         if num_enrollments > 0:
-            print 'qs: ' + query_string
-            print res.content
             self.assertIn('enrollment', res.content)
         self.assertEqual(res.status_code, 200)
 

--- a/lms/djangoapps/appsembler_api/tests/test_views.py
+++ b/lms/djangoapps/appsembler_api/tests/test_views.py
@@ -19,6 +19,9 @@ from search.tests.test_course_discovery import DemoCourse
 from mock import patch
 from datetime import datetime
 from rest_framework.permissions import AllowAny
+from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
+# from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+
 
 from student.tests.factories import UserFactory, CourseEnrollmentFactory
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -26,108 +29,32 @@ from certificates.models import GeneratedCertificate
 
 from appsembler_api.views import GetBatchEnrollmentDataView
 
-# @override_settings(SEARCH_ENGINE="search.tests.mock_search_engine.MockSearchEngine")
-@patch.object(GetBatchEnrollmentDataView, 'permission_classes', [AllowAny])
+# @patch('appsembler_api.views.GetBatchEnrollmentDataView.permission_classes', [AllowAny])
+# @patch('appsembler_api.views.GetBatchEnrollmentDataView.authentication_classes', [])
+@patch('appsembler_api.views.GetBatchEnrollmentDataView.authentication_classes', [])
+@patch('appsembler_api.views.GetBatchEnrollmentDataView.permission_classes', [AllowAny])
 class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase):
     """
     Tests for the endpoint: /analytics/enrollment/batch
     """
 
-    # def setUp(self):
-    #     super(AnalyticsEnrollmentBatchViewTest, self).setUp()
-    #     DemoCourse.reset_count()
-    #     self.searcher.destroy()
-
-    #     self.courses = [
-    #         self.add_course("OrgA", "Find this one with the right parameter"),
-    #         self.add_course("OrgB", "Find this one with another parameter"),
-    #         self.add_course("OrgC", "Find this one somehow"),
-    #     ]
-
-    #     self.url = reverse('course-list')
-    #     self.staff_user = self.create_user(username='staff', is_staff=True)
-    #     self.honor_user = self.create_user(username='honor', is_staff=False)
-
-    # def add_course(self, org_code, short_description):
-    #     """
-    #     Add a course to both database and search.
-    #     Warning: A ton of gluing here! If this fails, double check both CourseListViewTestCase and MockSearchUrlTest.
-    #     """
-
-    #     search_course = DemoCourse.get({
-    #         "org": org_code,
-    #         "run": "2010",
-    #         "number": "DemoZ",
-    #         "id": "{org_code}/DemoZ/2010".format(org_code=org_code),
-    #         "content": {
-    #             "short_description": short_description,
-    #         },
-    #     })
-
-    #     DemoCourse.index(self.searcher, [search_course])
-
-    #     org, course, run = search_course['id'].split('/')
-
-    #     db_course = self.create_course(
-    #         org=org,
-    #         course=course,
-    #         run=run,
-    #         short_description=short_description,
-    #     )
-
-    #     return db_course
-
-    # def search_request(self, search_term=''):
-    #     res = self.client.get(reverse("course_list_search"), data={'search_term': search_term})
-    #     return res.status_code, json.loads(res.content)
-
-    # def test_search_api_alone(self):
-    #     """
-    #     Double check that search alone works fine.
-    #     """
-    #     res = self.client.post(reverse('course_discovery'))
-    #     data = json.loads(res.content)
-    #     self.assertNotEqual(data["results"], [])
-    #     self.assertNotIn('course-v1', unicode(self.courses[0].id))
-    #     self.assertContains(res, unicode(self.courses[0].id))
-    #     self.assertEqual(data["total"], 3)
-
-    # def test_course_api_alone(self):
-    #     """
-    #     Double check that search alone works fine.
-    #     """
-    #     self.setup_user(self.staff_user)
-    #     response = self.verify_response(expected_status_code=200, params={'username': self.staff_user.username})
-    #     data = json.loads(response.content)
-    #     self.assertNotEqual(data["results"], [])
-    #     self.assertEqual(data["pagination"]["count"], 3)
-    #     self.assertNotIn('course-v1', response.content)
-
-    # def test_list_all(self):
-    #     """ test searching using the url """
-    #     code, data = self.search_request()
-    #     self.assertEqual(200, code)
-    #     self.assertIn("results", data)
-    #     self.assertNotEqual(data["results"], [])
-    #     self.assertEqual(data["pagination"]["count"], 3)
-
-    # def test_list_all_with_search_term(self):
-    #     """ test searching using the url """
-    #     code, data = self.search_request(search_term='somehow')
-    #     self.assertEqual(200, code)
-    #     self.assertIn("results", data)
-    #     self.assertNotEqual(data["results"], [])
-    #     self.assertEqual(data["pagination"]["count"], 1)
-
-@patch.object(GetBatchEnrollmentDataView, 'permission_classes', [AllowAny])
-class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase):
-    """
-    Tests for the endpoint: /analytics/enrollment/batch
-    """
+    USERNAME = "Bob"
+    EMAIL = "bob@example.com"
+    PASSWORD = "edx"
 
     def setUp(self):
         super(AnalyticsEnrollmentBatchViewTest, self).setUp()
         
+        self.view = GetBatchEnrollmentDataView.as_view()
+
+        self.staff = UserFactory.create(
+            username=self.USERNAME,
+            email=self.EMAIL,
+            password=self.PASSWORD,
+            is_staff=True,
+        )
+        self.request_factory = APIRequestFactory()
+
         self.course1 = CourseFactory()
         self.course2 = CourseFactory()
 
@@ -153,7 +80,14 @@ class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCa
         self.url = reverse('get_batch_user_data')
 
     def test_analytics_enrollment_endpoint_alone(self):
-        res = self.client.get(self.url)
-        print res
-        self.assertEqual(res.status_code,4)
-        self.assertEquel(GeneratedCertificate.objects.count(),4)
+        request = self.request_factory.get(self.url, content_type='application/json')
+        force_authenticate(request, user=self.staff)
+        res = self.view(request)
+        res.render()
+
+        # res = self.client.get(self.url)
+        print res.content
+        self.assertEqual(res.status_code, 200)
+        # self.assertEqual(res.status_code,4)
+        # self.assertEqual(len(self.certificates),4)
+

--- a/lms/djangoapps/appsembler_api/tests/test_views.py
+++ b/lms/djangoapps/appsembler_api/tests/test_views.py
@@ -1,0 +1,159 @@
+"""
+Tests for the Appsembler API views.
+"""
+
+from urllib import quote, urlencode
+
+from django.core.urlresolvers import reverse
+
+from lms.djangoapps.course_api.tests.test_views import CourseApiTestViewMixin
+import json
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+from django.test.utils import override_settings
+
+from search.tests.test_course_discovery import DemoCourse
+
+
+### for this endpoint test
+from mock import patch
+from datetime import datetime
+from rest_framework.permissions import AllowAny
+
+from student.tests.factories import UserFactory, CourseEnrollmentFactory
+from xmodule.modulestore.tests.factories import CourseFactory
+from certificates.models import GeneratedCertificate
+
+from appsembler_api.views import GetBatchEnrollmentDataView
+
+# @override_settings(SEARCH_ENGINE="search.tests.mock_search_engine.MockSearchEngine")
+@patch.object(GetBatchEnrollmentDataView, 'permission_classes', [AllowAny])
+class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase):
+    """
+    Tests for the endpoint: /analytics/enrollment/batch
+    """
+
+    # def setUp(self):
+    #     super(AnalyticsEnrollmentBatchViewTest, self).setUp()
+    #     DemoCourse.reset_count()
+    #     self.searcher.destroy()
+
+    #     self.courses = [
+    #         self.add_course("OrgA", "Find this one with the right parameter"),
+    #         self.add_course("OrgB", "Find this one with another parameter"),
+    #         self.add_course("OrgC", "Find this one somehow"),
+    #     ]
+
+    #     self.url = reverse('course-list')
+    #     self.staff_user = self.create_user(username='staff', is_staff=True)
+    #     self.honor_user = self.create_user(username='honor', is_staff=False)
+
+    # def add_course(self, org_code, short_description):
+    #     """
+    #     Add a course to both database and search.
+    #     Warning: A ton of gluing here! If this fails, double check both CourseListViewTestCase and MockSearchUrlTest.
+    #     """
+
+    #     search_course = DemoCourse.get({
+    #         "org": org_code,
+    #         "run": "2010",
+    #         "number": "DemoZ",
+    #         "id": "{org_code}/DemoZ/2010".format(org_code=org_code),
+    #         "content": {
+    #             "short_description": short_description,
+    #         },
+    #     })
+
+    #     DemoCourse.index(self.searcher, [search_course])
+
+    #     org, course, run = search_course['id'].split('/')
+
+    #     db_course = self.create_course(
+    #         org=org,
+    #         course=course,
+    #         run=run,
+    #         short_description=short_description,
+    #     )
+
+    #     return db_course
+
+    # def search_request(self, search_term=''):
+    #     res = self.client.get(reverse("course_list_search"), data={'search_term': search_term})
+    #     return res.status_code, json.loads(res.content)
+
+    # def test_search_api_alone(self):
+    #     """
+    #     Double check that search alone works fine.
+    #     """
+    #     res = self.client.post(reverse('course_discovery'))
+    #     data = json.loads(res.content)
+    #     self.assertNotEqual(data["results"], [])
+    #     self.assertNotIn('course-v1', unicode(self.courses[0].id))
+    #     self.assertContains(res, unicode(self.courses[0].id))
+    #     self.assertEqual(data["total"], 3)
+
+    # def test_course_api_alone(self):
+    #     """
+    #     Double check that search alone works fine.
+    #     """
+    #     self.setup_user(self.staff_user)
+    #     response = self.verify_response(expected_status_code=200, params={'username': self.staff_user.username})
+    #     data = json.loads(response.content)
+    #     self.assertNotEqual(data["results"], [])
+    #     self.assertEqual(data["pagination"]["count"], 3)
+    #     self.assertNotIn('course-v1', response.content)
+
+    # def test_list_all(self):
+    #     """ test searching using the url """
+    #     code, data = self.search_request()
+    #     self.assertEqual(200, code)
+    #     self.assertIn("results", data)
+    #     self.assertNotEqual(data["results"], [])
+    #     self.assertEqual(data["pagination"]["count"], 3)
+
+    # def test_list_all_with_search_term(self):
+    #     """ test searching using the url """
+    #     code, data = self.search_request(search_term='somehow')
+    #     self.assertEqual(200, code)
+    #     self.assertIn("results", data)
+    #     self.assertNotEqual(data["results"], [])
+    #     self.assertEqual(data["pagination"]["count"], 1)
+
+@patch.object(GetBatchEnrollmentDataView, 'permission_classes', [AllowAny])
+class AnalyticsEnrollmentBatchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase):
+    """
+    Tests for the endpoint: /analytics/enrollment/batch
+    """
+
+    def setUp(self):
+        super(AnalyticsEnrollmentBatchViewTest, self).setUp()
+        
+        self.course1 = CourseFactory()
+        self.course2 = CourseFactory()
+
+        test_time = datetime(year=1999, month=1, day=1, minute=0, second=0)
+
+        #enrollment dates at years 2000, 2010, 2020
+        self.enrollments = [
+            CourseEnrollmentFactory(course_id=self.course1.id, created=test_time.replace(year=2000)),
+            CourseEnrollmentFactory(course_id=self.course1.id, created=test_time.replace(year=2010)),
+            CourseEnrollmentFactory(course_id=self.course1.id, created=test_time.replace(year=2020)),
+            CourseEnrollmentFactory(course_id=self.course2.id, created=test_time.replace(year=2020)),
+        ]
+
+        #certificate issue dates at years 2005, 2015, 2025
+        self.certificates = [ GeneratedCertificate(
+                                course_id=ce.course_id, 
+                                user=ce.user, 
+                                created_date=ce.created.replace(year=ce.created.year+5)
+                            ) 
+                                for ce in self.enrollments
+                        ]
+
+        self.url = reverse('get_batch_user_data')
+
+    def test_analytics_enrollment_endpoint_alone(self):
+        res = self.client.get(self.url)
+        print res
+        self.assertEqual(res.status_code,4)
+        self.assertEquel(GeneratedCertificate.objects.count(),4)

--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -625,12 +625,12 @@ class GetBatchEnrollmentDataView(APIView):
             cert_query_filter['user__username'] = username
 
         if updated_min:
-            min_date = parser.parse(updated_min)
+            min_date = parser.parse(updated_min + ' UTC')
             enrollment_query_filter['created__gt'] = min_date
             cert_query_filter['created_date__gt'] = min_date
 
         if updated_max:
-            max_date = parser.parse(updated_max)
+            max_date = parser.parse(updated_max + ' UTC')
             enrollment_query_filter['created__lt'] = max_date
             cert_query_filter['created_date__lt'] = max_date
 

--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -3,6 +3,7 @@ import logging
 import string
 import random
 import operator
+import pytz
 
 from dateutil import parser
 
@@ -625,12 +626,12 @@ class GetBatchEnrollmentDataView(APIView):
             cert_query_filter['user__username'] = username
 
         if updated_min:
-            min_date = parser.parse(updated_min + ' UTC')
+            min_date = parser.parse(updated_min).replace(tzinfo=pytz.UTC)
             enrollment_query_filter['created__gt'] = min_date
             cert_query_filter['created_date__gt'] = min_date
 
         if updated_max:
-            max_date = parser.parse(updated_max + ' UTC')
+            max_date = parser.parse(updated_max).replace(tzinfo=pytz.UTC)
             enrollment_query_filter['created__lt'] = max_date
             cert_query_filter['created_date__lt'] = max_date
 

--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -606,6 +606,7 @@ class GetBatchEnrollmentDataView(APIView):
         updated_min = request.GET.get('updated_min', '')
         updated_max = request.GET.get('updated_max', '')
         course_id = request.GET.get('course_id')
+        username = request.GET.get('username')
 
         enrollment_query_filter = {}
         cert_query_filter = {}
@@ -618,6 +619,10 @@ class GetBatchEnrollmentDataView(APIView):
             course_key = CourseKey.from_string(course_id)
             enrollment_query_filter['course_id'] = course_key
             cert_query_filter['course_id'] = course_key
+
+        if username:   
+            enrollment_query_filter['user__username'] = username
+            cert_query_filter['user__username'] = username
 
         if updated_min:
             min_date = parser.parse(updated_min)

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -71,6 +71,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     start_display = serializers.CharField()
     start_type = serializers.CharField()
     pacing = serializers.CharField()
+    modified = serializers.DateTimeField()
 
     # 'course_id' is a deprecated field, please use 'id' instead.
     course_id = serializers.CharField(source='id', read_only=True)


### PR DESCRIPTION
There are two API enhancements in this PR:

1. Add the "modified" field to the core `course_api` endpoint 
2. Include CourseEnrollment data for issued certificates in our `analytics/enrollment/batch` endpoint

Enhancement no.1 is straightforward and entirely contained here: https://github.com/appsembler/edx-platform/compare/appsembler/eucalyptus/develop...appsembler:appsembler/pennstate/eucalyptus/feature/batch-api-enhancements?expand=1#diff-f9734940d65817788caea70dc8086b14R74)

Enhancement no.2 was a bit more problematic. Here are the docs on that endpoint:

https://github.com/appsembler/edx-platform/blob/909f0a4fd32131bcc070bf3a769811be5487615e/lms/djangoapps/appsembler_api/apidocs.md#enrollments

Basically, with query parameters, it was possible to filter the CourseEnrollments on:

1. course_id
2. username
3. time parameters specifying a date range for the user's enrollment date

The customer wanted to extend the endpoint so that CourseEnrollments were also shown for a student that earned a certificate between the dates specified in the "time parameter" query parameter.

I couldn't find an easy way to maneuver from a CourseEnrollment object to a GerneratedCertificate object. Both classes define `user` and `course_id` as `unique_together`, but filtering through the ORM based on a tuple like that wasn't easy. 

The way I ended up solving this was to programmatically generate a large `Q` object that combines all `user`/`course_id` pairs. It's inelegant, but it works as expected. One major concern is that this large `Q` object could create a super inefficient SQL query if it's trying to pull too much data. 

I'm open to any suggestions here. But I'm a bit stumped as to whether or not there's a better approach to solving this. 