### PR TITLE
Add shell commands and admin panel to set AMC admins

### DIFF
--- a/common/templates/admin/user/make_amc_admin_action.html
+++ b/common/templates/admin/user/make_amc_admin_action.html
@@ -1,0 +1,32 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_static admin_modify %}
+{% block content %}
+<div id="content-main">
+  <form action="" method="POST">
+    {% csrf_token %}
+    {% if form.non_field_errors|length > 0 %}
+      <p class="errornote">
+          "Please correct the errors below."
+      </p>
+      {{ form.non_field_errors }}
+    {% endif %}
+    <fieldset class="module aligned">
+      {% for field in form %}
+        <div class="form-row">
+          {{ field.errors }}
+          {{ field.label_tag }}
+          {{ field }}
+          {% if field.field.help_text %}
+          <p class="help">
+            {{ field.field.help_text|safe }}
+          </p>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </fieldset>
+    <div class="submit-row">
+      <input type="submit" class="default" value="Submit”>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/common/templates/admin/user/make_amc_admin_action.html
+++ b/common/templates/admin/user/make_amc_admin_action.html
@@ -1,32 +1,82 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_static admin_modify %}
 {% block content %}
-<div id="content-main">
-  <form action="" method="POST">
-    {% csrf_token %}
-    {% if form.non_field_errors|length > 0 %}
-      <p class="errornote">
-          "Please correct the errors below."
-      </p>
-      {{ form.non_field_errors }}
-    {% endif %}
-    <fieldset class="module aligned">
-      {% for field in form %}
-        <div class="form-row">
-          {{ field.errors }}
-          {{ field.label_tag }}
-          {{ field }}
-          {% if field.field.help_text %}
-          <p class="help">
-            {{ field.field.help_text|safe }}
-          </p>
-          {% endif %}
-        </div>
-      {% endfor %}
-    </fieldset>
-    <div class="submit-row">
-      <input type="submit" class="default" value="Submit”>
+    <div id="content-main">
+        <form action="" method="POST">
+            {% csrf_token %}
+            {% if form.non_field_errors|length > 0 %}
+                <p class="errornote">
+                    Please correct the errors below.
+                </p>
+                {{ form.non_field_errors }}
+            {% endif %}
+            <fieldset class="module aligned">
+                <div class="form-row">
+                    <label><storng>Warning:</storng></label>
+                    <p>
+                        Please make sure you'r assigning the right user to the right organization!
+                        Otherwise customer data would be exposed.
+                    </p>
+                </div>
+
+                <div class="form-row">
+                    <label for="amc_username">Username</label>
+                    <input id="amc_username" readonly value="{{ amc_user.username }}" />
+                    <p class="help">Readonly</p>
+                </div>
+
+                <div class="form-row">
+                    <label for="amc_email">Email</label>
+                    <input id="amc_email" readonly value="{{ amc_user.email }}" />
+                    <p class="help">Readonly</p>
+                </div>
+
+                {% for field in form %}
+                    <div class="form-row">
+                        {{ field.errors }}
+                        {{ field.label_tag }}
+                        {{ field }}
+                        {% if field.field.help_text %}
+                            <p class="help">
+                                {{ field.field.help_text|safe }}
+                            </p>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+
+                <div class="form-row">
+                    <label for="amc_access_token">Access Token</label>
+                    <input id="amc_access_token" readonly value="{{ tokens.access_token }}" />
+                    <p class="help">Copy to AMC</p>
+                </div>
+
+                <div class="form-row">
+                    <label for="amc_refresh_token">Refresh Token</label>
+                    <input id="amc_refresh_token" readonly value="{{ tokens.refresh_token }}" />
+                    <p class="help">Copy to AMC</p>
+                </div>
+
+                <div class="form-row">
+                    <label for="amc_access_expiration_date">Access Token Expiration Date</label>
+                    <input id="amc_access_expiration_date" readonly value="{{ tokens.access_expires | date:"Y-m-d" }}" />
+                    <p class="help">Copy to AMC</p>
+                </div>
+                <div class="form-row">
+                    <label for="amc_access_expiration_time">Access Token Expiration Time</label>
+                    <input id="amc_access_expiration_time" readonly value="{{ tokens.access_expires | date:"H:i:s" }}" />
+                    <p class="help">Copy to AMC</p>
+                </div>
+
+                <div class="form-row">
+                    <label>Locate user in AMC Admin</label>
+                    <a target="_blank" class="button" href="{{ amc_app_url }}{% url 'admin:auth_user_changelist' %}?q={{ user.email | urlencode }}">
+                        Locate user in AMC Admin (new window)
+                    </a>
+                </div>
+            </fieldset>
+            <div class="submit-row">
+                <input type="submit" class="default" value="Reset Tokens, Make AMC Admin">
+            </div>
+        </form>
     </div>
-  </form>
-</div>
 {% endblock %}

--- a/openedx/core/djangoapps/appsembler/sites/admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/admin.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponseRedirect
 from django.contrib.auth.models import User
+from django.core.exceptions import MultipleObjectsReturned
 from django.core.urlresolvers import reverse
 from django.conf.urls import url
 from django.template.response import TemplateResponse
@@ -8,9 +9,12 @@ from ratelimitbackend import admin
 from student.admin import UserAdmin
 from openedx.core.djangolib.markup import HTML, Text
 from .models import AlternativeDomain
+from organizations.models import Organization
+
 
 
 from openedx.core.djangoapps.appsembler.sites.models import MakeAMCAdminForm
+from openedx.core.djangoapps.appsembler.sites.utils import make_amc_admin, get_single_user_organization
 
 
 class TahoeUserAdmin(UserAdmin, HijackUserAdminMixin):
@@ -37,21 +41,28 @@ class TahoeUserAdmin(UserAdmin, HijackUserAdminMixin):
 
     def process_make_amc_admin(self, request, user_id, *args, **kwargs):
         user = self.get_object(request, user_id)
+        form = MakeAMCAdminForm()
 
-        if request.method != 'POST':
-            form = MakeAMCAdminForm()
-        else:
-            form = MakeAMCAdminForm(request.POST)
+        try:
+            current_org = get_single_user_organization(user)
+            current_org_name = current_org.name
+        except (Organization.DoesNotExist, MultipleObjectsReturned):
+            current_org_name = ''
+
+        if request.method == 'POST':
+            initial = {'organization_name': current_org_name}
+            initial.update(request.POST)
+            form = MakeAMCAdminForm(initial)
             if form.is_valid():
-                form.save(user, request.user)
-                self.message_user(request, 'Success')
-                url = reverse(
-                    'admin:auth_user_change',
-                    args=[user.pk],
-                )
-                return HttpResponseRedirect(url)
+                make_amc_admin(user, form.cleaned_data['organization_name'])
+                self.message_user(request, HTML('Successfully made "{user}" an AMC admin for "{org}"').format(
+                    user=Text(user.username),
+                    org=Text(form.cleaned_data['organization_name']),
+                ))
+                return HttpResponseRedirect(reverse('admin:auth_user_change', args=[user.pk]))
+
         context = self.admin_site.each_context(request)
-        context['opts'] = self.model._meta
+        context['opts'] = self.model._meta  # pylint: disable=protected-access
         context['form'] = form
         context['user'] = user
         context['title'] = 'Make AMC Admin'

--- a/openedx/core/djangoapps/appsembler/sites/admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/admin.py
@@ -1,14 +1,65 @@
+from django.http import HttpResponseRedirect
 from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.conf.urls import url
+from django.template.response import TemplateResponse
 from hijack_admin.admin import HijackUserAdminMixin
 from ratelimitbackend import admin
 from student.admin import UserAdmin
+from openedx.core.djangolib.markup import HTML, Text
 from .models import AlternativeDomain
 
 
-class HijackableUserAdmin(UserAdmin, HijackUserAdminMixin):
+from openedx.core.djangoapps.appsembler.sites.models import MakeAMCAdminForm
+
+
+class TahoeUserAdmin(UserAdmin, HijackUserAdminMixin):
     list_display = UserAdmin.list_display + (
         'hijack_field',
+        'make_amc_admin_action',
     )
+
+    def get_urls(self):
+        return [
+            url(
+                r'^(?P<user_id>\d+)/make-amc-admin$',
+                self.admin_site.admin_view(self.process_make_amc_admin),
+                name='make-amc-admin',
+            ),
+        ] + super(UserAdmin, self).get_urls()
+
+    def make_amc_admin_action(self, obj):
+        return HTML('<a class="button" href="{href}">Make AMC Admin...</a> ').format(
+            href=Text(reverse('admin:make-amc-admin', args=[obj.id])),
+        )
+    make_amc_admin_action.short_description = 'AMC Actions'
+    make_amc_admin_action.allow_tags = True
+
+    def process_make_amc_admin(self, request, user_id, *args, **kwargs):
+        user = self.get_object(request, user_id)
+
+        if request.method != 'POST':
+            form = MakeAMCAdminForm()
+        else:
+            form = MakeAMCAdminForm(request.POST)
+            if form.is_valid():
+                form.save(user, request.user)
+                self.message_user(request, 'Success')
+                url = reverse(
+                    'admin:auth_user_change',
+                    args=[user.pk],
+                )
+                return HttpResponseRedirect(url)
+        context = self.admin_site.each_context(request)
+        context['opts'] = self.model._meta
+        context['form'] = form
+        context['user'] = user
+        context['title'] = 'Make AMC Admin'
+        return TemplateResponse(
+            request,
+            'admin/user/make_amc_admin_action.html',
+            context,
+        )
 
 
 class AlternativeDomainAdmin(admin.ModelAdmin):
@@ -19,5 +70,5 @@ class AlternativeDomainAdmin(admin.ModelAdmin):
 
 
 admin.site.unregister(User)
-admin.site.register(User, HijackableUserAdmin)
+admin.site.register(User, TahoeUserAdmin)
 admin.site.register(AlternativeDomain, AlternativeDomainAdmin)

--- a/openedx/core/djangoapps/appsembler/sites/admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/admin.py
@@ -3,18 +3,21 @@ from django.contrib.auth.models import User
 from django.core.exceptions import MultipleObjectsReturned
 from django.core.urlresolvers import reverse
 from django.conf.urls import url
+from django.conf import settings
 from django.template.response import TemplateResponse
 from hijack_admin.admin import HijackUserAdminMixin
 from ratelimitbackend import admin
 from student.admin import UserAdmin
 from openedx.core.djangolib.markup import HTML, Text
 from .models import AlternativeDomain
-from organizations.models import Organization
+from organizations.models import UserOrganizationMapping
 
-
-
-from openedx.core.djangoapps.appsembler.sites.models import MakeAMCAdminForm
-from openedx.core.djangoapps.appsembler.sites.utils import make_amc_admin, get_single_user_organization
+from openedx.core.djangoapps.appsembler.sites.forms import MakeAMCAdminForm
+from openedx.core.djangoapps.appsembler.sites.utils import (
+    get_amc_tokens,
+    get_single_user_organization,
+    make_amc_admin,
+)
 
 
 class TahoeUserAdmin(UserAdmin, HijackUserAdminMixin):
@@ -33,7 +36,7 @@ class TahoeUserAdmin(UserAdmin, HijackUserAdminMixin):
         ] + super(UserAdmin, self).get_urls()
 
     def make_amc_admin_action(self, obj):
-        return HTML('<a class="button" href="{href}">Make AMC Admin...</a> ').format(
+        return HTML('<a class="button" href="{href}">AMC Admin Form</a> ').format(
             href=Text(reverse('admin:make-amc-admin', args=[obj.id])),
         )
     make_amc_admin_action.short_description = 'AMC Actions'
@@ -41,31 +44,34 @@ class TahoeUserAdmin(UserAdmin, HijackUserAdminMixin):
 
     def process_make_amc_admin(self, request, user_id, *args, **kwargs):
         user = self.get_object(request, user_id)
-        form = MakeAMCAdminForm()
 
         try:
             current_org = get_single_user_organization(user)
             current_org_name = current_org.name
-        except (Organization.DoesNotExist, MultipleObjectsReturned):
+        except (UserOrganizationMapping.DoesNotExist, MultipleObjectsReturned):
             current_org_name = ''
 
+        form = MakeAMCAdminForm({'organization_name': current_org_name})
+
         if request.method == 'POST':
-            initial = {'organization_name': current_org_name}
-            initial.update(request.POST)
-            form = MakeAMCAdminForm(initial)
+            form = MakeAMCAdminForm(request.POST)
             if form.is_valid():
                 make_amc_admin(user, form.cleaned_data['organization_name'])
                 self.message_user(request, HTML('Successfully made "{user}" an AMC admin for "{org}"').format(
                     user=Text(user.username),
                     org=Text(form.cleaned_data['organization_name']),
                 ))
-                return HttpResponseRedirect(reverse('admin:auth_user_change', args=[user.pk]))
+                return HttpResponseRedirect(reverse('admin:make-amc-admin', args=[user.id]))
 
         context = self.admin_site.each_context(request)
-        context['opts'] = self.model._meta  # pylint: disable=protected-access
-        context['form'] = form
-        context['user'] = user
-        context['title'] = 'Make AMC Admin'
+        context.update({
+            'opts': self.model._meta,  # pylint: disable=protected-access
+            'form': form,
+            'amc_user': user,
+            'amc_app_url': settings.FEATURES['AMC_APP_URL'],
+            'title': 'Make AMC Admin',
+            'tokens': get_amc_tokens(user),
+        })
         return TemplateResponse(
             request,
             'admin/user/make_amc_admin_action.html',

--- a/openedx/core/djangoapps/appsembler/sites/forms.py
+++ b/openedx/core/djangoapps/appsembler/sites/forms.py
@@ -1,0 +1,8 @@
+"""
+Appsembler Sites Views.
+"""
+from django import forms
+from openedx.core.djangoapps.appsembler.sites.utils import make_amc_admin, reset_tokens
+
+
+class MakeAMCAdminForm(forms.Form):

--- a/openedx/core/djangoapps/appsembler/sites/forms.py
+++ b/openedx/core/djangoapps/appsembler/sites/forms.py
@@ -2,7 +2,10 @@
 Appsembler Sites Views.
 """
 from django import forms
-from openedx.core.djangoapps.appsembler.sites.utils import make_amc_admin, reset_tokens
 
 
 class MakeAMCAdminForm(forms.Form):
+    organization_name = forms.CharField(
+        required=True,
+        help_text='The name or short name of the organization',
+    )

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/make_amc_admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/make_amc_admin.py
@@ -3,7 +3,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from openedx.core.djangoapps.appsembler.sites.utils import reset_tokens, ensure_amc_site_admin
+from openedx.core.djangoapps.appsembler.sites.utils import make_amc_admin, reset_tokens
 
 
 log = logging.getLogger(__name__)
@@ -23,10 +23,10 @@ class Command(BaseCommand):
                             help='Username or email for the AMC admin.')
         parser.add_argument('-o', '--org',
                             action='store',
-                            dest='commit',
+                            dest='org',
                             help='The organization name or short name.')
 
-    def handle(self, user, org):
-        tokens = reset_tokens(user, org)
-        ensure_amc_site_admin(user, org)
+    def handle(self, *args, **options):
+        make_amc_admin(user=options['user'], org_name=options['org'])
+        tokens = reset_tokens(user=options['user'])
         self.stdout.write(json.dumps(tokens))

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/make_amc_admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/make_amc_admin.py
@@ -1,0 +1,32 @@
+import json
+import logging
+
+from django.core.management.base import BaseCommand
+
+from openedx.core.djangoapps.appsembler.sites.utils import reset_tokens, ensure_amc_site_admin
+
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        'Refresh both AMC access and refresh token, '
+        'make the user AMC site admin and print those tokens. '
+        'This command fixes the spinner issue.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('-u', '--user',
+                            action='store',
+                            dest='user',
+                            help='Username or email for the AMC admin.')
+        parser.add_argument('-o', '--org',
+                            action='store',
+                            dest='commit',
+                            help='The organization name or short name.')
+
+    def handle(self, user, org):
+        tokens = reset_tokens(user, org)
+        ensure_amc_site_admin(user, org)
+        self.stdout.write(json.dumps(tokens))

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/make_amc_admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/make_amc_admin.py
@@ -1,9 +1,11 @@
 import json
 import logging
 
+from django.db.models.query import Q
+from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
-from openedx.core.djangoapps.appsembler.sites.utils import make_amc_admin, reset_tokens
+from openedx.core.djangoapps.appsembler.sites.utils import make_amc_admin
 
 
 log = logging.getLogger(__name__)
@@ -21,12 +23,13 @@ class Command(BaseCommand):
                             action='store',
                             dest='user',
                             help='Username or email for the AMC admin.')
+
         parser.add_argument('-o', '--org',
                             action='store',
                             dest='org',
                             help='The organization name or short name.')
 
     def handle(self, *args, **options):
-        make_amc_admin(user=options['user'], org_name=options['org'])
-        tokens = reset_tokens(user=options['user'])
-        self.stdout.write(json.dumps(tokens))
+        user = User.objects.get(Q(email=options['user']) | Q(username=options['user']))
+        details = make_amc_admin(user=user, org_name=options['org'])
+        self.stdout.write(json.dumps(details))

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -46,7 +46,10 @@ def reset_tokens(username):
     Create and return new tokens, or extend existing ones to one year in the future.
     """
     client = Client.objects.get(url=settings.FEATURES['AMC_APP_URL'])
-    user = User.objects.get(Q(email=username) | Q(username=username))
+    if isinstance(username, User):
+        user = username
+    else:
+        user = User.objects.get(Q(email=username) | Q(username=username))
 
     try:
         access = AccessToken.objects.get(user=user, client=client)
@@ -85,7 +88,10 @@ def make_amc_admin(username, org_name):
       - Reset access and reset tokens, and set the expire one year ahead.
       - Return the recent tokens.
     """
-    user = User.objects.get(Q(email=username) | Q(username=username))
+    if isinstance(username, User):
+        user = username
+    else:
+        user = User.objects.get(Q(email=username) | Q(username=username))
     org = get_organization_by_name(org_name)
     site = get_site_by_organization(org)
 


### PR DESCRIPTION
This is an admin view (and a django shell command) for superusers to allow CSMs to make a user an AMC admin for an organization and its site, while showing those access and refresh tokens for CSMs to copy to AMC.

This is a hacky feature that has a lot of assumptions with not much bailout (except by failing with 500 error):

 - An organization should have one, and only one site.
 - There's only one access token for the AMC OAuth2 Client.
 - Only one refresh token for that.
 - Superusers will not just set users to be admins, except for those who are legit users.

The architecture of this view is largely guided by this tutorial:

 - [How to Add Custom Action Buttons to Django Admin
](https://medium.com/@hakibenita/how-to-add-custom-action-buttons-to-django-admin-8d266f5b0d41)


### TODO

 - [x] Basic implementation
 - [ ] Tests
 - [ ] Manual testing

### Reviewers

Please do check it out, and let me know what do you think. I need:

 - [x] One light review (@thraxil, perhaps) 
 - [x] Another more extensive one, from @melvinsoft.

Please indicate which one you have done, as we will probably add more of those custom pages in the future for CSMs.