### PR TITLE
Add webpack loader to avoid breaking devstacks wihtout figures

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -10,3 +10,4 @@ psycopg2==2.6.2
 django-compat==1.0.14
 django-hijack==2.1.4
 django-hijack-admin==2.1.4
+django-webpack-loader==0.4.1


### PR DESCRIPTION
Because #306 add `webpack` to [`INSTALLED_APPS` but not to requirements](https://github.com/appsembler/edx-platform/pull/306/files#diff-25244ba395948c2657a1dacb8853c16dR157).