### PR TITLE
add rough performance log/profiling to LMS dashboard view

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import uuid
 import json
+import time
 import warnings
 from collections import defaultdict
 from urlparse import urljoin, urlsplit, parse_qs, urlunsplit
@@ -587,6 +588,15 @@ def dashboard(request):
         The dashboard response.
 
     """
+    perflog = {
+        'start': time.time(),
+        # human readable timestamp is purely for convenience when looking through the logs
+        'timestamp': datetime.datetime.now(UTC),
+        # timestamps for each checkpoint execution passes
+        'checkpoints': [],
+        # keep track of which branches were executed
+        'branches': {},
+    }
     user = request.user
 
     platform_name = configuration_helpers.get_value("platform_name", settings.PLATFORM_NAME)
@@ -609,12 +619,20 @@ def dashboard(request):
 
     # remove our current org from the "filter out" list, if applicable
     if course_org_filter:
+        perflog['branches']['course_org_filter'] = True
         org_filter_out_set.remove(course_org_filter)
 
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'finished config'})
     # Build our (course, enrollment) list for the user, but ignore any courses that no
     # longer exist (because the course IDs have changed). Still, we don't delete those
     # enrollments, because it could have been a data push snafu.
     course_enrollments = list(get_course_enrollments(user, course_org_filter, org_filter_out_set))
+
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'got course enrollments'})
 
     # sort the enrollment pairs by the enrollment date
     course_enrollments.sort(key=lambda x: x.created, reverse=True)
@@ -630,16 +648,27 @@ def dashboard(request):
         for course_id, modes in unexpired_course_modes.iteritems()
     }
 
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'retrieved course modes for each course'})
+
     # Check to see if the student has recently enrolled in a course.
     # If so, display a notification message confirming the enrollment.
     enrollment_message = _create_recent_enrollment_message(
         course_enrollments, course_modes_by_course
     )
 
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'created enrollment message'})
     course_optouts = Optout.objects.filter(user=user).values_list('course_id', flat=True)
 
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'got course_optouts'})
     message = ""
     if not user.is_active:
+        perflog['branches']['user_not_active'] = True
         message = render_to_string(
             'registration/activate_account_notice.html',
             {'email': user.email, 'platform_name': platform_name}
@@ -649,6 +678,7 @@ def dashboard(request):
     staff_access = False
     errored_courses = {}
     if has_access(user, 'staff', 'global'):
+        perflog['branches']['has_global_staff_access'] = True
         # Show any courses that errored on load
         staff_access = True
         errored_courses = modulestore().get_errored_courses()
@@ -659,11 +689,21 @@ def dashboard(request):
         and has_access(request.user, 'view_courseware_with_prerequisites', enrollment.course_overview)
     )
 
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'global staff view'})
+
     # Find programs associated with courses being displayed. This information
     # is passed in the template context to allow rendering of program-related
     # information on the dashboard.
     meter = programs_utils.ProgramProgressMeter(user, enrollments=course_enrollments)
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'program_utils.ProgramProgressMeter'})
     programs_by_run = meter.engaged_programs(by_run=True)
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'meter.engaged_programs'})
 
     # Construct a dictionary of course mode information
     # used to render the course list.  We re-use the course modes dict
@@ -675,6 +715,9 @@ def dashboard(request):
         )
         for enrollment in course_enrollments
     }
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'course_mode_info constructed'})
 
     # Determine the per-course verification status
     # This is a dictionary in which the keys are course locators
@@ -691,10 +734,17 @@ def dashboard(request):
     # If a course is not included in this dictionary,
     # there is no verification messaging to display.
     verify_status_by_course = check_verify_status_by_course(user, course_enrollments)
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'check_verify_status_by_course'})
+
     cert_statuses = {
         enrollment.course_id: cert_info(request.user, enrollment.course_overview, enrollment.mode)
         for enrollment in course_enrollments
     }
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'cert_statuses'})
 
     # only show email settings for Mongo course and when bulk email is turned on
     show_email_settings_for = frozenset(
@@ -702,19 +752,31 @@ def dashboard(request):
             BulkEmailFlag.feature_enabled(enrollment.course_id)
         )
     )
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'show_email_settings_for'})
 
     # Verification Attempts
     # Used to generate the "you must reverify for course x" banner
     verification_status, verification_msg = SoftwareSecurePhotoVerification.user_status(user)
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'SoftwareSecurePhotoVerification.user_status'})
 
     # Gets data for midcourse reverifications, if any are necessary or have failed
     statuses = ["approved", "denied", "pending", "must_reverify"]
     reverifications = reverification_info(statuses)
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'reverification_info'})
 
     show_refund_option_for = frozenset(
         enrollment.course_id for enrollment in course_enrollments
         if enrollment.refundable()
     )
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'show_refund_options_for'})
 
     block_courses = frozenset(
         enrollment.course_id for enrollment in course_enrollments
@@ -727,11 +789,17 @@ def dashboard(request):
             enrollment.course_id
         )
     )
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'block_courses'})
 
     enrolled_courses_either_paid = frozenset(
         enrollment.course_id for enrollment in course_enrollments
         if enrollment.is_paid_course()
     )
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'enrolled_courses_either_paid'})
 
     # If there are *any* denied reverifications that have not been toggled off,
     # we'll display the banner
@@ -739,6 +807,9 @@ def dashboard(request):
 
     # Populate the Order History for the side-bar.
     order_history_list = order_history(user, course_org_filter=course_org_filter, org_filter_out_set=org_filter_out_set)
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'order_history'})
 
     # get list of courses having pre-requisites yet to be completed
     courses_having_prerequisites = frozenset(
@@ -746,16 +817,22 @@ def dashboard(request):
         if enrollment.course_overview.pre_requisite_courses
     )
     courses_requirements_not_met = get_pre_requisite_courses_not_completed(user, courses_having_prerequisites)
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'get_pre_requisite_courses_not_completed'})
 
     if 'notlive' in request.GET:
+        perflog['branches']['notlive'] = True
         redirect_message = _("The course you are looking for does not start until {date}.").format(
             date=request.GET['notlive']
         )
     elif 'course_closed' in request.GET:
+        perflog['branches']['courses_closed'] = True
         redirect_message = _("The course you are looking for is closed for enrollment as of {date}.").format(
             date=request.GET['course_closed']
         )
     else:
+        perflog['branches']['no_message'] = True
         redirect_message = ''
 
     context = {
@@ -795,13 +872,24 @@ def dashboard(request):
 
     ecommerce_service = EcommerceService()
     if ecommerce_service.is_enabled(request.user):
+        perflog['branches']['ecommerse_service.is_enabled'] = True
         context.update({
             'use_ecommerce_payment_flow': True,
             'ecommerce_payment_page': ecommerce_service.payment_page_url(),
         })
 
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'created context'})
     response = render_to_response('dashboard.html', context)
     set_user_info_cookie(response, request)
+    perflog['checkpoints'].append({
+        'time': time.time(),
+        'name': 'generated response'})
+    # slightly redundant, but simplifies analysis later
+    perflog['end'] = time.time()
+    perflog['total_duration'] = perflog['end'] - perflog['start']
+    log.info("PERFLOG %s" % json.dumps(perflog))
     return response
 
 


### PR DESCRIPTION
Trying at a very high level to figure out where dashboard is spending all its time on the mysterious slow requests.

This uses the existing logging mechanism and just generates some rough perf data for each request to `/dashboard` so we can narrow it down.

This commit should be reverted once we have identified the culprit (and probably replaced with something more surgical if we need to narrow it down further).

How this works:

* all the data for a single request gets bundled up into a single dict, which is then serialized as a JSON object at the end and written out as the body of a `log.info()` message.
* the most important part is the list of checkpoints, each of which are just a timestamp (unix time) and a label that I can use to tie it back to the code later. From those, I should be able to reconstruct a given request and see where all the time went.
* there's also a `branches` dict in there to keep track of which branches of code were included. For the most part, it seems that the code in `dashboard()` is pretty straightforward and the branches shouldn't impact execution time too much, but you never know.
* using `log.info()` is a bit ugly since it just dumps everything into a log entry. But it shouldn't be too hard for me to just grep out any `PERFLOG` entries from the logs, parse in the JSON from the rest of the line, and do some analysis from there. Meanwhile, it saves having to configure another log file somewhere else, make sure that threading is handled correctly, set up rotation, etc.

The basic plan once this is deployed:

* let it run for a day or two to gather data
* grab a copy of the log files from the servers
* grep for `PERFLOG` and parse the entries out from there
* probably filter out anything with a `total_duration` less than 1s (we are only interested in the slow requests)
* generate some reports on which checkpoints are the farthest apart on those slow requests
* if that narrows it down to a single (or few) parts, put similar instrumentation in the code that's being called there to narrow it down further.
* rinse and repeat until we've identified why `/dashboard` gets slow sometimes and fixed it.