### PR TITLE
Added Figures support to the LMS envs settings

### DIFF
--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -142,9 +142,20 @@ try:
 except ImportError:
     pass
 
+# Webpack loader needed by Figures and Taxoman
+if 'webpack_loader' not in INSTALLED_APPS:
+    INSTALLED_APPS += ('webpack_loader',)
 
 if TAXOMAN_ENABLED:
     WEBPACK_LOADER['TAXOMAN_APP'] = {
         'BUNDLE_DIR_NAME': taxoman.settings.bundle_dir_name,
         'STATS_FILE': taxoman.settings.stats_file,
     }
+
+# Enable Figures if it is included
+if 'figures' in INSTALLED_APPS:
+    import figures
+    figures.update_settings(
+        WEBPACK_LOADER,
+        CELERYBEAT_SCHEDULE,
+        ENV_TOKENS.get('FIGURES', {}))

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -139,8 +139,20 @@ except ImportError:
 # override devstack.py automatic enabling of courseware discovery
 FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS['FEATURES'].get('ENABLE_COURSE_DISCOVERY', FEATURES['ENABLE_COURSE_DISCOVERY'])
 
+# Webpack loader needed by Figures and Taxoman
+if 'webpack_loader' not in INSTALLED_APPS:
+    INSTALLED_APPS += ('webpack_loader',)
+
 if TAXOMAN_ENABLED:
     WEBPACK_LOADER['TAXOMAN_APP'] = {
         'BUNDLE_DIR_NAME': taxoman.settings.bundle_dir_name,
         'STATS_FILE': taxoman.settings.stats_file,
     }
+
+# Enable Figures if it is included
+if 'figures' in INSTALLED_APPS:
+    import figures
+    figures.update_settings(
+        WEBPACK_LOADER,
+        CELERYBEAT_SCHEDULE,
+        ENV_TOKENS.get('FIGURES', {}))

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -4,3 +4,6 @@ raven==5.21.0
 
 # for usage aggregation to Google Cloud SQL
 psycopg2==2.7.1
+
+# For Figures
+django-webpack-loader==0.4.1


### PR DESCRIPTION
* Added the simple settings check and include to load figures settings
in aws_appsembler.py and devstack_appsembler.py
* Added webpack_loader to Appsembler requirements and INSTALLED_APPS

This is basically the same as for Ginkgo (https://github.com/appsembler/edx-platform/pull/278/files) with the addition of creating the WEBPACK_LOADER settings dict IFF it doesn't already exist and adding webpack_loader to the requirements files
