### PR TITLE
Updated LMS envs for Figures

### DIFF
--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -131,5 +131,5 @@ except ImportError:
     pass
 
 # edx-figures additions
-if FEATURES.get('ENABLE_EDX_FIGURES'):
-    from edx_figures.settings import EDX_FIGURES
+if FEATURES.get('ENABLE_FIGURES'):
+    from figures.settings import FIGURES

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -129,3 +129,8 @@ if FEATURES.get('ENABLE_FIGURES'):
 
 # use configured course mode defaults as for aws, not standard devstack's
 COURSE_MODE_DEFAULTS.update(ENV_TOKENS.get('COURSE_MODE_DEFAULTS', COURSE_MODE_DEFAULTS))
+
+# To help working with DRF based endpoints easier in development mode
+REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] += (
+    'rest_framework.renderers.BrowsableAPIRenderer',
+)

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -124,8 +124,8 @@ except ImportError:
 FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS['FEATURES'].get('ENABLE_COURSE_DISCOVERY', FEATURES['ENABLE_COURSE_DISCOVERY'])
 
 # edx-figures additions
-if FEATURES.get('ENABLE_EDX_FIGURES'):
-    from edx_figures.settings import EDX_FIGURES
+if FEATURES.get('ENABLE_FIGURES'):
+    from figures.settings import FIGURES
 
 # use configured course mode defaults as for aws, not standard devstack's
 COURSE_MODE_DEFAULTS.update(ENV_TOKENS.get('COURSE_MODE_DEFAULTS', COURSE_MODE_DEFAULTS))

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -129,8 +129,3 @@ if FEATURES.get('ENABLE_FIGURES'):
 
 # use configured course mode defaults as for aws, not standard devstack's
 COURSE_MODE_DEFAULTS.update(ENV_TOKENS.get('COURSE_MODE_DEFAULTS', COURSE_MODE_DEFAULTS))
-
-# To help working with DRF based endpoints easier in development mode
-REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] += (
-    'rest_framework.renderers.BrowsableAPIRenderer',
-)


### PR DESCRIPTION

* Remove 'edx' from the Figures envs includes for LMS
* Enabled browsable API for DRF in devstack (but not production yet)