### PR TITLE
backport the chemical equations patch to ficus

### DIFF
--- a/common/lib/chem/chem/chemcalc.py
+++ b/common/lib/chem/chem/chemcalc.py
@@ -32,6 +32,8 @@ tokenizer = OneOrMore(tokens) + StringEnd()
 # other applications.
 # See LEARNER-5853 for more details.
 Text = markupsafe.escape                        # pylint: disable=invalid-name
+
+
 def HTML(html):                                 # pylint: disable=invalid-name
     return markupsafe.Markup(html)
 

--- a/common/lib/chem/chem/chemcalc.py
+++ b/common/lib/chem/chem/chemcalc.py
@@ -2,6 +2,7 @@ from __future__ import division
 from fractions import Fraction
 
 from pyparsing import (Literal, StringEnd, OneOrMore, ParseException)
+import markupsafe
 import nltk
 from nltk.tree import Tree
 
@@ -24,6 +25,15 @@ symbols = list("[](){}^+-/")
 phases = ["(s)", "(l)", "(g)", "(aq)"]
 tokens = reduce(lambda a, b: a ^ b, map(Literal, elements + digits + symbols + phases))
 tokenizer = OneOrMore(tokens) + StringEnd()
+
+
+# HTML, Text are temporarily copied from openedx.core.djangolib.markup
+# These libraries need to be moved out of edx-platform to be used by
+# other applications.
+# See LEARNER-5853 for more details.
+Text = markupsafe.escape                        # pylint: disable=invalid-name
+def HTML(html):                                 # pylint: disable=invalid-name
+    return markupsafe.Markup(html)
 
 
 def _orjoin(l):
@@ -161,20 +171,20 @@ def _render_to_html(tree):
             return tree[0][0]
         # If a fraction, return the fraction
         if len(tree) == 3:
-            return " <sup>{num}</sup>&frasl;<sub>{den}</sub> ".format(num=tree[0][0], den=tree[2][0])
+            return HTML(" <sup>{num}</sup>&frasl;<sub>{den}</sub> ").format(num=tree[0][0], den=tree[2][0])
         return "Error"
 
     def subscript(tree, children):
-        return "<sub>{sub}</sub>".format(sub=children)
+        return HTML("<sub>{sub}</sub>").format(sub=children)
 
     def superscript(tree, children):
-        return "<sup>{sup}</sup>".format(sup=children)
+        return HTML("<sup>{sup}</sup>").format(sup=children)
 
     def round_brackets(tree, children):
-        return "({insider})".format(insider=children)
+        return HTML("({insider})").format(insider=children)
 
     def square_brackets(tree, children):
-        return "[{insider}]".format(insider=children)
+        return HTML("[{insider}]").format(insider=children)
 
     dispatch = {'count': molecule_count,
                 'number_suffix': subscript,
@@ -185,7 +195,7 @@ def _render_to_html(tree):
     if isinstance(tree, str):
         return tree
     else:
-        children = "".join(map(_render_to_html, tree))
+        children = HTML("").join(map(_render_to_html, tree))
         if tree.node in dispatch:
             return dispatch[tree.node](tree, children)
         else:
@@ -200,18 +210,18 @@ def render_to_html(eq):
     '''
     def err(s):
         "Render as an error span"
-        return '<span class="inline-error inline">{0}</span>'.format(s)
+        return HTML('<span class="inline-error inline">{0}</span>').format(s)
 
     def render_arrow(arrow):
         """Turn text arrows into pretty ones"""
         if arrow == '->':
-            return u'\u2192'
+            return HTML(u'\u2192')
         if arrow == '<->':
-            return u'\u2194'
+            return HTML(u'\u2194')
 
         # this won't be reached unless we add more arrow types, but keep it to avoid explosions when
-        # that happens.
-        return arrow
+        # that happens. HTML-escape this unknown arrow just in case.
+        return HTML(arrow)
 
     def render_expression(ex):
         """
@@ -223,7 +233,7 @@ def render_to_html(eq):
             return err(ex)
 
     def spanify(s):
-        return u'<span class="math">{0}</span>'.format(s)
+        return HTML(u'<span class="math">{0}</span>').format(s)
 
     left, arrow, right = split_on_arrow(eq)
     if arrow == '':

--- a/common/lib/chem/chem/tests.py
+++ b/common/lib/chem/chem/tests.py
@@ -301,10 +301,17 @@ class Test_Render_Equations(unittest.TestCase):
         log(out + ' ------- ' + correct, 'html')
         self.assertEqual(out, correct)
 
-    def test_render_simple_brackets(self):
+    def test_render_simple_round_brackets(self):
         test_string = "(Ar)"
         out = render_to_html(test_string)
         correct = u'<span class="math">(Ar)</span>'
+        log(out + ' ------- ' + correct, 'html')
+        self.assertEqual(out, correct)
+
+    def test_render_simple_square_brackets(self):
+        test_string = "[Ar]"
+        out = render_to_html(test_string)
+        correct = u'<span class="math">[Ar]</span>'
         log(out + ' ------- ' + correct, 'html')
         self.assertEqual(out, correct)
 
@@ -325,7 +332,24 @@ class Test_Render_Equations(unittest.TestCase):
     def test_render_eq3(self):
         test_string = "H^+ + OH^- <= H2O"   # unsupported arrow
         out = render_to_html(test_string)
-        correct = u'<span class="math"><span class="inline-error inline">H^+ + OH^- <= H2O</span></span>'
+        correct = u'<span class="math"><span class="inline-error inline">H^+ + OH^- &lt;= H2O</span></span>'
+        log(out + ' ------- ' + correct, 'html')
+        self.assertEqual(out, correct)
+
+    def test_render_eq4(self):
+        test_string = "[H^+] + OH^- <-> (H2O)"  # with brackets
+        out = render_to_html(test_string)
+        correct = u'<span class="math">[H<sup>+</sup>]+OH<sup>-</sup>\u2194(H<sub>2</sub>O)</span>'
+        log(out + ' ------- ' + correct, 'html')
+        self.assertEqual(out, correct)
+
+    def test_escaping(self):
+        """
+        Tests that invalid input is escaped.
+        """
+        test_string = "<script>f()</script>"
+        out = render_to_html(test_string)
+        correct = u'<span class="math"><span class="inline-error inline">&lt;script&gt;f()&lt;/script&gt;</span></span>'
         log(out + ' ------- ' + correct, 'html')
         self.assertEqual(out, correct)
 

--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -9,5 +9,6 @@ setup(
         "numpy==1.6.2",
         "scipy==0.14.0",
         "nltk==2.0.6",
+        "markupsafe",
     ],
 )

--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -767,6 +767,7 @@ class GetBatchEnrollmentDataView(APIView):
 
         return Response(enrollment_list, status=200)
 
+
 class GetBatchCompletionDataView(ListAPIView):
     authentication_classes = OAuth2AuthenticationAllowInactiveUser,
     permission_classes = IsStaffOrOwner,
@@ -793,7 +794,6 @@ class GetBatchCompletionDataView(ListAPIView):
             max_date = parser.parse(updated_max).replace(tzinfo=pytz.UTC)
             query_filter['created_date__lt'] = max_date
 
-
         certificates = GeneratedCertificate.objects.filter(**query_filter)
 
         certificate_list = []
@@ -803,13 +803,13 @@ class GetBatchCompletionDataView(ListAPIView):
                 course_name = course.display_name
             except Http404:
                 course_name = str(certificate.course_id)
-                
+
             certificate_list.append({
                 'email': certificate.user.email,
                 'course_name': course_name,
                 'course_id': str(certificate.course_id),
                 'grade': certificate.grade,
-                'completion_date':  str(certificate.created_date),
+                'completion_date': str(certificate.created_date),
             })
 
         return Response(certificate_list)


### PR DESCRIPTION
I don't know if it definitely affects us, but it seems worth a little effort to get this patch onto our ficus instances as well.

The original patch also bumps the version in `common/lib/chem/setup.py` to `0.2.0-ginkgo`. I left that out here. Not sure if it is needed.