### PR TITLE
compile custom customer sass from site configuration

### DIFF
--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -200,6 +200,8 @@ class SiteConfiguration(models.Model):
     def _sass_var_override(self, path):
         if 'branding-basics' in path:
             return [(path, self._formatted_sass_variables())]
+        if 'customer-sass-input' in path:
+            return [(path, self.values.get('customer_sass_input', ''))]
         return None
 
     def _get_initial_microsite_values(self):


### PR DESCRIPTION
This addition to code checks if the current scss file that's included and needs to be compiled in is called `customer-sass-input`. If so, replace the contents of the file with the value of `customer_sass_input` from the customers site configuration.