### PR TITLE
(WIP) Add server events to tracking backends

### DIFF
--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -96,27 +96,26 @@ def server_track(request, event_type, event, page=None):
     except:
         username = "anonymous"
 
-    # define output:
-    event = {
-        "username": username,
-        "ip": _get_request_ip(request),
-        "referer": _get_request_header(request, 'HTTP_REFERER'),
-        "accept_language": _get_request_header(request, 'HTTP_ACCEPT_LANGUAGE'),
-        "event_source": "server",
-        "event_type": event_type,
-        "event": event,
-        "agent": _get_request_header(request, 'HTTP_USER_AGENT').decode('latin1'),
-        "page": page,
-        "time": datetime.datetime.utcnow(),
-        "host": _get_request_header(request, 'SERVER_NAME'),
-        "context": eventtracker.get_tracker().resolve_context(),
-    }
+    if isinstance(event, basestring) and event:
+       try:
+           event = json.loads(event)
+       except ValueError:
+           pass  # Don't decode, but pass the string as is
+
+    context_override = dict()
+    context_override.update(eventtracker.get_tracker().resolve_context())
+    context_override.update({
+        'page': page,
+        'event_source': 'server',
+        'username': username
+    })
 
     # Some duplicated fields are passed into event-tracking via the context by track.middleware.
     # Remove them from the event here since they are captured elsewhere.
     shim.remove_shim_context(event)
 
-    log_event(event)
+    with eventtracker.get_tracker().context('edx.course.server', context_override):
+        eventtracker.emit(name=event_type, data=event)
 
 
 def task_track(request_info, task_info, event_type, event, page=None):


### PR DESCRIPTION
This PR is part of the work to meet customer requirements related to edX events. There is a mismatch because all the events listed in the [edX documentation](https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs/index.html) and the events that finally go to segment. This is because the docs cover all the tracking logs events, but not all the tracking logs events are sent through the new event tracker backend, and are logged using legacy systems. 

In an email exchange with Brian Wilson from the edX Analytics team, he pointed this out, and also let us know: 

> there is a whole class of events that are written to the tracking log using a "legacy" path that does not make them available to be routed to Segment

The file changes in this PR handles three types of events: user events, server events and task events. User events has been updated already by open edX to use the new tracking backends, and those are being received in Segment, this PR is adding the same changes for server events, which provide us access to many CAPA problems in Segment.

I've audited events in the tracking logs before and after the change, and all the info is still there, I just have two new attributes in the JSON, but I don't think that is a problem, is just the new backend adds more info:

Tracking log event before the change:
```
{
  "username": "maxi_i18n4", 
  "event_type": "openassessmentblock.save_submission", 
  "ip": "10.0.2.2", 
  "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:64.0) Gecko/20100101 Firefox/64.0", 
  "host": "vagrant", 
  "referer": "http://app-i18n4.edx.test:8000/courses/course-v1:app-i18n4+001+2019/courseware/bf06dd1b123045ff8d7d09cc433d5b24/ee49138b1ab9479fbe7882552532dec1/", 
  "accept_language": "en;q=1.0, en;q=0.5", 
  "event": {
    "saved_response": "{\"parts\": [{\"text\": \"esto es mi ensayo\"}]}"
  }, 
  "event_source": "server", 
  "context": {
    "course_user_tags": {}, 
    "user_id": 38, 
    "org_id": "app-i18n4", 
    "asides": {}, 
    "module": {
      "usage_key": "block-v1:app-i18n4+001+2019+type@openassessment+block@3b20ce428f57457392bd0d93af0f016b", 
      "display_name": "Peer Assessment"
    }, 
    "course_id": "course-v1:app-i18n4+001+2019", 
    "path": "/courses/course-v1:app-i18n4+001+2019/xblock/block-v1:app-i18n4+001+2019+type@openassessment+block@3b20ce428f57457392bd0d93af0f016b/handler/save_submission"
  }, 
  "time": "2019-01-17T14:23:14.558516+00:00", 
  "page": "x_module"
}
```

Same tracking log after the change:
```
{
	"username": "maxi_i18n4",
  "event_type": "openassessmentblock.save_submission"
  "ip": "10.0.2.2",
  "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:64.0) Gecko/20100101 Firefox/64.0",
  "host": "vagrant",
  "referer": "http://app-i18n4.edx.test:8000/courses/course-v1:app-i18n4+001+2019/courseware/bf06dd1b123045ff8d7d09cc433d5b24/ee49138b1ab9479fbe7882552532dec1/",
  "accept_language": "en-US,en;q=0.5",
  "event": {
    "saved_response": "{\"parts\": [{\"text\": \"esto es mi ensayo 4\"}]}"
  },
	"event_source": "server",
  "context": {
		"asides": {},
		"course_id": "course-v1:app-i18n4+001+2019",
		"user_id": 38,
		"module": {
			"usage_key": "block-v1:app-i18n4+001+2019+type@openassessment+block@3b20ce428f57457392bd0d93af0f016b",
			"display_name": "Peer Assessment"
		},
		"path": "/courses/course-v1:app-i18n4+001+2019/xblock/block-v1:app-i18n4+001+2019+type@openassessment+block@3b20ce428f57457392bd0d93af0f016b/handler/save_submission",
		"course_user_tags": {},
		"org_id": "app-i18n4"
	},
  "time": "2019-01-17T16:15:50.284317+00:00",
  "page": "x_module",
  "name": "openassessmentblock.save_submission",
  "session": "480ba1e83814080c6692c57aa8fd0d5b",
}
```