### PR TITLE
Fixes for the trial experience and theme

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/apps.py
+++ b/openedx/core/djangoapps/appsembler/settings/apps.py
@@ -20,6 +20,7 @@ class SettingsConfig(AppConfig):
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: u'settings.common'},
                 SettingsType.AWS: {PluginSettings.RELATIVE_PATH: u'settings.aws_lms'},
                 SettingsType.DEVSTACK: {PluginSettings.RELATIVE_PATH: u'settings.devstack_lms'},
+                SettingsType.TEST: {PluginSettings.RELATIVE_PATH: u'settings.test_lms'},
             },
             ProjectType.CMS: {
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: u'settings.common'},

--- a/openedx/core/djangoapps/appsembler/settings/settings/test_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/test_lms.py
@@ -1,0 +1,10 @@
+"""
+Settings for Appsembler on test/LMS.
+"""
+
+
+def plugin_settings(settings):
+    """
+    Appsembler LMS overrides for testing environment.
+    """
+    settings.USE_S3_FOR_CUSTOMER_THEMES = False

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -32,15 +32,9 @@ def get_initial_sass_variables():
     This method loads the SASS variables file from the currently active theme. It is used as a default value
     for the sass_variables field on new Microsite objects.
     """
-    try:
-        values = get_branding_values_from_file()
-        labels = get_branding_labels_from_file()
-        return [(val[0], (val[1], lab[1])) for val, lab in izip(values, labels)]
-    except Exception as e:
-        # most likely, `edx-theme-codebase` just isn't installed
-        # this is a temporary fix for the hawthorn deploy. once we have
-        # themes back in, this should be removed
-        return []
+    values = get_branding_values_from_file()
+    labels = get_branding_labels_from_file()
+    return [(val[0], (val[1], lab[1])) for val, lab in izip(values, labels)]
 
 
 def get_branding_values_from_file():

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -1,0 +1,57 @@
+"""
+Tests for site configuration's Tahoe customizations.
+"""
+from mock import patch
+import unittest
+
+from django.test import TestCase
+from django.db import IntegrityError, transaction
+from django.contrib.sites.models import Site
+from django.test.utils import override_settings
+
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
+
+
+# TODO: This is an integration test, try to make it less so and more of a unit-test.
+@override_settings(
+    COMPREHENSIVE_THEME_DIRS=['/edx/src/themes'],
+    ENABLE_COMPREHENSIVE_THEMING=True,
+    DEFAULT_SITE_THEME='edx-theme-codebase',
+)
+class SiteConfigurationTests(TestCase):
+    """
+    Tests for SiteConfiguration and its signals/receivers.
+    """
+    domain = 'example-site.tahoe.appsembler.com'
+    name = 'Example Tahoe Site'
+
+    test_config = {
+        "university": "Tahoe University",
+        "platform_name": name,
+        "SITE_NAME": domain,
+        "course_org_filter": "TahoeX",
+        "css_overrides_file": "test/css/{domain}.css".format(domain=domain),
+        "ENABLE_MKTG_SITE": False,
+        "ENABLE_THIRD_PARTY_AUTH": False,
+        "course_about_show_social_links": False,
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        super(SiteConfigurationTests, cls).setUpClass()
+        cls.site, _ = Site.objects.get_or_create(
+            domain=cls.test_config['SITE_NAME'],
+            name=cls.test_config['SITE_NAME'],
+        )
+
+    def test_site_configuration_compile_sass(self):
+        """
+        Test that and entry is added to SiteConfigurationHistory model each time a new
+        SiteConfiguration is added.
+        """
+        # add SiteConfiguration to database
+        site_configuration = SiteConfigurationFactory.build(
+            site=self.site,
+        )
+
+        site_configuration.save()


### PR DESCRIPTION
So, this is a pretty tricky test to write and maintain, since it depends on having the `edx-theme-codebase` installed an configured on devstack. Which isn't ideal for testing purposes on a CI server.

I think it's better than the alternative method, which is to mindlessly click through the whole trail process just to see if the bug exists or not.

Make sure to review the theme PR (https://github.com/appsembler/edx-theme-customers/pull/68)  that actually fixes the issue, this pull request includes only tests.