### PR TITLE
Updated Tahoe LMS to support Figures

### DIFF
--- a/lms/envs/amc.py
+++ b/lms/envs/amc.py
@@ -147,3 +147,19 @@ CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX = 'custom_domains_redirects'
 # Settings for Tahoe API
 #
 INSTALLED_APPS += ('openedx.core.djangoapps.appsembler.api',)
+
+#
+# Support for Figures
+#
+
+# Webpack loader needed by Figures
+if 'webpack_loader' not in INSTALLED_APPS:
+    INSTALLED_APPS += ('webpack_loader',)
+
+# Enable Figures if it is included
+if 'figures' in INSTALLED_APPS:
+    import figures
+    figures.update_settings(
+        WEBPACK_LOADER,
+        CELERYBEAT_SCHEDULE,
+        ENV_TOKENS.get('FIGURES', {}))

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3048,3 +3048,7 @@ DOC_LINK_BASE_URL = None
 ############## Settings for the Enterprise App ######################
 
 ENTERPRISE_ENROLLMENT_API_URL = LMS_ROOT_URL + "/api/enrollment/v1/"
+
+
+# Figures needs Django Webpack Loader
+WEBPACK_LOADER = {}

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -9,8 +9,11 @@ from django.utils.translation import ugettext_lazy as _
 OAUTH_ENFORCE_SECURE = False
 
 # disable caching in dev environment
-for cache_key in CACHES.keys():
-    CACHES[cache_key]['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'
+# NOTE: Disabling cache breaks things like Celery subtasks
+if not FEATURES.get("ENABLE_DEVSTACK_CACHES"):
+    print('\nDISABLING CACHES...')
+    for cache_key in CACHES.keys():
+        CACHES[cache_key]['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
@@ -141,6 +144,18 @@ DEFAULT_MODE_NAME_FROM_SLUG = _(DEFAULT_COURSE_MODE_SLUG.capitalize())
 
 CUSTOM_DOMAINS_REDIRECT_CACHE_TIMEOUT = None  # The length of time we cache Redirect model data
 CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX = 'custom_domains_redirects'
+
+# Webpack loader needed by Figures
+if 'webpack_loader' not in INSTALLED_APPS:
+    INSTALLED_APPS += ('webpack_loader',)
+
+# Enable Figures if it is included
+if 'figures' in INSTALLED_APPS:
+    import figures
+    figures.update_settings(
+        WEBPACK_LOADER,
+        CELERYBEAT_SCHEDULE,
+        ENV_TOKENS.get('FIGURES', {}))
 
 try:
     from .private import *

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -980,3 +980,8 @@ urlpatterns += (
         include('openedx.core.djangoapps.appsembler.api.urls',
         namespace='tahoe-api')),
 )
+
+if 'figures' in settings.INSTALLED_APPS:
+    urlpatterns += (
+        url(r'^figures/', include('figures.urls', namespace='figures')),
+    )


### PR DESCRIPTION
* Added conditional inclusion for Figures in lms/urls.py if Figures is
in the INSTALLLED_APPS
* Added Figures settings to lms/envs/amc.py and
lms/envs/devstack_appsembler.py to support Figures
* Added WEBPACK_LOADER dict declaration in lms/envs/common.py