### PR TITLE
fix perms instructor certificates

### DIFF
--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -21,7 +21,7 @@ from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 from config_models.models import cache
-from courseware.tests.factories import GlobalStaffFactory, InstructorFactory, UserFactory
+from courseware.tests.factories import StaffFactory, GlobalStaffFactory, InstructorFactory, UserFactory
 from certificates.tests.factories import GeneratedCertificateFactory, CertificateWhitelistFactory, \
     CertificateInvalidationFactory
 from certificates.models import CertificateGenerationConfiguration, CertificateStatuses, CertificateWhitelist, \
@@ -53,6 +53,8 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
         super(CertificatesInstructorDashTest, self).setUp()
         self.global_staff = GlobalStaffFactory()
         self.instructor = InstructorFactory(course_key=self.course.id)
+        self.staff = StaffFactory(course_key=self.course.id)
+        self.user = UserFactory()
 
         # Need to clear the cache for model-based configuration
         cache.clear()
@@ -60,13 +62,17 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
         # Enable the certificate generation feature
         CertificateGenerationConfiguration.objects.create(enabled=True)
 
-    def test_visible_only_to_global_staff(self):
-        # Instructors don't see the certificates section
-        self.client.login(username=self.instructor.username, password="test")
+    def test_visible_only_to_course_staff(self):
+        # Regular users don't see the certificates section
+        self.client.login(username=self.user.username, password="test")
         self._assert_certificates_visible(False)
 
-        # Global staff can see the certificates section
-        self.client.login(username=self.global_staff.username, password="test")
+        # Course Instructors can see the certificates section
+        self.client.login(username=self.instructor.username, password="test")
+        self._assert_certificates_visible(True)
+
+        # Course staff can see the certificates section
+        self.client.login(username=self.staff.username, password="test")
         self._assert_certificates_visible(True)
 
     def test_visible_only_when_feature_flag_enabled(self):
@@ -220,6 +226,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         super(CertificatesInstructorApiTest, self).setUp()
         self.global_staff = GlobalStaffFactory()
         self.instructor = InstructorFactory(course_key=self.course.id)
+        self.staff = StaffFactory(course_key=self.course.id)
         self.user = UserFactory()
         CourseEnrollment.enroll(self.user, self.course.id)
 
@@ -228,16 +235,21 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         CertificateGenerationConfiguration.objects.create(enabled=True)
 
     @ddt.data('generate_example_certificates', 'enable_certificate_generation')
-    def test_allow_only_global_staff(self, url_name):
+    def test_allow_course_staff(self, url_name):
         url = reverse(url_name, kwargs={'course_id': self.course.id})
 
-        # Instructors do not have access
-        self.client.login(username=self.instructor.username, password='test')
+        # Regular users do not have access
+        self.client.login(username=self.user.username, password='test')
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
 
-        # Global staff have access
-        self.client.login(username=self.global_staff.username, password='test')
+        # Instructors have access
+        self.client.login(username=self.instructor.username, password='test')
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+
+        # Course staff have access
+        self.client.login(username=self.staff.username, password='test')
         response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
 
@@ -287,7 +299,7 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
     def test_certificate_generation_api_without_global_staff(self):
         """
         Test certificates generation api endpoint returns permission denied if
-        user who made the request is not member of global staff.
+        user who made the request is not member of the course staff.
         """
         user = UserFactory.create()
         self.client.login(username=user.username, password='test')
@@ -295,13 +307,11 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
             'start_certificate_generation',
             kwargs={'course_id': unicode(self.course.id)}
         )
-
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
-
         self.client.login(username=self.instructor.username, password='test')
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
 
     def test_certificate_generation_api_with_global_staff(self):
         """
@@ -776,6 +786,7 @@ class GenerateCertificatesInstructorApiTest(SharedModuleStoreTestCase):
         super(GenerateCertificatesInstructorApiTest, self).setUp()
         self.global_staff = GlobalStaffFactory()
         self.instructor = InstructorFactory(course_key=self.course.id)
+        self.staff = StaffFactory(course_key=self.course.id)
         self.user = UserFactory()
         CourseEnrollment.enroll(self.user, self.course.id)
         certificate_exception = CertificateWhitelistFactory.create(

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2766,7 +2766,7 @@ def _instructor_dash_url(course_key, section=None):
     return url
 
 
-@require_global_staff
+@require_level('staff')
 @require_POST
 def generate_example_certificates(request, course_id=None):  # pylint: disable=unused-argument
     """Start generating a set of example certificates.
@@ -2783,7 +2783,7 @@ def generate_example_certificates(request, course_id=None):  # pylint: disable=u
     return redirect(_instructor_dash_url(course_key, section='certificates'))
 
 
-@require_global_staff
+@require_level('staff')
 @require_POST
 def enable_certificate_generation(request, course_id=None):
     """Enable/disable self-generated certificates for a course.
@@ -2828,7 +2828,7 @@ def mark_student_can_skip_entrance_exam(request, course_id):  # pylint: disable=
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_global_staff
+@require_level('staff')
 @require_POST
 def start_certificate_generation(request, course_id):
     """
@@ -2848,7 +2848,7 @@ def start_certificate_generation(request, course_id):
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_global_staff
+@require_level('staff')
 @require_POST
 def start_certificate_regeneration(request, course_id):
     """
@@ -2892,7 +2892,7 @@ def start_certificate_regeneration(request, course_id):
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_global_staff
+@require_level('staff')
 @require_http_methods(['POST', 'DELETE'])
 def certificate_exception_view(request, course_id):
     """
@@ -3065,7 +3065,7 @@ def get_student(username_or_email, course_key):
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_global_staff
+@require_level('staff')
 @require_POST
 def generate_certificate_exceptions(request, course_id, generate_for=None):
     """
@@ -3107,7 +3107,7 @@ def generate_certificate_exceptions(request, course_id, generate_for=None):
 
 
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_global_staff
+@require_level('staff')
 @require_POST
 def generate_bulk_certificate_exceptions(request, course_id):  # pylint: disable=invalid-name
     """
@@ -3202,7 +3202,7 @@ def generate_bulk_certificate_exceptions(request, course_id):  # pylint: disable
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_global_staff
+@require_level('staff')
 @require_http_methods(['POST', 'DELETE'])
 def certificate_invalidation_view(request, course_id):
     """

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -111,7 +111,6 @@ def instructor_dashboard_2(request, course_id):
         'staff': bool(has_access(request.user, 'staff', course)),
         'forum_admin': has_forum_access(request.user, course_key, FORUM_ROLE_ADMINISTRATOR),
     }
-
     if not access['staff']:
         raise Http404()
 
@@ -187,7 +186,7 @@ def instructor_dashboard_2(request, course_id):
     # and enable self-generated certificates for a course.
     # Note: This is hidden for all CCXs
     certs_enabled = CertificateGenerationConfiguration.current().enabled and not hasattr(course_key, 'ccx')
-    if certs_enabled and access['admin']:
+    if certs_enabled and (access['admin'] or access['staff']):
         sections.append(_section_certificates(course))
 
     disable_buttons = not _is_small_course(course_key)


### PR DESCRIPTION
The Certificates tab in the Instructor dashboard (and all the action) require global staff permissions, which doesn't makes sense with the rest of the Instructor dashboard architecture. The permissions check is always if the user is staff in the course, not global.

This bug came up in Tahoe since none of our users have global staff, but it's affecting other customers as well, also this is something we should push upstream.