### PR TITLE
Add Course Feedback tab to course tab defaults

### DIFF
--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -336,6 +336,7 @@ class CourseTabList(List):
             discussion_tab,
             CourseTab.load('wiki'),
             CourseTab.load('progress'),
+            CourseTab.load('course_feedback'),  # InterSystems addition
         ])
 
     @staticmethod


### PR DESCRIPTION
We have to hard-code this at this point, since course tab intialization doesn't get plugin tab types.