### PR TITLE
Hawthorn fixes for course creator group in devstack

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
@@ -26,6 +26,7 @@ def plugin_settings(settings):
     # Those are usually hardcoded in devstack.py for some reason
     settings.LMS_BASE = settings.ENV_TOKENS.get('LMS_BASE')
     settings.LMS_ROOT_URL = settings.ENV_TOKENS.get('LMS_ROOT_URL')
+    settings.FEATURES['ENABLE_CREATOR_GROUP'] = settings.ENV_TOKENS['FEATURES'].get('ENABLE_CREATOR_GROUP', False)
 
     settings.MIDDLEWARE_CLASSES += (
         'organizations.middleware.OrganizationMiddleware',


### PR DESCRIPTION
Finally fixing [When I login to Studio, my user does not have permissions to create a course, only a library](https://trello.com/c/ZoR6er0f).

Read more about the courses in [MIT Open edX docs](https://github.com/Livit/Livit.Learn.EdX/wiki/Controlling-course-creation-rights).