### PR TITLE
avoid segment sending duplicate event

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1187,7 +1187,8 @@ class CourseEnrollment(models.Model):
             with tracker.get_tracker().context(event_name, context):
                 tracker.emit(event_name, data)
 
-                if hasattr(settings, 'LMS_SEGMENT_KEY') and settings.LMS_SEGMENT_KEY:
+                # Appsembler: Disabled to avoid receiving the event duplicated, with incomplete information the second time
+                if False and hasattr(settings, 'LMS_SEGMENT_KEY') and settings.LMS_SEGMENT_KEY:
                     tracking_context = tracker.get_tracker().resolve_context()
                     analytics.track(self.user_id, event_name, {
                         'category': 'conversion',


### PR DESCRIPTION
The Student app, in the enrollments section is sending the enrollment status change event two times to segment. 

Looks like this specific code for segment was added before the tracker backend was routed to segment. Now all the events routed on tracker backends are sent to segment, so there is no need of the specific segment code.