### PR TITLE
re-raise the exception on send_activation_email()

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -40,11 +40,11 @@ def send_activation_email(self, subject, message, from_address, dest_addr):
                 dest_addr,
                 exc_info=True
             )
-    except Exception:  # pylint: disable=bare-except
+    except Exception as e:
         log.exception(
             'Unable to send activation email to user from "%s" to "%s"',
             from_address,
             dest_addr,
             exc_info=True
         )
-        raise Exception
+        raise e


### PR DESCRIPTION
This sentry error:

https://sentry.io/appsembler/amc/issues/525166614/

shows 'Exception' as the problem. Not super informative.

That's because the code is just doing `raise Exception` and raising a generic exception.

I think the actual exception should be captured and re-raised so we can get useful error messages in Sentry.

If it was done that way on purpose (I don't know... maybe there's a concern about sensitive info being in the exception?), we should at least generate a new, slighly more informative exception with whatever other info we can. It would be really helpful to at least not mask the type of the underlying exception.