### PR TITLE
Test fixes for appsembler Djangoapps and hacks

### DIFF
--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -51,10 +51,15 @@ def get_link_for_about_page(course):
     elif settings.FEATURES.get('ENABLE_MKTG_SITE') and getattr(course, 'marketing_url', None):
         course_about_url = course.marketing_url
     else:
-        about_base = u'https://{}'.format(get_lms_link_from_course_key(
-            configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+        protocol = 'https' if settings.LMS_ROOT_URL.startswith('https') else 'http'
+        lms_domain = get_lms_link_from_course_key(
+            configuration_helpers.get_value('LMS_BASE', settings.LMS_BASE),
             course.id,
-        ))
+        )
+        about_base = u'{protocol}://{lms_domain}'.format(
+            lms_domain=lms_domain,
+            protocol=protocol,
+        )
 
         course_about_url = u'{about_base_url}/courses/{course_key}/about'.format(
             about_base_url=about_base,

--- a/common/djangoapps/util/tests/test_course.py
+++ b/common/djangoapps/util/tests/test_course.py
@@ -68,7 +68,7 @@ class TestCourseSharingLinks(ModuleStoreTestCase):
         (True, True, 'test_social_sharing_url'),
         (False, True, 'test_marketing_url'),
         (True, False, 'test_social_sharing_url'),
-        (False, False, '{}/courses/course-v1:test_org+test_number+test_run/about'.format(settings.LMS_ROOT_URL)),
+        (False, False, '{}/courses/course-v1:test_org+test_number+test_run/about'.format('http://test_org.localhost:8000')),
     )
     @ddt.unpack
     def test_sharing_link_with_settings(self, enable_social_sharing, enable_mktg_site, expected_course_sharing_link):
@@ -86,7 +86,7 @@ class TestCourseSharingLinks(ModuleStoreTestCase):
         (['marketing_url'], 'test_social_sharing_url'),
         (
             ['social_sharing_url', 'marketing_url'],
-            '{}/courses/course-v1:test_org+test_number+test_run/about'.format(settings.LMS_ROOT_URL)
+            '{}/courses/course-v1:test_org+test_number+test_run/about'.format('http://test_org.localhost:8000')
         ),
     )
     @ddt.unpack
@@ -110,7 +110,7 @@ class TestCourseSharingLinks(ModuleStoreTestCase):
         (True, 'test_social_sharing_url'),
         (
             False,
-            '{}/courses/course-v1:test_org+test_number+test_run/about'.format(settings.LMS_ROOT_URL)
+            '{}/courses/course-v1:test_org+test_number+test_run/about'.format('http://test_org.localhost:8000')
         ),
     )
     @ddt.unpack

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -569,6 +569,7 @@ COURSE_CATALOG_API_URL = 'https://catalog.example.com/api/v1'
 COMPREHENSIVE_THEME_DIRS = [REPO_ROOT / "themes", REPO_ROOT / "common/test"]
 COMPREHENSIVE_THEME_LOCALE_PATHS = [REPO_ROOT / "themes/conf/locale", ]
 
+LMS_BASE = "localhost:8000"
 LMS_ROOT_URL = "http://localhost:8000"
 
 ECOMMERCE_API_URL = 'https://ecommerce.example.com/api/v2/'

--- a/openedx/core/djangoapps/appsembler/analytics/context_processors.py
+++ b/openedx/core/djangoapps/appsembler/analytics/context_processors.py
@@ -7,8 +7,8 @@ from student.roles import CourseCreatorRole
 
 def google_analytics(request):
     data = {
-        'GOOGLE_ANALYTICS_APP_ID': settings.GOOGLE_ANALYTICS_APP_ID,
-        'SHOW_GOOGLE_ANALYTICS': settings.GOOGLE_ANALYTICS_APP_ID,
+        'GOOGLE_ANALYTICS_APP_ID': getattr(settings, 'GOOGLE_ANALYTICS_APP_ID', None),
+        'SHOW_GOOGLE_ANALYTICS': getattr(settings, 'GOOGLE_ANALYTICS_APP_ID', None),
     }
 
     user = request.user
@@ -21,16 +21,17 @@ def google_analytics(request):
 
 def mixpanel(request):
     data = {
-        'MIXPANEL_APP_ID': settings.MIXPANEL_APP_ID,
-        'SHOW_MIXPANEL': settings.MIXPANEL_APP_ID,
+        'MIXPANEL_APP_ID': getattr(settings, 'MIXPANEL_APP_ID', None),
+        'SHOW_MIXPANEL': getattr(settings, 'MIXPANEL_APP_ID', None),
     }
     return data
 
 
 def hubspot(request):
     user = request.user
+    hubspot_portal_id = getattr(settings, 'HUBSPOT_PORTAL_ID', None)
     data = {
-        'HUBSPOT_PORTAL_ID': settings.HUBSPOT_PORTAL_ID,
-        'SHOW_HUBSPOT': settings.HUBSPOT_PORTAL_ID and user.is_authenticated() and user_has_role(user, CourseCreatorRole()),
+        'HUBSPOT_PORTAL_ID': hubspot_portal_id,
+        'SHOW_HUBSPOT': hubspot_portal_id and user.is_authenticated() and user_has_role(user, CourseCreatorRole()),
     }
     return data

--- a/openedx/core/djangoapps/appsembler/intercom_integration/context_processors.py
+++ b/openedx/core/djangoapps/appsembler/intercom_integration/context_processors.py
@@ -9,7 +9,7 @@ from student.roles import CourseCreatorRole
 def intercom(request):
     data = {'show_intercom_widget': False}
 
-    intercom_app_id = settings.INTERCOM_APP_ID
+    intercom_app_id = getattr(settings, 'INTERCOM_APP_ID', None)
     if not intercom_app_id:
         return data
 

--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 class CustomDomainsRedirectMiddleware(object):
 
     def process_request(self, request):
-        cache_general = caches['general']
+        cache_general = caches['default']
         hostname = request.get_host()
         if hostname.endswith(settings.SITE_NAME):
             cache_key = '{prefix}-{site}'.format(prefix=settings.CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX, site=hostname)

--- a/openedx/core/djangoapps/appsembler/sites/models.py
+++ b/openedx/core/djangoapps/appsembler/sites/models.py
@@ -8,7 +8,7 @@ from django.http.request import split_domain_port
 from django.contrib.sites.models import Site, SiteManager, SITE_CACHE
 import django
 
-cache = caches['general']
+cache = caches['default']
 
 
 def _cache_key_for_site_id(site_id):

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -7,9 +7,8 @@ import sass
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
-from django.contrib.staticfiles.templatetags.staticfiles import static
-from organizations.api import add_organization
-from organizations.models import UserOrganizationMapping, Organization
+from organizations import api as org_api
+from organizations import models as org_models
 
 from openedx.core.djangoapps.theming.models import SiteTheme
 
@@ -143,12 +142,12 @@ def bootstrap_site(site, org_data=None, user_email=None):
     site.configuration_id = site_config.id
     # temp workarounds while old staging is still up and running
     if organization_slug:
-        organization_data = add_organization({
+        organization_data = org_api.add_organization({
             'name': organization_slug,
             'short_name': organization_slug,
             'edx_uuid': org_data.get('edx_uuid')
         })
-        organization = Organization.objects.get(id=organization_data.get('id'))
+        organization = org_models.Organization.objects.get(id=organization_data.get('id'))
         organization.sites.add(site)
         site_config.values['course_org_filter'] = organization_slug
         site_config.save()
@@ -156,7 +155,7 @@ def bootstrap_site(site, org_data=None, user_email=None):
         organization = {}
     if user_email:
         user = User.objects.get(email=user_email)
-        UserOrganizationMapping.objects.create(user=user, organization=organization, is_amc_admin=True)
+        org_models.UserOrganizationMapping.objects.create(user=user, organization=organization, is_amc_admin=True)
     else:
         user = {}
     return organization, site, user

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -16,10 +16,28 @@ from jsonfield.fields import JSONField
 from model_utils.models import TimeStampedModel
 
 from storages.backends.s3boto import S3BotoStorage
-from openedx.core.djangoapps.appsembler.sites.utils import get_initial_sass_variables, get_initial_page_elements, \
-    compile_sass
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
+
+
+def get_initial_sass_variables():
+    """
+    Proxy to `utils.get_initial_sass_variables` to avoid test-time Django errors.
+
+    # TODO: Fix Site Configuration and Organizations hacks. https://github.com/appsembler/edx-platform/issues/329
+    """
+    from openedx.core.djangoapps.appsembler.sites import utils
+    return utils.get_initial_sass_variables
+
+
+def get_initial_page_elements():
+    """
+    Proxy to `utils.get_initial_page_elements` to avoid test-time Django errors.
+
+    # TODO: Fix Site Configuration and Organizations hacks. https://github.com/appsembler/edx-platform/issues/329
+    """
+    from openedx.core.djangoapps.appsembler.sites import utils
+    return utils.get_initial_page_elements
 
 
 class SiteConfiguration(models.Model):
@@ -143,6 +161,9 @@ class SiteConfiguration(models.Model):
         super(SiteConfiguration, self).delete(using=using)
 
     def compile_microsite_sass(self):
+        # Proxy to `utils.get_initial_page_elements` to avoid test-time Django errors.
+        # TODO: Fix Site Configuration and Organizations hacks. https://github.com/appsembler/edx-platform/issues/329
+        from openedx.core.djangoapps.appsembler.sites.utils import compile_sass
         css_output = compile_sass('main.scss', custom_branding=self._sass_var_override)
         file_name = self.get_value('css_overrides_file')
         if settings.USE_S3_FOR_CUSTOMER_THEMES:


### PR DESCRIPTION
I'm running a couple of tests on specific modules that were a bit difficult to merge (see ![](https://github.trello.services/images/mini-trello-icon.png) [Hawthorn: Multiple modules to test after Tahoe Ginkgo merge](https://trello.com/c/pPXxurQg/3113-6-hawthorn-multiple-modules-to-test-after-tahoe-ginkgo-merge)). I've found some test failures, this pull request fixes most of those failures.

### Things for Reviewers to Double Check

 - [ ] I found that a big part of our test failures are due to hacks we did in both `Site Configuration` Django application and the `edx-organizations` repository that we maintain a for of. I've had created a Tech Debt issue (https://github.com/appsembler/edx-platform/issues/329). Until this issue is resolved, I've made some of the imports local to lazilly load them to avoid early imports issues. @melvinsoft for your info.

 - [x] I have found that using `caches['general']` in tests breaks. So I used `caches['default']` instead for our modules. I really don't know what's the difference between both of them, but `default` definitely works in tests. @thraxil Could you please help?