### PR TITLE
Change certification setting check to config helper

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -497,7 +497,7 @@ def render_html_view(request, user_id, course_id):
     configuration = CertificateHtmlViewConfiguration.get_config()
 
     # Kick the user back to the "Invalid" screen if the feature is disabled globally
-    if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
+    if not configuration_helpers.get_value('CERTIFICATES_HTML_VIEW', False):
         return _render_invalid_certificate(course_id, platform_name, configuration)
 
     # Load the course and user objects


### PR DESCRIPTION
This check must be microsite aware. Currently is checking the setting right directly, avoiding the site configuration. 