### PR TITLE
Updated the interface on how Figures updates settings from the LMS

### DIFF
--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -130,6 +130,10 @@ try:
 except ImportError:
     pass
 
-# edx-figures additions
-if FEATURES.get('ENABLE_FIGURES'):
-    from figures.settings import FIGURES
+# Enable Figures if it is included
+if 'figures' in INSTALLED_APPS:
+    import figures
+    figures.update_settings(
+        WEBPACK_LOADER,
+        CELERYBEAT_SCHEDULE,
+        ENV_TOKENS.get('FIGURES', {}))

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -123,9 +123,13 @@ except ImportError:
 # override devstack.py automatic enabling of courseware discovery
 FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS['FEATURES'].get('ENABLE_COURSE_DISCOVERY', FEATURES['ENABLE_COURSE_DISCOVERY'])
 
-# edx-figures additions
-if FEATURES.get('ENABLE_FIGURES'):
-    from figures.settings import FIGURES
+# Enable Figures if it is included
+if 'figures' in INSTALLED_APPS:
+    import figures
+    figures.update_settings(
+        WEBPACK_LOADER,
+        CELERYBEAT_SCHEDULE,
+        ENV_TOKENS.get('FIGURES', {}))
 
 # use configured course mode defaults as for aws, not standard devstack's
 COURSE_MODE_DEFAULTS.update(ENV_TOKENS.get('COURSE_MODE_DEFAULTS', COURSE_MODE_DEFAULTS))


### PR DESCRIPTION
This is another option for updating LMS settings needed by Figures and minimizing the configuration needed in the LMS and let Figures tune its settings w/ WEBPACK_LOADER and CELERYBEAT_SCHEDULE with minimizing additional modifications to the LMS settings (and installation/setup documentation)

Please also see the Figures PR matching this PR: https://github.com/appsembler/figures/pull/48
