### PR TITLE
Fix /media/ redirects on devstack

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
@@ -32,3 +32,7 @@ def plugin_settings(settings):
         customer_themes_dir = path.join(settings.COMPREHENSIVE_THEME_DIRS[0], 'customer_themes')
         if path.isdir(customer_themes_dir):
             settings.STATICFILES_DIRS.insert(0, customer_themes_dir)
+
+    # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
+    # from the redirect mechanics.
+    settings.MAIN_SITE_REDIRECT_WHITELIST += ['/media/']


### PR DESCRIPTION
Trello Card: ![](https://github.trello.services/images/mini-trello-icon.png) [[Bug] Tahoe Hawthorn Devstack - static assets issues](https://trello.com/c/gUKVLaEB/3874-bug-tahoe-hawthorn-devstack-static-assets-issues)


Example of the issue:
- when a logo is uploaded in Tahoe Dashboard, it appears on the LMS. However it does not display in Tahoe Dashboard (console says 404 on that static asset, even though it is there).
- when Devstack is restarted, the same static asset also breaks in LMS (header logo in this example)

Importance: this is a critical bug as we can't really properly test in local dev environment, nor continue with some planned feature building.