### PR TITLE
use same cache for custom domain redirect

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.cache import cache
+from django.core.cache import cache, caches
 from django.contrib.redirects.models import Redirect
 from django.shortcuts import redirect
 
@@ -12,18 +12,18 @@ log = logging.getLogger(__name__)
 class CustomDomainsRedirectMiddleware(object):
 
     def process_request(self, request):
-
+        cache_general = caches['general']
         hostname = request.get_host()
         if hostname.endswith(settings.SITE_NAME):
             cache_key = '{prefix}-{site}'.format(prefix=settings.CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX, site=hostname)
-            custom_domain = cache.get(cache_key)
+            custom_domain = cache_general.get(cache_key)
             if custom_domain is None:
                 try:
                     alternative_domain = AlternativeDomain.objects.select_related('site').get(domain=hostname)
                     custom_domain = alternative_domain.site.domain
                 except AlternativeDomain.DoesNotExist:
                     custom_domain = ""
-                cache.set(cache_key, custom_domain, settings.CUSTOM_DOMAINS_REDIRECT_CACHE_TIMEOUT)
+                cache_general.set(cache_key, custom_domain, settings.CUSTOM_DOMAINS_REDIRECT_CACHE_TIMEOUT)
 
             if custom_domain:
                 return redirect("https://" + custom_domain)


### PR DESCRIPTION
This is a follow up of https://github.com/appsembler/edx-platform/pull/236

The bug is: In openedx/core/djangoapps/appsembler/sites/models.py we are calling the general cache at the top of the file, and in the middleware we were just calling the default cache.

The fix just calls the general cache in the scope of the function.