### PR TITLE
Fix encoding of values for certificate email subject and body

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -297,27 +297,28 @@ def _update_social_context(request, context, course, user, user_certificate, pla
     # support emailing links to certificates
     #
     context['email_share_enabled'] = share_settings.get('CERTIFICATE_EMAIL_SHARE', False)
-    context['email_share_subj'] = urllib.quote(
+    email_share_subj = unicode(
         share_settings.get(
             'CERTIFICATE_EMAIL_SUBJECT',
             _("Course certificate from {platform_name}: {name} for course {coursename}")
         ).format(platform_name=platform_name, name=user.profile.name, coursename=course.display_name)
     )
+    context['email_share_subj'] = urllib.quote(email_share_subj.encode('utf-8'))
 
     # specific to ExtraCare
     context['email_share_warn'] = False  # in case not ready to share via email (no StudyLocation set)
     try:
 
         studylocation = StudentStudyLocation.location_for_student(user).studylocation
-        context['email_share_body'] = urllib.quote(
+        email_share_body = unicode(
             share_settings.get(
                 'CERTIFICATE_EMAIL_BODY',
                 _("Dear {location},\n\nThe student {student_name} {student_email} has completed the following course in {platform_name} .\n\n{coursename}.\n\nPlease use the link below to print off a copy of their certificate for their training file. You can also use this link to create an electronic copy.\n{link}\n\nThank you in advance.")
-            ).format(
+            )).format(
                 platform_name=platform_name, link=share_url,
                 location=studylocation.location, coursename=course.display_name,
                 student_name=user.profile.name, student_email=user.email)
-        )
+        context['email_share_body'] = urllib.quote(email_share_body.encode('utf-8'))
 
         # specific to ExtraCare
         context['email_share_to'] = studylocation.contact_email


### PR DESCRIPTION
(was failing on non-ASCII characters)

Ensure configured values for CERTIFICATE_EMAIL_SUBJECT and CERTIFICATE_EMAIL_BODY are interpreted as unicode, and explicitly encode to UTF8 before trying to url-quote for emailing.