### PR TITLE
modify signal to create CertificateGenerationCourseSetting on course publish

### DIFF
--- a/openedx/core/djangoapps/appsembler/html_certificates/signals.py
+++ b/openedx/core/djangoapps/appsembler/html_certificates/signals.py
@@ -14,10 +14,16 @@ from course_modes.models import CourseMode
 def set_default_mode_on_course_publish(sender, course_key, **kwargs):  # pylint: disable=unused-argument
     """
     Catches the signal that a course has been published in Studio and
-    creates a CourseMode in the default mode
+    creates a CourseMode in the default mode and it also creates a
+    CertificateGenerationCourseSetting for the course, to allow self generation.
     """
     default_mode, created = CourseMode.objects.get_or_create(
         course_id=course_key,
         mode_slug=settings.DEFAULT_COURSE_MODE_SLUG,
         mode_display_name=settings.DEFAULT_MODE_NAME_FROM_SLUG
+    )
+    from lms.djangoapps.certificates.models import CertificateGenerationCourseSetting  # Importing locally to avoid potential cross-system import issues
+    CertificateGenerationCourseSetting.set_self_generatation_enabled_for_course(
+        course_key,
+        True
     )


### PR DESCRIPTION
This signal was introduced by us in Ficus. Since customers doesn't have access to Django Admin to create those configs, we create them automatically when a course is created.

In Hawthorne a new model is introduced: `CertificateGenerationCourseSetting` each course needs this configuration in order to allow cert gen certificates. This PRs adds the ability to create that model on Course creation too. 