### PR TITLE
fix: Host poisoning vulnerability in appsembler_api

### DIFF
--- a/lms/djangoapps/appsembler_api/utils.py
+++ b/lms/djangoapps/appsembler_api/utils.py
@@ -38,7 +38,6 @@ def send_activation_email(request):
             from_email=configuration_helpers.get_value(
                 'email_from_address', settings.DEFAULT_FROM_EMAIL),
             request=request,
-            domain_override=request.get_host(),
             subject_template_name='appsembler_api/set_password_subject.txt',
             email_template_name='appsembler_api/set_password_email.html')
         return True


### PR DESCRIPTION
Edx did a Host poisoning vulnerability fix [#15781](https://github.com/edx/edx-platform/pull/15781/files) and we already have that merge in our Ginkgo code

```
git log --grep="Host poisoning vulnerability fix"
commit 37052afe316f14c61ab5c799434e4610b9d2d912 (tag: open-release/ginkgo.1)
Merge: 83ebc23198 ea5ac4988a
Author: Ned Batchelder <ned@nedbatchelder.com>
Date:   Thu Aug 10 10:36:20 2017 -0400

    Merge pull request #15781 from edx/nedbat/learner-2172-ginkgo

    Host poisoning vulnerability fix

commit ea5ac4988a7feff11a7580f396e6a8cd1f4bee78
Author: Ahsan Ulhaq <ahsan.haq@arbisoft.com>
Date:   Wed Aug 9 10:52:59 2017 -0400

    Host poisoning vulnerability fix

    LEARNER-2172

    Applied as a patch from pull #15773 by @nedbat

    (cherry picked from commit 4201a3150295cf459c0fbe4d19061f2b0e28d4a3)
```

in Appsembler Api we were still using  `domain_override` in `PasswordResetFormNoActive` i did delete it to prevent [unexpected keyword argument 'domain_override'](https://sentry.io/organizations/appsembler/issues/931051478/?project=1275506&query=is%3Aunresolved&statsPeriod=14d&utc=true)