### PR TITLE
Bug fix for accredible API - grades as integers

### DIFF
--- a/lms/djangoapps/accredible_certificate/queue.py
+++ b/lms/djangoapps/accredible_certificate/queue.py
@@ -164,7 +164,6 @@ class CertificateGeneration(object):
                 # the embargoed country restricted list
                 # otherwise, put a new certificate request
                 # on the queue
-                logger.info('grade is {}'.format(grade_contents))
                 print grade_contents
                 if self.restricted.filter(user=student).exists():
                     new_status = status.restricted
@@ -180,7 +179,6 @@ class CertificateGeneration(object):
                         'grade': grade_contents
                     }
 
-                    logger.info('the contents are {}'.format(contents))
                     if defined_status == "generating":
                         approve = False
                     else:

--- a/lms/djangoapps/accredible_certificate/queue.py
+++ b/lms/djangoapps/accredible_certificate/queue.py
@@ -97,10 +97,10 @@ class CertificateGeneration(object):
         """
 
         VALID_STATUSES = [status.generating,
-                          status.unavailable,
-                          status.deleted,
-                          status.error,
-                          status.notpassing]
+                            status.unavailable,
+                            status.deleted,
+                            status.error,
+                            status.notpassing]
 
         cert_status = certificate_status_for_student(student, course_id)['status']
 
@@ -127,13 +127,13 @@ class CertificateGeneration(object):
                 loc = loc = course.location.replace(category='about', name=section_key)
                 try:
                     if modulestore().get_item(loc).data:
-                       description = modulestore().get_item(loc).data
-                       break
+                        description = modulestore().get_item(loc).data
+                        break
                 except:
                     print "this course don't have " +section_key
-              
+
             if not description:
-               description = "course_description"
+                description = "course_description"
 
 
             is_whitelisted = self.whitelist.filter(user=student, course_id=course_id, whitelist=True).exists()
@@ -154,13 +154,9 @@ class CertificateGeneration(object):
             cert.grade = grade['percent']
             cert.course_id = course_id
             cert.name = profile_name
+
             # Strip HTML from grade range label
-            grade_contents = grade.get('grade', None)
-            try:
-                grade_contents = lxml.html.fromstring(grade_contents).text_content()
-            except (TypeError, XMLSyntaxError, ParserError) as e:
-                #   Despite blowing up the xml parser, bad values here are fine
-                grade_contents = None
+            grade_contents = int(grade['percent'] * 100) # convert percent to points as an integer
 
             if is_whitelisted or grade_contents is not None:
 
@@ -168,13 +164,13 @@ class CertificateGeneration(object):
                 # the embargoed country restricted list
                 # otherwise, put a new certificate request
                 # on the queue
+                logger.info('grade is {}'.format(grade_contents))
                 print grade_contents
                 if self.restricted.filter(user=student).exists():
                     new_status = status.restricted
                     cert.status = new_status
                     cert.save()
                 else:
-                  
                     contents = {
                         'action': 'create',
                         'username': student.username,
@@ -183,10 +179,12 @@ class CertificateGeneration(object):
                         'name': profile_name,
                         'grade': grade_contents
                     }
+
+                    logger.info('the contents are {}'.format(contents))
                     if defined_status == "generating":
-                      approve = False
+                        approve = False
                     else:
-                      approve = True
+                        approve = True
 
                     # check to see if this is a BETA course
                     course_name = course_name.strip()
@@ -204,25 +202,27 @@ class CertificateGeneration(object):
                                     "course_link": "/courses/" +contents['course_id'] + "/about",
                                     "approve": approve,
                                     "template_name": contents['course_id'],
-                                    "grade": grade_contents,
+                                    "grade": contents['grade'],
                                     "recipient": {
-                                      "name": contents['name'],
-                                      "email": student.email
+                                        "name": contents['name'],
+                                        "email": student.email
                                     }
                                 }
                             }
+
                     payload = json.dumps(payload)
+
                     r = requests.post('https://api.accredible.com/v1/credentials', payload, headers={'Authorization':'Token token=' + self.api_key, 'Content-Type':'application/json'})
                     
                     if r.status_code == 200:
-                       json_response = r.json()  
-                       cert.status = defined_status
-                       cert.key = json_response["credential"]["id"]
-                       if 'private' in json_response:
-                          cert.download_url = "https://wwww.accredible.com/" + str(json_response["credential"]["id"]) + "?key" + str(json_response["private_key"])
-                       else:
-                          cert.download_url = "https://www.accredible.com/" + str(cert.key)
-                       cert.save()
+                        json_response = r.json()  
+                        cert.status = defined_status
+                        cert.key = json_response["credential"]["id"]
+                        if 'private' in json_response:
+                            cert.download_url = "https://wwww.accredible.com/" + str(json_response["credential"]["id"]) + "?key" + str(json_response["private_key"])
+                        else:
+                            cert.download_url = "https://www.accredible.com/" + str(cert.key)
+                        cert.save()
                     else:
                         new_status = "errors"
                     


### PR DESCRIPTION
Working on this with @tkeemon based on issues we saw arise in the past few days.

# What this PR includes:
- general python formatting fixes: indentation is now multiples of 4 spaces across this file
- Grade is now passed in as an integer from 0-100, rather than a string of `Pass` or `Fail` from before, from some lovely undocumented changes on Accredible's side