### PR TITLE
Disable heartbeat redirect

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
@@ -96,7 +96,7 @@ def plugin_settings(settings):
 
     # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
     # from the redirect mechanics.
-    settings.MAIN_SITE_REDIRECT_WHITELIST = ['api', 'admin', 'oauth', 'status']
+    settings.MAIN_SITE_REDIRECT_WHITELIST = ['api', 'admin', 'oauth', 'status', '/heartbeat']
 
     settings.USE_S3_FOR_CUSTOMER_THEMES = True
 


### PR DESCRIPTION
Simple and stupid. Makes https://tahoe.appsembler.com/heartbeat work.

I'm adding `/` prefix, inconsistently because I don't think that having such intrusive redirect check is OK.

Because `'/heartbeat' in request.path` is much "safer" than `'heartbeat' in request.path`