### PR TITLE
Fixed the issue wth  missing Taxoman filters in the LMS course discovery sidebar

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -548,10 +548,11 @@ class AboutInfo(object):
             raise ValueError("Context dictionary does not contain expected argument 'course'")
         course_facet_value = CourseFacetValue.objects.filter(
             course_id=course.id,
-            facet_value__facet__slug=self.property_name).values_list('facet_value__id', 'facet_value__value')
+            facet_value__facet__slug=self.property_name,
+        ).values_list('facet_value__id', 'facet_value__value')
         # IMPORTANT: If you change the pattern here, make sure you also change
         # the regex in refine_sidebar.js 'termName' function
-        return ['{} ::{}'.format(v[1], v[0]) for v in course_facet_value]
+        return ['{value} ::{pk}'.format(value=value, pk=pk) for pk, value in course_facet_value]
 
     # Source location options - either from the course or the about info
     FROM_ABOUT_INFO = from_about_dictionary

--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -546,8 +546,12 @@ class AboutInfo(object):
         course = kwargs.get('course', None)
         if not course:
             raise ValueError("Context dictionary does not contain expected argument 'course'")
-        course_facet_value = CourseFacetValue.objects.filter(course_id=course.id, facet_value__facet__slug=self.property_name).values_list('facet_value__value', flat=True)
-        return list(course_facet_value)
+        course_facet_value = CourseFacetValue.objects.filter(
+            course_id=course.id,
+            facet_value__facet__slug=self.property_name).values_list('facet_value__id', 'facet_value__value')
+        # IMPORTANT: If you change the pattern here, make sure you also change
+        # the regex in refine_sidebar.js 'termName' function
+        return ['{} ::{}'.format(v[1], v[0]) for v in course_facet_value]
 
     # Source location options - either from the course or the about info
     FROM_ABOUT_INFO = from_about_dictionary

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -16,7 +16,8 @@ SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING = True
 COURSE_CATALOG_VISIBILITY_PERMISSION = 'see_in_catalog'
 COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_about_page'
 
-COURSE_DISCOVERY_FILTERS = ["org", "language", "modes"]
+# Removed the default filters, "org", "language", "modes" per customer request
+COURSE_DISCOVERY_FILTERS = []
 
 CMS_SEARCH_API_URL = ENV_TOKENS.get("CMS_SEARCH_API_URL", None)
 CMS_SEARCH_API_URL_SSL = ENV_TOKENS.get("CMS_SEARCH_API_URL_SSL", None)

--- a/lms/static/js/discovery/views/refine_sidebar.js
+++ b/lms/static/js/discovery/views/refine_sidebar.js
@@ -35,7 +35,7 @@ define([
 
             // We are appending a double colon followed by a number (the facet
             // value database row id) and her we trim the trailing key if present
-            return term_name.replace(/::\d+\s*$/,'');
+            return term_name.replace(/ ::\d+\s*$/, '');
         },
 
         renderOptions: function (options) {

--- a/lms/static/js/discovery/views/refine_sidebar.js
+++ b/lms/static/js/discovery/views/refine_sidebar.js
@@ -29,9 +29,13 @@ define([
         },
 
         termName: function (facetKey, termKey) {
-            return this.meanings[facetKey] &&
+            var term_name = this.meanings[facetKey] &&
                 this.meanings[facetKey].terms  &&
                 this.meanings[facetKey].terms[termKey] || termKey;
+
+            // We are appending a double colon followed by a number (the facet
+            // value database row id) and her we trim the trailing key if present
+            return term_name.replace(/::\d+\s*$/,'');
         },
 
         renderOptions: function (options) {


### PR DESCRIPTION
Facet values (terms) are required to be globally unique. This patch
fixes this by doing two things:

First, we add the facet value's model id to the facet name. This
compound value is then pushed to elastic search and retrieved by the
front end.

Second, we remove the trailing identifier from the facet name when
showing in the sidebar

