### PR TITLE
chore: enable Indonesian language

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -41,7 +41,7 @@ locales:
     # - hr  # Croatian
     # - hu  # Hungarian
     # - hy_AM  # Armenian (Armenia)
-    # - id  # Indonesian
+    - id  # Indonesian
     # - it_IT  # Italian (Italy)
     # - ja_JP  # Japanese (Japan)
     # - kk_KZ  # Kazakh (Kazakhstan)


### PR DESCRIPTION
Enabling the Indonesian language for Eucalyptus version (DHIS2 request)