### PR TITLE
[Gymnasium Release] Add event tracking logic to edx-platform for grading

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -28,6 +28,7 @@ from .fields import Timedelta, Date
 from django.utils.timezone import UTC
 from xmodule.capa_base_constants import RANDOMIZATION, SHOWANSWER
 from django.conf import settings
+from eventtracking import tracker
 
 log = logging.getLogger("edx.courseware")
 
@@ -1129,6 +1130,13 @@ class CapaMixin(CapaFields):
                 metric_name('attempts'),
                 self.attempts,
             )
+
+        # note: this is a hack to track grade events, and should be removed
+        #       once we move from Eucalyptus to edx-plaform Hawthorn or later
+        tracker.emit(
+            'edx.course.grade.submitted.eucalyptus',
+            event_info,
+        )
 
         # render problem into HTML
         html = self.get_problem_html(encapsulate=False)


### PR DESCRIPTION
(attn @tkeemon)
This is a follow up to #310 - to move this code from staging to production.  I'll drop a note in trello and our shared Gymnasium Slack channel so that Andrew, TJ, and Myself are all on the same page.

What follows is borrowed/modified from that PR's description:

# What this PR contains:
- adds an event to track grading of courseware problems with the event tracker (which pipes event data to Segment)

# 🚨 AN IMPORTANT NOTE 🚨 
-**this requires an addition to the SEGMENT_EVENTS_WHITELIST in our ansible configuration** which will end up in `lms.auth.json`.  

The event in question is called 
```
edx.course.grade.submitted.eucalyptus
```

# Other notes:
- this is only a patch for our deployment on Eucalyptus, and should not be recreated on versions after Hawthorn, since these events are tracked by default on later versions of open edx.
- After taking a look at the shape of events in [later versions](https://github.com/edx/edx-platform/blob/896e66f8fcc1d2828d9c8299da0187ba96e8156e/lms/djangoapps/grades/events.py#L37-L48) of the platform, I decided not to update the shape of the event we're reporting for now - we should be able to extract relevant data for reporting from this event type.

# Testing
1. To test this, for any course, skip ahead to the final exam, and hit the submit button to get a grade
1. Logs should show an event sent to segment
1. I can help verify that they made it there from our segment console - just ping me
