### PR TITLE
cherrypick Ginkgo version change on django-celery and edx-celeryutils

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,7 +16,7 @@ dealer==2.0.4
 defusedxml==0.4.1
 django-babel-underscore==0.5.1
 markey==0.8  # From django-babel-underscore
-django-celery==3.1.16
+django-celery==3.2.1
 django-config-models==0.1.3
 django-countries==4.0
 django-extensions==1.5.9
@@ -43,7 +43,7 @@ django==1.8.18
 djangorestframework-jwt==1.8.0
 djangorestframework-oauth==1.1.0
 edx-ccx-keys==0.2.1
-edx-celeryutils==0.2.4
+edx-celeryutils==0.2.2
 edx-drf-extensions==1.2.2
 edx-i18n-tools==0.3.7
 edx-lint==0.4.3


### PR DESCRIPTION
Previously I had only manually updated the versions, but django-celery was still at an earlier version using South migrations and broke migration.  

It's possible that `--fake-initial` will have to be run on djcelery `manage.py lms migrate djcelery --fake-initial`