### PR TITLE
Update XBlock Utils to `1.1.1` for better i18n support in XBlock

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -85,7 +85,7 @@ git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd3
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/pmitros/DoneXBlock.git@release-2016-08-10#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.10#egg=edx-milestones==0.1.10
-git+https://github.com/edx/xblock-utils.git@v1.0.3#egg=xblock-utils==1.0.3
+git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/edx-reverification-block.git@0.0.5#egg=edx-reverification-block==0.0.5
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1


### PR DESCRIPTION
This is mainly intended for Tahoe, but adding it here since I don't have access to a Tahoe Vagrant machine at the moment. It should then be cherry-picked into the Tahoe branch.

# TODO:
 - [x] Open the same PR for Tahoe: #271
 - [x] Open the same PR for Ginkgo: https://github.com/appsembler/edx-platform/pull/270