### PR TITLE
Backport ORA Instructor dashboard to Ficus

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -321,6 +321,30 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         # Max number of student per page is one.  Patched setting MAX_STUDENTS_PER_PAGE_GRADE_BOOK = 1
         self.assertEqual(len(response.mako_context['students']), 1)  # pylint: disable=no-member
 
+    def test_open_response_assessment_page(self):
+        """
+        Test that Open Responses is available only if course contains at least one ORA block
+        """
+        ora_section = (
+            '<li class="nav-item">'
+            '<button type="button" class="btn-link" data-section="open_response_assessment">'
+            'Open Responses'
+            '</button>'
+            '</li>'
+        )
+
+        response = self.client.get(self.url)
+        self.assertNotIn(ora_section, response.content)
+
+        course = ItemFactory.create(
+            parent_location=self.course.location,
+            category="course",
+            display_name="Test course",
+        )
+        ItemFactory.create(parent_location=course.location, category="openassessment")
+        response = self.client.get(self.url)
+        self.assertIn(ora_section, response.content)
+
 
 @ddt.ddt
 class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTestCase, XssTestMixin):

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -336,14 +336,27 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
         self.assertNotIn(ora_section, response.content)
 
-        course = ItemFactory.create(
-            parent_location=self.course.location,
-            category="course",
-            display_name="Test course",
-        )
-        ItemFactory.create(parent_location=course.location, category="openassessment")
+        ItemFactory.create(parent_location=self.course.location, category="openassessment")
         response = self.client.get(self.url)
         self.assertIn(ora_section, response.content)
+
+    def test_open_response_assessment_page_orphan(self):
+        """
+        Tests that the open responses tab loads if the course contains an
+        orphaned openassessment block
+        """
+        # create non-orphaned openassessment block
+        ItemFactory.create(
+            parent_location=self.course.location,
+            category="openassessment",
+        )
+        # create orphan
+        self.store.create_item(
+            self.user.id, self.course.id, 'openassessment', "orphan"
+        )
+        response = self.client.get(self.url)
+        # assert we don't get a 500 error
+        self.assertEqual(200, response.status_code)
 
 
 @ddt.ddt

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -191,7 +191,13 @@ def instructor_dashboard_2(request, course_id):
     if certs_enabled and access['admin']:
         sections.append(_section_certificates(course))
 
-    openassessment_blocks = modulestore().get_items(course_key, qualifiers={'category': 'openassessment'})
+    openassessment_blocks = modulestore().get_items(
+        course_key, qualifiers={'category': 'openassessment'}
+    )
+    # filter out orphaned openassessment blocks
+    openassessment_blocks = [
+        block for block in openassessment_blocks if block.parent is not None
+    ]
     if len(openassessment_blocks) > 0:
         sections.append(_section_open_response_assessment(request, course, openassessment_blocks, access))
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -38,6 +38,7 @@ from student.models import CourseEnrollment
 from shoppingcart.models import Coupon, PaidCourseRegistration, CourseRegCodeItem
 from course_modes.models import CourseMode, CourseModesArchive
 from student.roles import CourseFinanceAdminRole, CourseSalesAdminRole
+from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from certificates.models import (
     CertificateGenerationConfiguration,
     CertificateWhitelist,
@@ -189,6 +190,10 @@ def instructor_dashboard_2(request, course_id):
     certs_enabled = CertificateGenerationConfiguration.current().enabled and not hasattr(course_key, 'ccx')
     if certs_enabled and access['admin']:
         sections.append(_section_certificates(course))
+
+    openassessment_blocks = modulestore().get_items(course_key, qualifiers={'category': 'openassessment'})
+    if len(openassessment_blocks) > 0:
+        sections.append(_section_open_response_assessment(request, course, openassessment_blocks, access))
 
     disable_buttons = not _is_small_course(course_key)
 
@@ -690,3 +695,55 @@ def _section_metrics(course, access):
         'post_metrics_data_csv_url': reverse('post_metrics_data_csv'),
     }
     return section_data
+
+
+def _section_open_response_assessment(request, course, openassessment_blocks, access):
+    """Provide data for the corresponding dashboard section """
+    course_key = course.id
+
+    ora_items = []
+    parents = {}
+
+    for block in openassessment_blocks:
+        block_parent_id = unicode(block.parent)
+        result_item_id = unicode(block.location)
+        if block_parent_id not in parents:
+            parents[block_parent_id] = modulestore().get_item(block.parent)
+
+        ora_items.append({
+            'id': result_item_id,
+            'name': block.display_name,
+            'parent_id': block_parent_id,
+            'parent_name': parents[block_parent_id].display_name,
+            'staff_assessment': 'staff-assessment' in block.assessment_steps,
+            'url_base': reverse('xblock_view', args=[course.id, block.location, 'student_view']),
+            'url_grade_available_responses': reverse('xblock_view', args=[course.id, block.location,
+                                                                          'grade_available_responses_view']),
+        })
+
+    openassessment_block = openassessment_blocks[0]
+    block, __ = get_module_by_usage_id(
+        request, unicode(course_key), unicode(openassessment_block.location),
+        disable_staff_debug_info=True, course=course
+    )
+    section_data = {
+        'fragment': block.render('ora_blocks_listing_view', context={
+            'ora_items': ora_items,
+            'ora_item_view_enabled': settings.FEATURES.get('ENABLE_XBLOCK_VIEW_ENDPOINT', False)
+        }),
+        'section_key': 'open_response_assessment',
+        'section_display_name': _('Open Responses'),
+        'access': access,
+        'course_id': unicode(course_key),
+    }
+    return section_data
+
+
+def is_ecommerce_course(course_key):
+    """
+    Checks if the given course is an e-commerce course or not, by checking its SKU value from
+    CourseMode records for the course
+    """
+    sku_count = len([mode.sku for mode in CourseMode.modes_for_course(course_key) if mode.sku])
+    return sku_count > 0
+

--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -190,6 +190,9 @@ such that the value can be defined later than this assignment (file load order).
             }, {
                 constructor: window.InstructorDashboard.sections.Certificates,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#certificates')
+            }, {
+                constructor: window.InstructorDashboard.sections.OpenResponseAssessment,
+                $element: idashContent.find('.' + CSS_IDASH_SECTION + '#open_response_assessment')
             }
         ];
         if (edx.instructor_dashboard.proctoring !== void 0) {

--- a/lms/static/js/instructor_dashboard/open_response_assessment.js
+++ b/lms/static/js/instructor_dashboard/open_response_assessment.js
@@ -1,0 +1,40 @@
+/* globals _ */
+
+(function(_) {
+    'use strict';
+
+    var OpenResponseAssessment = (function() {
+        function OpenResponseAssessmentBlock($section) {
+            this.$section = $section;
+            this.$section.data('wrapper', this);
+        }
+
+        OpenResponseAssessmentBlock.prototype.onClickTitle = function() {
+            var block = this.$section.find('.open-response-assessment');
+            XBlock.initializeBlock($(block).find('.xblock')[0]);
+        };
+
+        return OpenResponseAssessmentBlock;
+    }());
+
+    if (typeof window.setup_debug === 'undefined') {
+        // eslint-disable-next-line no-unused-vars, camelcase
+        window.setup_debug = function(element_id, edit_link, staff_context) {
+            // stub function.
+        };
+    }
+
+    _.defaults(window, {
+        InstructorDashboard: {}
+    });
+
+    _.defaults(window.InstructorDashboard, {
+        sections: {}
+    });
+
+    _.defaults(window.InstructorDashboard.sections, {
+        OpenResponseAssessment: OpenResponseAssessment
+    });
+
+    this.OpenResponseAssessment = OpenResponseAssessment;
+}).call(this, _);

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1482,6 +1482,14 @@
   }
 }
 
+// view - student admin
+// --------------------
+.instructor-dashboard-wrapper-2 section.idash-section#open_response_assessment {
+  .open-response-assessment {
+    padding-top: 20px;
+  }
+}
+
 input[name="subject"] {
   width:600px;
 }

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -5,6 +5,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from openedx.core.djangolib.markup import HTML
 %>
 <%block name="bodyclass">view-in-course view-instructordash</%block>
 
@@ -63,6 +64,19 @@ from django.core.urlresolvers import reverse
   <script type="text/javascript" src="${static.url('js/views/notification.js')}"></script>
   <script type="text/javascript" src="${static.url('js/views/file_uploader.js')}"></script>
   <script type="text/javascript" src="${static.url('js/utils/animation.js')}"></script>
+  % for section_data in sections:
+    % if 'fragment' in section_data:
+      ${HTML(section_data['fragment'].head_html())}
+    % endif
+  % endfor
+</%block>
+
+<%block name="js_extra">
+  % for section_data in sections:
+    % if 'fragment' in section_data:
+      ${HTML(section_data['fragment'].foot_html())}
+    % endif
+  % endfor
 </%block>
 
 ## Include Underscore templates

--- a/lms/templates/instructor/instructor_dashboard_2/open_response_assessment.html
+++ b/lms/templates/instructor/instructor_dashboard_2/open_response_assessment.html
@@ -1,0 +1,6 @@
+<%page args="section_data" expression_filter="h"/>
+<%! from openedx.core.djangolib.markup import HTML %>
+
+<section class="open-response-assessment">
+    ${HTML(section_data['fragment'].body_html())}
+</section>


### PR DESCRIPTION
This brings the ORA Dashboard feature from Ginkgo back to Ficus.  Also adds styling fix from our Hawthorn branch so that the unit and assessment name appear.

TODO: 
- [x]  Make the Assessment name a link to the staff review view for the Asssessment  