### PR TITLE
cherry pick from Hawthorn: Allow masquerade on progress page

### DIFF
--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -117,6 +117,18 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         request.session = session or {}
         return request
 
+    def get_progress_page(self):
+        """
+        Returns the server response for progress page.
+        """
+        url = reverse(
+            'progress',
+            kwargs={
+                'course_id': unicode(self.course.id),
+            }
+        )
+        return self.client.get(url)
+
     def verify_staff_debug_present(self, staff_debug_expected):
         """
         Verifies that the staff debug control visibility is as expected (for staff only).
@@ -377,6 +389,31 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         self.update_masquerade(role='student', user_name=self.student_user.username)
         content = self.get_course_info_page().content
         self.assertIn("OOGIE BLOOGIE", content)
+
+    def test_masquerade_as_specific_student_progress(self):
+        """
+        Test masquesrading as a specific user for progress page.
+        """
+        # Give the student some correct answers, check their progress page
+        self.login_student()
+        self.submit_answer('Correct', 'Correct')
+        student_progress = self.get_progress_page().content
+        self.assertNotIn("1 of 2 possible points", student_progress)
+        self.assertIn("2 of 2 possible points", student_progress)
+
+        # Staff answers are slightly different
+        self.login_staff()
+        self.submit_answer('Incorrect', 'Correct')
+        staff_progress = self.get_progress_page().content
+        self.assertNotIn("2 of 2 possible points", staff_progress)
+        self.assertIn("1 of 2 possible points", staff_progress)
+
+        # Should now see the student's scores
+        self.update_masquerade(role='student', user_name=self.student_user.username)
+        masquerade_progress = self.get_progress_page().content
+        self.assertNotIn("1 of 2 possible points", masquerade_progress)
+        self.assertIn("2 of 2 possible points", masquerade_progress)
+        self.verify_real_user_profile_link()
 
 
 @attr(shard=1)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -739,9 +739,10 @@ def _progress(request, course_key, student_id):
 
     staff_access = bool(has_access(request.user, 'staff', course))
 
+    masquerade = None
     if student_id is None or student_id == request.user.id:
-        # always allowed to see your own profile
-        student = request.user
+        # This will be a no-op for non-staff users, returning request.user
+        masquerade, student = setup_masquerade(request, course_key, staff_access, reset_masquerade_data=True)
     else:
         try:
             coach_access = has_ccx_coach_role(request.user, course_key)
@@ -782,7 +783,8 @@ def _progress(request, course_key, student_id):
         'student': student,
         'passed': is_course_passed(course, grade_summary),
         'credit_course_requirements': _credit_course_requirements(course_key, student),
-        'certificate_data': _get_cert_data(student, course, course_key, is_active, enrollment_mode)
+        'certificate_data': _get_cert_data(student, course, course_key, is_active, enrollment_mode),
+        'masquerade': masquerade
     }
 
     with outer_atomic():

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -20,7 +20,7 @@ if active_page is None and active_page_context is not UNDEFINED:
 def selected(is_selected):
   return "selected" if is_selected else ""
 
-show_preview_menu = not disable_preview_menu and staff_access and active_page in ["courseware", "info"]
+show_preview_menu = not disable_preview_menu and staff_access and active_page in ["courseware", "info", "progress"]
 cohorted_user_partition = get_cohorted_user_partition(course)
 masquerade_user_name = masquerade.user_name if masquerade else None
 masquerade_group_id = masquerade.group_id if masquerade else None


### PR DESCRIPTION
Trinity and NYIF have requested this feature (also missing in Ginkgo)

https://trello.com/c/NaRC6mxM/2421-4-nyif-staff-user-unable-to-see-student-progress-pages
https://trello.com/c/eaLahF3O/3561-trinity-view-progress-page-is-not-working-for-course-staff


