### PR TITLE
Create app config for Tahoe registration API

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/__init__.py
+++ b/openedx/core/djangoapps/appsembler/api/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'openedx.core.djangoapps.appsembler.api.apps.TahoeAPIConfig'

--- a/openedx/core/djangoapps/appsembler/api/apps.py
+++ b/openedx/core/djangoapps/appsembler/api/apps.py
@@ -1,0 +1,12 @@
+"""
+Configuration for the openedx.core.djangoapps.appsembler.api Django app.
+"""
+from django.apps import AppConfig
+
+
+class TahoeAPIConfig(AppConfig):
+    """
+    Configuration class for the Tahoe API Django app.
+    """
+    name = 'openedx.core.djangoapps.appsembler.api'
+    label = 'tahoe.api'


### PR DESCRIPTION
This should solve the current "Internal Server Error" in Studio. It's an app name conflict.