### PR TITLE
Use the AMC user email instead of the logged admin

### DIFF
--- a/common/templates/admin/user/make_amc_admin_action.html
+++ b/common/templates/admin/user/make_amc_admin_action.html
@@ -69,7 +69,7 @@
 
                 <div class="form-row">
                     <label>Locate user in AMC Admin</label>
-                    <a target="_blank" class="button" href="{{ amc_app_url }}{% url 'admin:auth_user_changelist' %}?q={{ user.email | urlencode }}">
+                    <a target="_blank" class="button" href="{{ amc_app_url }}{% url 'admin:auth_user_changelist' %}?q={{ amc_user.email | urlencode }}">
                         Locate user in AMC Admin (new window)
                     </a>
                 </div>


### PR DESCRIPTION
Should match what's the input above `<input id="amc_email" readonly value="{{ amc_user.email }}" />`.

It's currently not doing that, because I wrote the wrong variable.