### PR TITLE
Use Celery task for cert award on passing grade, same as Ginkgo

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -963,6 +963,10 @@ INSTALLED_APPS = (
     # Unusual migrations
     'database_fixups',
 
+    # Customized celery tasks, including persisting failed tasks so they can
+    # be retried
+    'celery_utils',
+
     # Appsembler API Extensions
     'rest_framework',
     'rest_framework.authtoken',

--- a/lms/djangoapps/certificates/tasks.py
+++ b/lms/djangoapps/certificates/tasks.py
@@ -1,0 +1,28 @@
+from celery import task
+from logging import getLogger
+
+from celery_utils.logged_task import LoggedTask
+from celery_utils.persist_on_failure import PersistOnFailureTask
+
+logger = getLogger(__name__)
+
+
+class _BaseCertificateTask(PersistOnFailureTask, LoggedTask):  # pylint: disable=abstract-method
+    """
+    Include persistence features, as well as logging of task invocation.
+    """
+    abstract = True
+
+
+@task(base=_BaseCertificateTask)
+def generate_certificate(**kwargs):
+    """
+    Generates a certificate for a single user.
+    """
+    # need to delay import
+    from .api import generate_user_certificates
+
+    student = kwargs.pop('student')
+    course_key = kwargs.pop('course_key')
+    generate_user_certificates(student=student, course_key=course_key, **kwargs)
+

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -1,9 +1,16 @@
 """ Unit tests for enabling self-generated certificates by default
 for self-paced courses.
 """
+import mock
+
 from certificates import api as certs_api
+from certificates.config import waffle
 from certificates.models import CertificateGenerationConfiguration
 from certificates.signals import _listen_for_course_publish
+from certificates.tasks import generate_certificate
+from lms.djangoapps.course_blocks.api import get_course_blocks
+from lms.djangoapps.grades.new.course_grade import CourseGradeFactory
+from lms.djangoapps.grades.tests.utils import mock_get_score
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -40,6 +47,7 @@ class PassingGradeCertsTest(ModuleStoreTestCase):
         super(PassingGradeCertsTest, self).setUp()
         self.course = CourseFactory.create(self_paced=True)
         self.user = UserFactory.create()
+        self.course_structure = get_course_blocks(self.user, self.course.location)
         self.enrollment = CourseEnrollmentFactory(
             user=self.user,
             course_id=self.course.id,
@@ -56,20 +64,20 @@ class PassingGradeCertsTest(ModuleStoreTestCase):
             with waffle.waffle().override(waffle.SELF_PACED_ONLY, active=True):
                 grade_factory = CourseGradeFactory()
                 with mock_get_score(0, 2):
-                    grade_factory.update(self.user, self.course)
+                    grade_factory.update(self.user, self.course, self.course_structure)
                     mock_generate_certificate_apply_async.assert_not_called(
                         student=self.user,
                         course_key=self.course.id
                     )
                 with mock_get_score(1, 2):
-                    grade_factory.update(self.user, self.course)
+                    grade_factory.update(self.user, self.course, self.course_structure)
                     mock_generate_certificate_apply_async.assert_called(
                         student=self.user,
                         course_key=self.course.id
                     )
                 # Certs are not re-fired after passing
                 with mock_get_score(2, 2):
-                    grade_factory.update(self.user, self.course)
+                    grade_factory.update(self.user, self.course, self.course_structure)
                     mock_generate_certificate_apply_async.assert_not_called(
                         student=self.user,
                         course_key=self.course.id

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2156,6 +2156,10 @@ INSTALLED_APPS = (
     # additional release utilities to ease automation
     'release_util',
 
+    # Customized celery tasks, including persisting failed tasks so they can
+    # be retried
+    'celery_utils',
+
     # Unusual migrations
     'database_fixups',
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -43,6 +43,7 @@ django==1.8.18
 djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.2.1
+edx-celeryutils==0.2.4
 edx-drf-extensions==1.2.2
 edx-i18n-tools==0.3.7
 edx-lint==0.4.3


### PR DESCRIPTION
This is more manual patching from Ginkgo.  Previously in backporting the feature, I avoided any changes requiring additional Python requirements, but since there are some strange behaviors on JFrog (the only customer implementation), I decided to bring in the rest of the related changes:

* previous backport from Ginkgo did not use async task and this may have been causing some failures for JFrog)
* requires installing new requirements

I ran the full LMS system tests and while there are still a lot of ERRORs that make trusting the tests a bit difficult, I fixed all of those related to Appsembler features in #358 , reran and paid close attention to the certificates, student, and courseware apps, which should be affected by these changes, and no relevant tests seem to be erroring on failing.  

I also fixed some tests in `certificates.tests.test_signals` which were likely broken in Ficus anyhow.

This may or may not fix the inconsistent behavior on JFrog (sometimes the auto-cert award works, sometimes it doesn't) but at least it shouldn't hurt, and brings the backport code quite close to the original Ginkgo code.
