### PR TITLE
Tahoe Hawthorn support for production environments

### DIFF
--- a/openedx/core/djangoapps/appsembler/html_certificates/apps.py
+++ b/openedx/core/djangoapps/appsembler/html_certificates/apps.py
@@ -7,4 +7,4 @@ class HtmlCertificatesAppConfig(AppConfig):
     label = 'html_certificates'
 
     def ready(self):
-        from . import signals  # pylint: disable=unused-variable
+        from openedx.core.djangoapps.appsembler.html_certificates import signals  # pylint: disable=unused-variable

--- a/openedx/core/djangoapps/appsembler/msft_lp/__init__.py
+++ b/openedx/core/djangoapps/appsembler/msft_lp/__init__.py
@@ -1,1 +1,0 @@
-#from . import monkeypatch

--- a/openedx/core/djangoapps/appsembler/msft_lp/monkeypatch.py
+++ b/openedx/core/djangoapps/appsembler/msft_lp/monkeypatch.py
@@ -1,8 +1,9 @@
 from xmodule import course_module
 
-from . import mixins
+from openedx.core.djangoapps.appsembler.msft_lp import mixins
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 

--- a/openedx/core/djangoapps/appsembler/settings/apps.py
+++ b/openedx/core/djangoapps/appsembler/settings/apps.py
@@ -17,9 +17,13 @@ class SettingsConfig(AppConfig):
     plugin_app = {
         PluginSettings.CONFIG: {
             ProjectType.LMS: {
+                SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: u'settings.common'},
+                SettingsType.AWS: {PluginSettings.RELATIVE_PATH: u'settings.aws_lms'},
                 SettingsType.DEVSTACK: {PluginSettings.RELATIVE_PATH: u'settings.devstack_lms'},
             },
             ProjectType.CMS: {
+                SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: u'settings.common'},
+                SettingsType.AWS: {PluginSettings.RELATIVE_PATH: u'settings.aws_cms'},
                 SettingsType.DEVSTACK: {PluginSettings.RELATIVE_PATH: u'settings.devstack_cms'},
             }
         }

--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_cms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_cms.py
@@ -1,0 +1,41 @@
+"""
+Settings for Appsembler on CMS in Production (aka AWS).
+"""
+
+from openedx.core.djangoapps.appsembler.settings.settings import aws_common
+
+
+def plugin_settings(settings):
+    """
+    Appsembler CMS overrides for both production AND devstack.
+
+    Make sure those are compatible for devstack via defensive coding.
+
+    This file, however, won't run in test environments.
+    """
+    aws_common.plugin_settings(settings)
+
+    settings.APPSEMBLER_SECRET_KEY = settings.AUTH_TOKENS.get("APPSEMBLER_SECRET_KEY")
+
+    settings.INTERCOM_APP_ID = settings.AUTH_TOKENS.get("INTERCOM_APP_ID")
+    settings.INTERCOM_APP_SECRET = settings.AUTH_TOKENS.get("INTERCOM_APP_SECRET")
+
+    settings.FEATURES['ENABLE_COURSEWARE_INDEX'] = True
+    settings.FEATURES['ENABLE_LIBRARY_INDEX'] = True
+
+    settings.ELASTIC_FIELD_MAPPINGS = {
+        "start_date": {
+            "type": "date"
+        }
+    }
+
+    if settings.SENTRY_DSN:
+        settings.RAVEN_CONFIG['tags']['app'] = 'cms'
+
+    settings.MIDDLEWARE_CLASSES += (
+        'organizations.middleware.OrganizationMiddleware',
+    )
+
+    settings.SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+
+    settings.XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5

--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_common.py
@@ -1,0 +1,72 @@
+"""
+Settings for Appsembler on production (aka AWS), both LMS and CMS.
+"""
+
+import dj_database_url
+from django.utils.translation import ugettext_lazy as _
+
+
+def plugin_settings(settings):
+    """
+    Appsembler overrides for both production AND devstack.
+
+    Make sure those are compatible for devstack via defensive coding.
+
+    This file, however, won't run in test environments.
+    """
+    settings.APPSEMBLER_FEATURES = settings.ENV_TOKENS.get('APPSEMBLER_FEATURES', settings.APPSEMBLER_FEATURES)
+    settings.APPSEMBLER_AMC_API_BASE = settings.AUTH_TOKENS.get('APPSEMBLER_AMC_API_BASE')
+    settings.APPSEMBLER_FIRST_LOGIN_API = '/logged_into_edx'
+
+    settings.AMC_APP_URL = settings.ENV_TOKENS.get('AMC_APP_URL')
+
+    settings.DEFAULT_COURSE_MODE_SLUG = settings.ENV_TOKENS.get('EDXAPP_DEFAULT_COURSE_MODE_SLUG', 'audit')
+    settings.DEFAULT_MODE_NAME_FROM_SLUG = _(settings.DEFAULT_COURSE_MODE_SLUG.capitalize())
+
+    settings.SEARCH_ENGINE = "search.elastic.ElasticSearchEngine"
+
+    settings.INTERCOM_APP_ID = settings.AUTH_TOKENS.get("INTERCOM_APP_ID")
+    settings.INTERCOM_APP_SECRET = settings.AUTH_TOKENS.get("INTERCOM_APP_SECRET")
+
+    settings.GOOGLE_ANALYTICS_APP_ID = settings.AUTH_TOKENS.get('GOOGLE_ANALYTICS_APP_ID')
+    settings.HUBSPOT_API_KEY = settings.AUTH_TOKENS.get('HUBSPOT_API_KEY')
+    settings.HUBSPOT_PORTAL_ID = settings.AUTH_TOKENS.get('HUBSPOT_PORTAL_ID')
+    settings.MIXPANEL_APP_ID = settings.AUTH_TOKENS.get('MIXPANEL_APP_ID')
+
+    settings.MANDRILL_API_KEY = settings.AUTH_TOKENS.get("MANDRILL_API_KEY")
+    if settings.MANDRILL_API_KEY:
+        settings.EMAIL_BACKEND = settings.ENV_TOKENS.get('EMAIL_BACKEND', 'anymail.backends.mandrill.MandrillBackend')
+        settings.ANYMAIL = {
+            "MANDRILL_API_KEY": settings.MANDRILL_API_KEY,
+        }
+        settings.INSTALLED_APPS += ("anymail",)
+
+    # Sentry
+    settings.SENTRY_DSN = settings.AUTH_TOKENS.get('SENTRY_DSN', False)
+    if settings.SENTRY_DSN:
+        # Set your DSN value
+        settings.RAVEN_CONFIG = {
+            'environment': settings.FEATURES['ENVIRONMENT'],  # This should be moved somewhere more sensible
+            'tags': {
+                'app': 'edxapp',
+            },
+            'dsn': settings.SENTRY_DSN,
+        }
+
+        settings.INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
+
+    if settings.FEATURES.get('ENABLE_TIERS_APP', False):
+        settings.TIERS_ORGANIZATION_MODEL = 'organizations.Organization'
+        settings.TIERS_EXPIRED_REDIRECT_URL = settings.ENV_TOKENS.get('TIERS_EXPIRED_REDIRECT_URL', None)
+        settings.TIERS_ORGANIZATION_TIER_GETTER_NAME = 'get_tier_for_org'
+
+        settings.TIERS_DATABASE_URL = settings.AUTH_TOKENS.get('TIERS_DATABASE_URL')
+        settings.DATABASES['tiers'] = dj_database_url.parse(settings.TIERS_DATABASE_URL)
+        settings.DATABASE_ROUTERS += ['openedx.core.djangoapps.appsembler.sites.routers.TiersDbRouter']
+
+        settings.MIDDLEWARE_CLASSES += (
+            'tiers.middleware.TierMiddleware',
+        )
+        settings.INSTALLED_APPS += (
+            'tiers',
+        )

--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
@@ -1,0 +1,71 @@
+"""
+Settings for Appsembler on LMS in Production (aka AWS).
+"""
+
+from openedx.core.djangoapps.appsembler.settings.settings import aws_common
+
+
+def plugin_settings(settings):
+    """
+    Appsembler LMS overrides for both production AND devstack.
+
+    Make sure those are compatible for devstack via defensive coding.
+
+    This file, however, won't run in test environments.
+    """
+    aws_common.plugin_settings(settings)
+
+    settings.LMS_BASE = settings.ENV_TOKENS.get('LMS_BASE')
+
+    settings.INSTALLED_APPS += (
+        'openedx.core.djangoapps.appsembler.tpa_admin',
+    )
+
+    settings.CORS_ORIGIN_ALLOW_ALL = True
+
+    settings.CORS_ALLOW_HEADERS = (
+        'x-requested-with',
+        'content-type',
+        'accept',
+        'origin',
+        'authorization',
+        'x-csrftoken',
+        'cache-control'
+    )
+
+    settings.SEARCH_INITIALIZER = "lms.lib.courseware_search.lms_search_initializer.LmsSearchInitializer"
+    settings.SEARCH_RESULT_PROCESSOR = "lms.lib.courseware_search.lms_result_processor.LmsSearchResultProcessor"
+    settings.SEARCH_FILTER_GENERATOR = "lms.lib.courseware_search.lms_filter_generator.LmsSearchFilterGenerator"
+
+    # enable course visibility feature flags
+    settings.COURSE_CATALOG_VISIBILITY_PERMISSION = 'see_in_catalog'
+    settings.COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_about_page'
+    settings.SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING = True
+
+    if settings.APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_AUTH_BACKENDS', True):
+        settings.AUTHENTICATION_BACKENDS = (
+            'organizations.backends.DefaultSiteBackend',
+            'organizations.backends.SiteMemberBackend',
+            'organizations.backends.OrganizationMemberBackend',
+        )
+
+    if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+        settings.AUTHENTICATION_BACKENDS = list(settings.AUTHENTICATION_BACKENDS) + (
+            settings.ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
+                'social_core.backends.google.GoogleOAuth2',
+                'social_core.backends.linkedin.LinkedinOAuth2',
+                'social_core.backends.facebook.FacebookOAuth2',
+                'social_core.backends.azuread.AzureADOAuth2',
+                'third_party_auth.saml.SAMLAuthBackend',
+                'third_party_auth.lti.LTIAuthBackend',
+            ])
+        )
+
+    if settings.SENTRY_DSN:
+        settings.RAVEN_CONFIG['tags']['app'] = 'lms'
+
+    # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
+    # from the redirect mechanics.
+    settings.MAIN_SITE_REDIRECT_WHITELIST = ['api', 'admin', 'oauth', 'status']
+
+    settings.USE_S3_FOR_CUSTOMER_THEMES = True

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -1,0 +1,38 @@
+"""
+Common Appsembler settings for all environments in both LMS and CMS.
+"""
+
+
+def plugin_settings(settings):
+    """
+    Appsembler overrides for all of the environments (devstack, prod and test) in both of CMS and LMS.
+
+    This is a useful place for placing Appsembler-wide settings, for production
+    and devstack settings checkout the other `common_aws.py` and `common_devstack.py` sibling files.
+    """
+    settings.APPSEMBLER_FEATURES = {}
+
+    settings.INSTALLED_APPS += (
+        'hijack',
+        'compat',
+        'hijack_admin',
+
+        'openedx.core.djangoapps.appsembler.sites',
+        'openedx.core.djangoapps.appsembler.html_certificates',
+    )
+
+    settings.DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] += (
+        'openedx.core.djangoapps.appsembler.intercom_integration.context_processors.intercom',
+        'openedx.core.djangoapps.appsembler.analytics.context_processors.google_analytics',
+        'openedx.core.djangoapps.appsembler.analytics.context_processors.hubspot',
+        'openedx.core.djangoapps.appsembler.analytics.context_processors.mixpanel',
+    )
+
+    settings.SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+
+    settings.CLONE_COURSE_FOR_NEW_SIGNUPS = False
+    settings.HIJACK_ALLOW_GET_REQUESTS = True
+    settings.HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'
+
+    settings.CUSTOM_DOMAINS_REDIRECT_CACHE_TIMEOUT = None  # The length of time we cache Redirect model data
+    settings.CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX = 'custom_domains_redirects'

--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_cms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_cms.py
@@ -7,10 +7,8 @@ from openedx.core.djangoapps.appsembler.settings.settings import devstack_common
 
 def plugin_settings(settings):
     """
-    Make devstack lookin shiny blue!
+    Appsembler CMS overrides for devstack.
     """
     devstack_common.plugin_settings(settings)
-
-    settings.XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5
 
     settings.ALTERNATE_QUEUE_ENVS = ['lms']

--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
@@ -2,77 +2,32 @@
 Settings for Appsembler on devstack, both LMS and CMS.
 """
 
-import dj_database_url
-from django.utils.translation import ugettext_lazy as _
-
 
 def plugin_settings(settings):
     """
-    Make devstack lookin shiny blue!
+    Appsembler overrides devstack, both LMS and CMS.
+
+    This runs after `aws_common.py`, check that for relevant settings.
     """
-    # TODO: Create a new `common.py` settings instead and move all the common settings to it.
     settings.OAUTH_ENFORCE_SECURE = False
+    settings.SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
     # disable caching in dev environment
     for cache_key in settings.CACHES.keys():
         settings.CACHES[cache_key]['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'
 
-    settings.SESSION_ENGINE = 'django.contrib.sessions.backends.db'
-
-    settings.APPSEMBLER_FEATURES = settings.ENV_TOKENS.get('APPSEMBLER_FEATURES', {})
-
     settings.INSTALLED_APPS += (
-        'hijack',
-        'compat',
-        'hijack_admin',
-
         'django_extensions',
-        'openedx.core.djangoapps.appsembler.sites',
-        'openedx.core.djangoapps.appsembler.html_certificates',
         'openedx.core.djangoapps.appsembler.msft_lp',
     )
 
-    # those are usually hardcoded in devstack.py for some reason
+    # Those are usually hardcoded in devstack.py for some reason
     settings.LMS_BASE = settings.ENV_TOKENS.get('LMS_BASE')
     settings.LMS_ROOT_URL = settings.ENV_TOKENS.get('LMS_ROOT_URL')
-
-    settings.GOOGLE_ANALYTICS_APP_ID = settings.AUTH_TOKENS.get('GOOGLE_ANALYTICS_APP_ID')
-    settings.HUBSPOT_API_KEY = settings.AUTH_TOKENS.get('HUBSPOT_API_KEY')
-    settings.HUBSPOT_PORTAL_ID = settings.AUTH_TOKENS.get('HUBSPOT_PORTAL_ID')
-    settings.MIXPANEL_APP_ID = settings.AUTH_TOKENS.get('MIXPANEL_APP_ID')
-
-    settings.DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] += (
-        'openedx.core.djangoapps.appsembler.intercom_integration.context_processors.intercom',
-        'openedx.core.djangoapps.appsembler.analytics.context_processors.google_analytics',
-        'openedx.core.djangoapps.appsembler.analytics.context_processors.hubspot',
-        'openedx.core.djangoapps.appsembler.analytics.context_processors.mixpanel',
-    )
-
-    settings.INTERCOM_APP_ID = settings.AUTH_TOKENS.get("INTERCOM_APP_ID")
-    settings.INTERCOM_APP_SECRET = settings.AUTH_TOKENS.get("INTERCOM_APP_SECRET")
 
     settings.MIDDLEWARE_CLASSES += (
         'organizations.middleware.OrganizationMiddleware',
     )
-
-    settings.SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
-
-    if settings.FEATURES.get("ENABLE_TIERS_APP", False):
-        settings.TIERS_ORGANIZATION_MODEL = 'organizations.Organization'
-        settings.TIERS_EXPIRED_REDIRECT_URL = settings.ENV_TOKENS.get('TIERS_EXPIRED_REDIRECT_URL', None)
-        settings.TIERS_ORGANIZATION_TIER_GETTER_NAME = 'get_tier_for_org'
-
-        settings.TIERS_DATABASE_URL = settings.AUTH_TOKENS.get('TIERS_DATABASE_URL')
-        settings.DATABASES['tiers'] = dj_database_url.parse(settings.TIERS_DATABASE_URL)
-        settings.DATABASE_ROUTERS += ['openedx.core.djangoapps.appsembler.sites.routers.TiersDbRouter']
-
-        settings.MIDDLEWARE_CLASSES += (
-            'tiers.middleware.TierMiddleware',
-        )
-
-        settings.INSTALLED_APPS += (
-            'tiers',
-        )
 
     settings.COURSE_TO_CLONE = "course-v1:Appsembler+CC101+2017"
 
@@ -83,20 +38,8 @@ def plugin_settings(settings):
         for alternate in settings.ALTERNATE_QUEUE_ENVS
     ]
 
-    settings.CELERY_QUEUES.update(
-        {
-            alternate: {}
-            for alternate in settings.ALTERNATE_QUEUES
-            if alternate not in settings.CELERY_QUEUES.keys()
-        }
-    )
-
-    settings.CLONE_COURSE_FOR_NEW_SIGNUPS = False
-    settings.HIJACK_ALLOW_GET_REQUESTS = True
-    settings.HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'
-
-    DEFAULT_COURSE_MODE_SLUG = settings.ENV_TOKENS.get('EDXAPP_DEFAULT_COURSE_MODE_SLUG', 'audit')
-    settings.DEFAULT_MODE_NAME_FROM_SLUG = _(DEFAULT_COURSE_MODE_SLUG.capitalize())
-
-    settings.CUSTOM_DOMAINS_REDIRECT_CACHE_TIMEOUT = None  # The length of time we cache Redirect model data
-    settings.CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX = 'custom_domains_redirects'
+    settings.CELERY_QUEUES.update({
+        alternate: {}
+        for alternate in settings.ALTERNATE_QUEUES
+        if alternate not in settings.CELERY_QUEUES.keys()
+    })

--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
@@ -18,7 +18,6 @@ def plugin_settings(settings):
 
     settings.INSTALLED_APPS += (
         'django_extensions',
-        'openedx.core.djangoapps.appsembler.msft_lp',
     )
 
     # Those are usually hardcoded in devstack.py for some reason

--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
@@ -7,56 +7,16 @@ from openedx.core.djangoapps.appsembler.settings.settings import devstack_common
 
 def plugin_settings(settings):
     """
-    Make devstack lookin shiny blue!
+    Appsembler LMS overrides for devstack.
     """
     devstack_common.plugin_settings(settings)
 
-    settings.INSTALLED_APPS += (
-        'openedx.core.djangoapps.appsembler.tpa_admin',
-    )
-
-    settings.CORS_ORIGIN_ALLOW_ALL = True
-
-    settings.CORS_ALLOW_HEADERS = (
-        'x-requested-with',
-        'content-type',
-        'accept',
-        'origin',
-        'authorization',
-        'x-csrftoken',
-        'cache-control'
-    )
     settings.DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
-    # settings.SITE_ID = 1
-
-    # TODO: Fix the error and enable the Tahoe backends
-    # settings.AUTHENTICATION_BACKENDS = (
-    #     'organizations.backends.DefaultSiteBackend',
-    #     'organizations.backends.SiteMemberBackend',
-    #     'organizations.backends.OrganizationMemberBackend',
-    # )
+    settings.SITE_ID = 1
 
     settings.EDX_API_KEY = "test"
-
-    settings.COURSE_CATALOG_VISIBILITY_PERMISSION = 'see_in_catalog'
-    settings.COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_about_page'
-    settings.SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING = True
 
     settings.ALTERNATE_QUEUE_ENVS = ['cms']
 
     settings.USE_S3_FOR_CUSTOMER_THEMES = False
-
-    settings.LMS_BASE = settings.ENV_TOKENS.get('LMS_BASE')
-
-    if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
-        settings.AUTHENTICATION_BACKENDS = list(settings.AUTHENTICATION_BACKENDS) + (
-            settings.ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
-                'social_core.backends.google.GoogleOAuth2',
-                'social_core.backends.linkedin.LinkedinOAuth2',
-                'social_core.backends.facebook.FacebookOAuth2',
-                'social_core.backends.azuread.AzureADOAuth2',
-                'third_party_auth.saml.SAMLAuthBackend',
-                'third_party_auth.lti.LTIAuthBackend',
-            ])
-        )

--- a/openedx/core/djangoapps/appsembler/sites/admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/admin.py
@@ -2,7 +2,8 @@ from django.contrib.auth.models import User
 from hijack_admin.admin import HijackUserAdminMixin
 from ratelimitbackend import admin
 from student.admin import UserAdmin
-from .models import AlternativeDomain
+
+from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
 
 
 class HijackableUserAdmin(UserAdmin, HijackUserAdminMixin):

--- a/openedx/core/djangoapps/appsembler/sites/api.py
+++ b/openedx/core/djangoapps/appsembler/sites/api.py
@@ -17,11 +17,16 @@ from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
 )
 
-from .models import AlternativeDomain
-from .permissions import AMCAdminPermission
-from .serializers import SiteConfigurationSerializer, SiteConfigurationListSerializer, SiteSerializer, \
-    RegistrationSerializer, AlternativeDomainSerializer
-from .utils import delete_site
+from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
+from openedx.core.djangoapps.appsembler.sites.permissions import AMCAdminPermission
+from openedx.core.djangoapps.appsembler.sites.serializers import (
+    SiteConfigurationSerializer,
+    SiteConfigurationListSerializer,
+    SiteSerializer,
+    RegistrationSerializer,
+    AlternativeDomainSerializer,
+)
+from openedx.core.djangoapps.appsembler.sites.utils import delete_site
 
 
 class SiteViewSet(viewsets.ReadOnlyModelViewSet):

--- a/openedx/core/djangoapps/appsembler/sites/apps.py
+++ b/openedx/core/djangoapps/appsembler/sites/apps.py
@@ -8,6 +8,6 @@ class SitesConfig(AppConfig):
     label = 'appsembler_sites'
 
     def ready(self):
-        from .models import patched_clear_site_cache
+        from openedx.core.djangoapps.appsembler.sites.models import patched_clear_site_cache
 
         pre_save.connect(patched_clear_site_cache, sender='site_configuration.SiteConfiguration')

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/clear_user_and_site_data.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/clear_user_and_site_data.py
@@ -2,10 +2,9 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.contrib.sites.models import Site
 
-from cms.djangoapps.course_creators.models import CourseCreator
 import lms.lib.comment_client as cc
 from organizations.models import Organization
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
@@ -20,7 +19,14 @@ class Command(BaseCommand):
            " Keeps the superusers and the default site"
 
     def handle(self, *args, **options):
-        # delete course creator permissions
+        """
+        Delete course creator permissions.
+        """
+        if settings.ROOT_URLCONF == 'lms.urls':
+            # TODO: Not important, but cool: Fix the weird dependency and make it work in LMS.
+            raise CommandError('Run this command only from CMS, it cannot be run from within LMS.')
+
+        from course_creators.models import CourseCreator  # Keep this import local to avoid errors.
         CourseCreator.objects.all().delete()
         CourseAccessRole.objects.all().delete()
 

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/delete_user_data.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/delete_user_data.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 from django.contrib.sites.models import Site
 
-from cms.djangoapps.course_creators.models import CourseCreator
 import lms.lib.comment_client as cc
 from organizations.models import Organization
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
@@ -22,6 +21,12 @@ class Command(BaseCommand):
         parser.add_argument('email', nargs='*')
 
     def handle(self, *args, **options):
+        if settings.ROOT_URLCONF == 'lms.urls':
+            # TODO: Not important, but cool: Fix the weird dependency and make it work in LMS.
+            raise CommandError('Run this command only from CMS, it cannot be run from within LMS.')
+
+        from course_creators.models import CourseCreator  # Keep this import local to avoid errors.
+
         for email in options['email']:
             try:
                 user = User.objects.get(email=email)

--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -3,7 +3,7 @@ from django.core.cache import cache, caches
 from django.contrib.redirects.models import Redirect
 from django.shortcuts import redirect
 
-from .models import AlternativeDomain
+from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
 
 import logging
 log = logging.getLogger(__name__)

--- a/openedx/core/djangoapps/appsembler/sites/models.py
+++ b/openedx/core/djangoapps/appsembler/sites/models.py
@@ -6,7 +6,6 @@ from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from django.http.request import split_domain_port
 from django.contrib.sites.models import Site, SiteManager, SITE_CACHE
-from django.core.exceptions import ImproperlyConfigured
 import django
 
 cache = caches['general']

--- a/openedx/core/djangoapps/appsembler/sites/serializers.py
+++ b/openedx/core/djangoapps/appsembler/sites/serializers.py
@@ -7,8 +7,8 @@ from organizations.models import Organization
 
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.appsembler.sites.tasks import clone_course
-from .models import AlternativeDomain
-from .utils import sass_to_dict, dict_to_sass, bootstrap_site
+from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
+from openedx.core.djangoapps.appsembler.sites.utils import sass_to_dict, dict_to_sass, bootstrap_site
 
 
 class SASSDictField(serializers.DictField):

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_permissions.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_permissions.py
@@ -4,8 +4,7 @@ from organizations.tests.factories import UserFactory, OrganizationFactory
 from rest_framework.test import APIRequestFactory
 
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
-
-from ..permissions import AMCAdminPermission
+from openedx.core.djangoapps.appsembler.sites.permissions import AMCAdminPermission
 
 
 class AMCAdminPermissionsTestCase(TestCase):

--- a/openedx/core/djangoapps/appsembler/sites/urls.py
+++ b/openedx/core/djangoapps/appsembler/sites/urls.py
@@ -1,8 +1,17 @@
 from django.conf import settings
 from django.conf.urls import url, include
 from rest_framework.routers import DefaultRouter
-from .api import SiteConfigurationViewSet, SiteViewSet, FileUploadView, SiteCreateView,\
-    UsernameAvailabilityView, DomainAvailabilityView, CustomDomainView, DomainSwitchView
+
+from openedx.core.djangoapps.appsembler.sites.api import (
+    SiteConfigurationViewSet,
+    SiteViewSet,
+    FileUploadView,
+    SiteCreateView,
+    UsernameAvailabilityView,
+    DomainAvailabilityView,
+    CustomDomainView,
+    DomainSwitchView,
+)
 
 # Create a router and register our viewsets with it.
 router = DefaultRouter()

--- a/openedx/core/djangoapps/appsembler/tpa_admin/api.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/api.py
@@ -6,7 +6,10 @@ from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
 )
 from third_party_auth.models import SAMLConfiguration, SAMLProviderConfig
-from .serializers import SAMLConfigurationSerializer, SAMLProviderConfigSerializer
+from openedx.core.djangoapps.appsembler.tpa_admin.serializers import (
+    SAMLConfigurationSerializer,
+    SAMLProviderConfigSerializer,
+)
 
 
 class SAMLConfigurationViewSet(viewsets.ModelViewSet):

--- a/openedx/core/djangoapps/appsembler/tpa_admin/urls.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 
-from .api import (
+from openedx.core.djangoapps.appsembler.tpa_admin.api import (
     SAMLConfigurationViewSet,
     SAMLConfigurationSiteDetail,
     SAMLProviderConfigViewSet,


### PR DESCRIPTION
Appsembler settings were only added to Devstack, this PR adds it to prod (aka AWS) as well.

This PR uses the new Hawthorn plugins architecture, there's a good amount of documentation inline. Please take a look and let me know what do you think.

Heads up:

 - This will likely require another round of review. Please take an initial look and let me know what do you think.

@thraxil: 
 
 - This PR should fix the production issues we're having.
 - Probably it's better for now to set `APPSEMBLER_FEATURES['ENABLE_APPSEMBLER_AUTH_BACKENDS']` to `False` in `server-vars.yml` until I fix the the organizations app.