### PR TITLE
Update the deprecated idp_slug field for SAML API

### DIFF
--- a/openedx/core/djangoapps/appsembler/tpa_admin/serializers.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/serializers.py
@@ -35,7 +35,7 @@ class SAMLProviderConfigSerializer(serializers.ModelSerializer):
         model = SAMLProviderConfig
         fields = (
             'id', 'site', 'enabled', 'name', 'icon_class', 'icon_image', 'secondary', 'skip_registration_form',
-            'visible', 'skip_email_verification', 'idp_slug', 'entity_id', 'metadata_source', 'attr_user_permanent_id',
+            'visible', 'skip_email_verification', 'slug', 'entity_id', 'metadata_source', 'attr_user_permanent_id',
             'attr_full_name', 'attr_first_name', 'attr_last_name', 'attr_username', 'attr_email', 'other_settings',
             'metadata_ready'
         )


### PR DESCRIPTION
`idp_slug` has been renamed to `slug` https://github.com/edx/edx-platform/pull/17911 the API have become broken since it expects that field.

This pull request fixes that issue.

```
Error adding the identity provider:
ImproperlyConfigured at /appsembler/api/saml-providers-config/
Field name `idp_slug` is not valid for model `SAMLProviderConfig`.
Request Method: POST Request URL:
http://localhost:18000/appsembler/api/saml-providers-config/ 
Django Version: 1.11.15 
Python Executable: /edx/app/edxapp/venvs/edxapp/bin/python Python Version: 2.7.12 
Python Path:
   ['/edx/app/edxapp/edx-platform',
    '/edx/app/edxapp/venvs/edxapp/lib/python2.7',
    '/edx/app/edxapp/venvs/edxapp/lib/python2.7/plat-x86_64-linux-gnu',
    '/edx/app/edxapp/venvs/edxapp/lib/python2.7/lib-tk',
    '/edx/app/edxapp/venvs/edxapp/lib/python2.7/lib-old',
    '/edx/app/edxapp/venvs/edxapp/lib/python2.7/lib-dynload',
    '/usr/lib/python2.7',
    '/usr/lib/python2.7/plat-x86_64-linux-gnu',
    '/usr/lib/python2.7/lib-tk',
    '/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages',
    '/edx/app/edxapp/venvs/edxapp/src/acid-xblock',
    '/edx/app/edxapp/venvs/edxapp/src/code-block-timer',
    '/edx/app/edxapp/venvs/edxapp/src/codejail',
    ...
```