### PR TITLE
Fix broken LMS static build in devstack

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
@@ -1,7 +1,8 @@
 """
 Settings for Appsembler on devstack, both LMS and CMS.
 """
-
+from __future__ import print_function
+import sys
 
 def plugin_settings(settings):
     """
@@ -14,7 +15,7 @@ def plugin_settings(settings):
 
     # Disable caching in dev environment
     if not settings.FEATURES.get('ENABLE_DEVSTACK_CACHES', False):
-        print('\nDISABLING CACHES...')
+        print('\nAppsembler: disabling devstack caches\n', file=sys.stderr)
         for cache_key in settings.CACHES.keys():
             if cache_key != 'celery':  # NOTE: Disabling cache breaks things like Celery subtasks
                 settings.CACHES[cache_key]['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'


### PR DESCRIPTION
### TL;DR
This to fix a devstack error that @johnbaldwin [reported](https://github.com/appsembler/devstack/pull/10#discussion_r277193813) in https://github.com/appsembler/devstack/pull/10. The devstack does _not_ expect debug information to be printed to `stdout` when making `$ make lms-static` in `devstack`.

### [The Reported Error](https://github.com/appsembler/devstack/pull/10#discussion_r277193813)
> I started with a new workspace. and cloned the devstack appsembler fork. Did not change branch (so branch is `hawthorn`)
> After cloning the appsembler devstack fork and cd'ing to that directory, I ran just the commands specified above
> 
> `make dev.clone` This seems to have worked fine
> 
> `make dev.provision` this seems to have worked well until here:
> 
> ```
> ---> pavelib.assets.webpack
> python manage.py lms --settings=devstack_docker print_setting STATIC_ROOT 2>/dev/null
> python manage.py cms --settings=devstack_docker print_setting STATIC_ROOT 2>/dev/null
> python manage.py lms --settings=devstack_docker print_setting WEBPACK_CONFIG_PATH 2>/dev/null
> NODE_ENV=development STATIC_ROOT_LMS=DISABLING CACHES...
> /edx/var/edxapp/staticfiles STATIC_ROOT_CMS=DISABLING CACHES...
> /edx/var/edxapp/staticfiles/studio $(npm bin)/webpack --config=DISABLING CACHES...
> webpack.dev.config.js
> /bin/sh: 1: CACHES...: not found
> /bin/sh: 2: /edx/var/edxapp/staticfiles: Permission denied
> /bin/sh: 3: /edx/var/edxapp/staticfiles/studio: Permission denied
> /bin/sh: 4: webpack.dev.config.js: not found
> 
> ...
> 
> Build failed running pavelib.assets.update_assets: Subprocess return code: 127
> make: *** [dev.provision.run] Error 1
> ```
