### PR TITLE
Tahoe: Use early_with_info as default certs display behaviour

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -483,7 +483,9 @@ class CourseFields(object):
             "soon as certificates are generated, enter early_no_info."
         ),
         scope=Scope.settings,
-        default="end"
+        # Appsembler: Defaulting to "early_with_info" rather than edX's "end" to match customers needs
+        # More info on: https://trello.com/c/bi7J0a4z
+        default="early_with_info",
     )
     course_image = String(
         display_name=_("Course About Page Image"),


### PR DESCRIPTION
It's suspiciously straightforward, it also works for the old courses since the `default` works for any unset value.

It's too good to be true, but let's try it.

Here's a screenshot from an old course on my devstack:

![image](https://user-images.githubusercontent.com/645156/57866665-60c36380-7808-11e9-978a-19e46c4071e1.png)


All I have now is :man_shrugging: 