### PR TITLE
check for user_lookup key in request data

### DIFF
--- a/lms/djangoapps/appsembler_api/views.py
+++ b/lms/djangoapps/appsembler_api/views.py
@@ -282,7 +282,7 @@ class UpdateUserAccount(APIView):
         """
         data = request.data
 
-        if data['user_lookup'].strip() == "":
+        if data.get('user_lookup', '').strip() == "":
             errors = {"lookup_error": "No user lookup has been provided"}
             return Response(errors, status=400)
 


### PR DESCRIPTION
Looking into this sentry error, which is triggering hundreds of events per day:

https://sentry.io/appsembler/pennstate/issues/541515901/

It appears that the client isn't sending the `user_lookup` key in the request. This doesn't fix that, but it does make the backend respond properly with a 400 in that case instead of raising a `MultiValueDictKeyError` and spamming sentry.

I'm not positive, but I think this exception may be what's pushing us over our Sentry rate limit (it seems to be our most frequent exception). So it would be good to get this fixed.


### TODO
 - [ ] Open the same branch for Ginkgo
 - [ ] Open the same branch for AMC? maybe not