### PR TITLE
Adds throttling (rate limiting) to the Tahoe API

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/permissions.py
+++ b/openedx/core/djangoapps/appsembler/api/permissions.py
@@ -47,11 +47,8 @@ class IsSiteAdminUser(BasePermission):
         return is_site_admin_user(request)
 
 
-#
-# Throttling
-#
-
-
 class TahoeAPIUserThrottle(UserRateThrottle):
-    """Limit the number of requests users can make to the enrollment API."""
+    """
+    Limit the rate of requests users can make to the Tahoe API
+    """
     rate = '60/minute'

--- a/openedx/core/djangoapps/appsembler/api/permissions.py
+++ b/openedx/core/djangoapps/appsembler/api/permissions.py
@@ -3,9 +3,10 @@
 Code adapted from Figures
 
 """
-from rest_framework.permissions import BasePermission
-
 import django.contrib.sites.shortcuts
+
+from rest_framework.permissions import BasePermission
+from rest_framework.throttling import UserRateThrottle
 
 from organizations.models import (
     Organization,
@@ -44,3 +45,13 @@ class IsSiteAdminUser(BasePermission):
     """
     def has_permission(self, request, view):
         return is_site_admin_user(request)
+
+
+#
+# Throttling
+#
+
+
+class TahoeAPIUserThrottle(UserRateThrottle):
+    """Limit the number of requests users can make to the enrollment API."""
+    rate = '60/minute'

--- a/openedx/core/djangoapps/appsembler/api/tests/test_permissions.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_permissions.py
@@ -49,7 +49,8 @@ def get_api_classes():
 
 @ddt.ddt
 class AppsemblerAPIPermissionsTests(TestCase):
-    """See the comments in the ``get_api_classes`` function above
+    """
+    See the comments in the ``get_api_classes`` function above
     """
     def test_api_classes_are_being_found(self):
         self.assertTrue(get_api_classes())  # Ensure the API classes are filtered correctly

--- a/openedx/core/djangoapps/appsembler/api/tests/test_permissions.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_permissions.py
@@ -30,6 +30,11 @@ SITE_CONFIGURATION_CLASS = ('openedx.core.djangoapps.site_configuration'
 
 
 def get_api_classes():
+    """
+    This method retrieves all classes from the views module. This means only
+    view classes should be in the views module OR the API permissions tests
+    need to be refactored
+    """
     api_classes = []
 
     for member_name in dir(api_views):
@@ -44,7 +49,8 @@ def get_api_classes():
 
 @ddt.ddt
 class AppsemblerAPIPermissionsTests(TestCase):
-
+    """See the comments in the ``get_api_classes`` function above
+    """
     def test_api_classes_are_being_found(self):
         self.assertTrue(get_api_classes())  # Ensure the API classes are filtered correctly
 

--- a/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
@@ -18,6 +18,7 @@ APPSEMBLER_API_VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.api.v1.views'
 @ddt.ddt
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.authentication_classes', [])
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.permission_classes', [AllowAny])
+@patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.throttle_classes', [])
 @override_settings(APPSEMBLER_FEATURES={
     'SKIP_LOGIN_AFTER_REGISTRATION': False,
 })

--- a/openedx/core/djangoapps/appsembler/api/tests/test_throttling.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_throttling.py
@@ -1,0 +1,70 @@
+"""Tests throttling (rate limiting) for the Tahoe API
+
+"""
+
+from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
+
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.test import APITestCase
+
+import ddt
+from mock import patch
+
+from ..v1.views import TahoeAPIUserThrottle
+
+APPSEMBLER_API_VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.api.v1.views'
+
+
+def make_post_data(val):
+    """
+    val is some unique idetifier, typically an integer
+    """
+    return dict(
+        name='Joe Bob-{}'.format(val),
+        username='joebob{}'.format(val),
+        email='joebob-{}@example.com'.format(val)
+    )
+
+
+@ddt.ddt
+@patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.authentication_classes', [])
+@patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.permission_classes', [AllowAny])
+@override_settings(APPSEMBLER_FEATURES={
+    'SKIP_LOGIN_AFTER_REGISTRATION': False,
+})
+@override_settings(CACHES={
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+    'general': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    },
+    'mongo_metadata_inheritance': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    },
+    'loc_cache': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    },
+    'course_structure_cache': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    },
+})
+class TahoeApiThrotteTest(APITestCase):
+    def setUp(self):
+        self.url = reverse('tahoe-api:v1:registrations-list')
+        self.rate_limit, self.rate_limit_unit = TahoeAPIUserThrottle.rate.split('/')
+        self.rate_limit = int(self.rate_limit)
+        assert self.rate_limit_unit == 'minute'
+
+    def test_throttle_with_registration_api(self):
+
+        for attempt in xrange(self.rate_limit):
+            post_data = make_post_data(attempt)
+            response = self.client.post(self.url, post_data)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        post_data = make_post_data(self.rate_limit)
+        response = self.client.post(self.url, post_data)
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)

--- a/openedx/core/djangoapps/appsembler/api/tests/test_throttling.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_throttling.py
@@ -1,5 +1,5 @@
-"""Tests throttling (rate limiting) for the Tahoe API
-
+"""
+Tests throttling (rate limiting) for the Tahoe API
 """
 
 from django.core.urlresolvers import reverse

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -78,7 +78,11 @@ class TahoeAuthMixin(object):
 
 
 class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
+    """
+    Allows remote clients to register new users via API
 
+    This API has a rate limit of 60 requets per minutes
+    """
     throttle_classes = (TahoeAPIUserThrottle,)
     http_method_names = ['post', 'head']
 

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -1,5 +1,7 @@
 """Tahoe version 1 API views
 
+Only include view classes here. See the tests/test_permissions.py:get_api_classes()
+method.
 """
 
 import logging
@@ -19,7 +21,7 @@ from openedx.core.djangoapps.user_api.accounts.api import check_account_exists
 from student.forms import PasswordResetFormNoActive
 from student.views import create_account_with_params
 
-from ..permissions import IsSiteAdminUser
+from ..permissions import IsSiteAdminUser, TahoeAPIUserThrottle
 
 
 log = logging.getLogger(__name__)
@@ -77,6 +79,7 @@ class TahoeAuthMixin(object):
 
 class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
 
+    throttle_classes = (TahoeAPIUserThrottle,)
     http_method_names = ['post', 'head']
 
     def create(self, request):


### PR DESCRIPTION
- User based throttling added to the user registration api
- Throttling is assigned per ViewSet
- Throttle class is `TahoeAPIUserThrottle`
- Rate is 60/minute