### PR TITLE
Updated how Figures is included in the LMS appsembler settings

### DIFF
--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -130,6 +130,7 @@ try:
 except ImportError:
     pass
 
-# edx-figures additions
-if FEATURES.get('ENABLE_FIGURES'):
-    from figures.settings import FIGURES
+# Enable Figures if it is included
+if 'figures' in INSTALLED_APPS:
+    import figures.settings
+

--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -133,4 +133,3 @@ except ImportError:
 # Enable Figures if it is included
 if 'figures' in INSTALLED_APPS:
     import figures.settings
-

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -123,9 +123,9 @@ except ImportError:
 # override devstack.py automatic enabling of courseware discovery
 FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS['FEATURES'].get('ENABLE_COURSE_DISCOVERY', FEATURES['ENABLE_COURSE_DISCOVERY'])
 
-# edx-figures additions
-if FEATURES.get('ENABLE_FIGURES'):
-    from figures.settings import FIGURES
+# Enable Figures if it is included
+if 'figures' in INSTALLED_APPS:
+    import figures.settings
 
 # use configured course mode defaults as for aws, not standard devstack's
 COURSE_MODE_DEFAULTS.update(ENV_TOKENS.get('COURSE_MODE_DEFAULTS', COURSE_MODE_DEFAULTS))


### PR DESCRIPTION
We're removing the `FEATURES` entry to check to include Figures. Instead we're checking if Figures is in the `INSTALLED_APPS`. Simpler. Thanks @OmarIthawi !

We import `figures.settings` so that when the LMS starts up, Figures can inject new entries into `django.conf.settings.WEBPACK_LOADER` and `django.conf.settings.CELERYBEAT_SCHEDULE`

This is to minimize the customization needed in edx-platform.

If we didn't do this, then we'd need to explicitly run the code in `figures.settings` in `aws_appsembler.py` and `devstack_appsembler.py` 