### PR TITLE
Change default cert status for open-ended courses to 'unavailable'

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -345,7 +345,8 @@ def _cert_info(user, course_overview, cert_status, course_mode):  # pylint: disa
         CertificateStatuses.unverified: 'unverified',
     }
 
-    default_status = 'processing'
+    # open-ended courses should not display the 'processing' message
+    default_status = 'unavailable' if not course_overview.end else 'processing' 
 
     default_info = {
         'status': default_status,


### PR DESCRIPTION
Echoing @bryanlandia explanation here below, also take a look at the referenced card please.

> Open edX still doesn't really deal with open-ended courses (no end date) very well and this is one of those cases. In Open edX default cert status for a student who has just begun a course is 'processing'. This means that if you choose to display certificate/grade info on the dashboard before the course end (which you have to do if you ever want to show it for an open-ended course) then you will get this non-sensical 'final course details ...' message.

> On the enterprise side we have a small change that fixes this.

> https://github.com/appsembler/edx-platform/blob/appsembler/ginkgo/master/common/djangoapps/student/views.py#L344-L346

> sets default cert status to 'unavailable' if the course has no end date. We submitted a PR for this but it went nowhere so for now we're stuck with a difference here in our fork. Also, the code will have to move in Hawthorn from common/djangoapps/student/views.py to common/djangoapps/student/helpers.py.