### PR TITLE
Whitelist course_num and course_name URL parameters

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -200,7 +200,7 @@ def auth_pipeline_urls(auth_entry, redirect_url=None):
 
 # Query string parameters that can be passed to the "finish_auth" view to manage
 # things like auto-enrollment.
-POST_AUTH_PARAMS = ('course_id', 'enrollment_action', 'course_mode', 'email_opt_in', 'purchase_workflow')
+POST_AUTH_PARAMS = ('course_id', 'enrollment_action', 'course_mode', 'email_opt_in', 'purchase_workflow', 'course_num', 'course_name')
 
 
 def get_next_url_for_login_page(request):


### PR DESCRIPTION
# What this is
- This is a companion PR to https://github.com/gymnasium/edx-theme/pull/96 (specifically for [this bit](https://github.com/gymnasium/edx-theme/pull/96/files#diff-ea6a0e99803ebc6bfb6911d899e9b17dR54))
- It adds the necessary support for edx-platform to pass along 2 URL parameters that are needed to support logging course enrollments in Intercom for Gymnasium