### PR TITLE
add command to re-index elasticsearch for all courses

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/management/commands/reindex_elasticsearch.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/reindex_elasticsearch.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User
+
+from contentstore.views.course import reindex_course_and_check_access
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+
+class Command(BaseCommand):
+    help = "Force re-index of elasticsearch for all courses"
+
+    def handle(self, *args, **options):
+        if not settings.ROOT_URLCONF == 'cms.urls':
+            raise CommandError('this command can only be run with the cms settings')
+        all_courses = CourseOverview.get_all_courses()
+        amc_admin = User.objects.get(username="amc")
+
+        for c in all_courses:
+            try:
+                reindex_course_and_check_access(c.id, amc_admin)
+            except Exception as e:
+                print('Error indexing course')
+                print(c.id)
+                print(e)

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/reindex_elasticsearch.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/reindex_elasticsearch.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if not settings.ROOT_URLCONF == 'cms.urls':
-            raise CommandError('this command can only be run with the cms settings')
+            raise CommandError('this command can only be run from within the CMS')
         all_courses = CourseOverview.get_all_courses()
         amc_admin = User.objects.get(username="amc")
 


### PR DESCRIPTION
Required after an upgrade. Converting this from Maxi's script pasted into a shell: https://gist.github.com/melvinsoft/86d4f478a3943bbc83094bd7cd084ab8

This needs to be run with `manage.py cms ...` and not the LMS config. Does anyone know of a convenient way to check that from within the command so it can bail and warn the user?