### PR TITLE
Appsembler/matej/change account settings content

### DIFF
--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -38,6 +38,13 @@ export class StudentAccountDeletion extends React.Component {
 
   render() {
     const { deletionModalOpen, socialAuthConnected, isActive } = this.state;
+    const appsemblerAccountRemovalText = StringUtils.interpolate(
+      gettext('If you require your account on this site to be deleted, please submit a request via email to {htmlStart}account.deletions@appsembler.com{htmlEnd}. Please submit your request from the email address linked to your user account, and in the email body, include any other profile details you wish to share to enable us to verify your identity, as well as clearly stating that you wish for your account to be deleted. We will endeavor to action your request within 30 days, and intend to further automate this process in the future for a more immediate response. There is no way to undo this request once it has been actioned, and should only be undertaken if absolutely necessary.'),
+      {
+        htmlStart: '<a href="mailto:account.deletions@appsembler.com">',
+        htmlEnd: '</a>',
+      },
+    )
     const loseAccessText = StringUtils.interpolate(
       gettext('You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for {htmlStart}printing or downloading a certificate{htmlEnd}.'),
       {
@@ -67,8 +74,10 @@ export class StudentAccountDeletion extends React.Component {
     return (
       <div className="account-deletion-details">
         <p className="account-settings-header-subtitle">{ gettext('We’re sorry to see you go!') }</p>
-        <p className="account-settings-header-subtitle">{ gettext('Please note: Deletion of your account and personal data is permanent and cannot be undone. EdX will not be able to recover your account or the data that is deleted.') }</p>
-        <p className="account-settings-header-subtitle">{ gettext('Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</p>
+        <p
+          className="account-settings-header-subtitle"
+          dangerouslySetInnerHTML={{ __html: appsemblerAccountRemovalText }}
+        />
         <p
           className="account-settings-header-subtitle"
           dangerouslySetInnerHTML={{ __html: loseAccessText }}

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -35,7 +35,7 @@ def validate_social_link(platform_name, new_social_link):
         required_url_stub = settings.SOCIAL_PLATFORMS[platform_name]['url_stub']
         raise ValueError(_(
             ' Make sure that you are providing a valid username or a URL that contains "' +
-            required_url_stub + '". To remove the link from your edX profile, leave this field blank.'
+            required_url_stub + '". To remove the link from your profile, leave this field blank.'
         ))
 
 


### PR DESCRIPTION
This is a quick and dirty fix for the issue where we had content in Account Settings page that we wanted to change. Since this is a ReactJS powered view, we cannot override it using the theme (at this moment).
Related Trello card: https://trello.com/c/Zdgzvgha/4057-delete-my-account-replace-current-content-with-a-message-allowing-learner-to-request-account-deletion