### PR TITLE
Always use configured COURSE_MODE_DEFAULTS from env tokens in devstack and aws envs

### DIFF
--- a/cms/envs/aws_appsembler.py
+++ b/cms/envs/aws_appsembler.py
@@ -91,3 +91,6 @@ MEDIA_ROOT = '/edx/var/edxapp/media'
 MEDIA_URL = '/media/'
 
 HTTPS = 'on' if ENV_TOKENS.get('BASE_SCHEME', 'https').lower() == 'https' else 'off'
+
+# use configured course mode defaults as for aws, not standard devstack's
+COURSE_MODE_DEFAULTS.update(ENV_TOKENS.get('COURSE_MODE_DEFAULTS', COURSE_MODE_DEFAULTS))

--- a/cms/envs/devstack_appsembler.py
+++ b/cms/envs/devstack_appsembler.py
@@ -77,3 +77,6 @@ elif 'appsembler_usage' in DATABASES:
 
 # to allow to run python-saml with custom port
 SP_SAML_RESTRICT_MODE = False
+
+# use configured course mode defaults as for aws, not standard devstack's
+COURSE_MODE_DEFAULTS.update(ENV_TOKENS.get('COURSE_MODE_DEFAULTS', COURSE_MODE_DEFAULTS))

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -124,3 +124,6 @@ FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS['FEATURES'].get('ENABLE_COURSE_
 # edx-figures additions
 if FEATURES.get('ENABLE_EDX_FIGURES'):
     from edx_figures.settings import EDX_FIGURES
+
+# use configured course mode defaults as for aws, not standard devstack's
+COURSE_MODE_DEFAULTS.update(ENV_TOKENS.get('COURSE_MODE_DEFAULTS', COURSE_MODE_DEFAULTS))


### PR DESCRIPTION
(will default to 'honor' in our edx-configs base settings)

`aws.py` settings already honor as set via ENV_TOKENS, but `devstack.py` settings do not.  They always set the mode to 'audit', making it difficult to test custom certificates setup.  

We keep price, sku, some other default devstack course mode values.

This isn't something to upstream, as the community will probably want to keep their devstack settings as is.  