### PR TITLE
avoid fetching large json fields on site_configuration filtering

### DIFF
--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -103,7 +103,7 @@ class SiteConfiguration(models.Model):
         Returns:
             Configuration value for the given key.
         """
-        for configuration in cls.objects.filter(values__contains=org, enabled=True).all():
+        for configuration in cls.objects.filter(values__contains=org, enabled=True).defer('page_elements', 'sass_variables').all():
             org_filter = configuration.get_value('course_org_filter', None)
             if org_filter == org:
                 return configuration.get_value(name, default)
@@ -120,7 +120,7 @@ class SiteConfiguration(models.Model):
         """
         org_filter_set = set()
 
-        for configuration in cls.objects.filter(values__contains='course_org_filter', enabled=True).all():
+        for configuration in cls.objects.filter(values__contains='course_org_filter', enabled=True).defer('page_elements', 'sass_variables').all():
             org_filter = configuration.get_value('course_org_filter', None)
             if org_filter:
                 org_filter_set.add(org_filter)


### PR DESCRIPTION
On Tahoe we have ~800 SiteConfiguration objects. The `sass_variables` and `page_elements` fields are very large and cause the queries here to take almost 2 seconds, plus another two seconds of JSON decoding every time they are called. This adds up to 4-5 seconds of latency on the LMS dashboard and 8-10 seconds of latency on the CMS settings page. The extra work that the application and database are doing when that happens probably also account for other views running slow at times as well.

This should fix a good chunk of the performance problems we are seeing on Tahoe.

I've written quite a bit about the investigation that lead here in these posts:

* https://appsembler-infrastructure.appspot.com/post/anders-2018-07-11-13-13-26-utc/
* https://appsembler-infrastructure.appspot.com/post/anders-2018-07-17-10-23-09-utc/

The key part of the solution is at the end of the second one.

What I'd like from a review, if possible, is some input on whether this will have any dangerous unintended side-effects. Ie, looking at the code, it does not appear that `page_elements` or `sass_variables` are ever used (it fetches the objects, gets an element from `values` for each and then discards everything else). As long as there isn't some crazy monkey patching going on, this performance improvement looks pretty harmless.

Once it's tested in Tahoe, it's probably a good candidate for getting upstream.