### PR TITLE
Fix course creator role for AMC users

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -98,7 +98,7 @@ from student.models import (
     create_comments_service_user,
     email_exists_or_retired,
 )
-from student.roles import CourseCreatorRole
+from student.roles import CourseAccessRole, CourseCreatorRole
 from student.signals import REFUND_ORDER
 from student.tasks import send_activation_email
 from student.text_me_the_app import TextMeTheAppFragmentView
@@ -724,7 +724,7 @@ def create_account_with_params(request, params):
         if 'registered_from_amc' in params:
             from cms.djangoapps.course_creators.models import CourseCreator
             CourseCreator.objects.update_or_create(user=user, defaults={'state': CourseCreator.GRANTED})
-            CourseCreatorRole().add_users(user)
+            CourseAccessRole.objects.create(user=user, role=CourseCreatorRole.ROLE, course_id=None, org='')
         # APPSEMBLER SPECIFIC END
 
         if do_external_auth:


### PR DESCRIPTION
For whatever reason `CourseCreatorRole().add_users(user)` doesn't work and I have to create the database entry manually via the underlying `CourseAccessRole` model.

It doesn't make a lot of sense, but it's an outstanding bug in staging that's also reproducible in devstack.

I debugged the issue, but couldn't find the root cause among the following lines:

```python
@register_access_role
class CourseCreatorRole(RoleBase):
    """
    This is the group of people who have permission to create new courses (we may want to eventually
    make this an org based role).
    """
    ROLE = "course_creator_group"

    def __init__(self, *args, **kwargs):
        super(CourseCreatorRole, self).__init__(self.ROLE, *args, **kwargs)

...

class RoleBase(AccessRole):
    """
    Roles by type (e.g., instructor, beta_user) and optionally org, course_key
    """
    ...
    def add_users(self, *users):
        """
        Add the supplied django users to this role.
        """
        # silently ignores anonymous and inactive users so that any that are
        # legit get updated.
        from student.models import CourseAccessRole
        for user in users:
            if user.is_authenticated and user.is_active and not self.has_user(user):
                entry = CourseAccessRole(user=user, role=self._role_name, course_id=self.course_key, org=self.org)
                entry.save()
                if hasattr(user, '_roles'):
                    del user._roles
```