### PR TITLE
Fix badge award evidence code

### DIFF
--- a/lms/djangoapps/badges/admin.py
+++ b/lms/djangoapps/badges/admin.py
@@ -2,10 +2,11 @@
 Admin registration for Badge Models
 """
 from django.contrib import admin
-from badges.models import CourseCompleteImageConfiguration, CourseEventBadgesConfiguration, BadgeClass
+from badges.models import CourseCompleteImageConfiguration, CourseEventBadgesConfiguration, BadgeClass, BadgeAssertion
 from config_models.admin import ConfigurationModelAdmin
 
 admin.site.register(CourseCompleteImageConfiguration)
 admin.site.register(BadgeClass)
+admin.site.register(BadgeAssertion)
 # Use the standard Configuration Model Admin handler for this model.
 admin.site.register(CourseEventBadgesConfiguration, ConfigurationModelAdmin)

--- a/lms/djangoapps/badges/backends/badgr.py
+++ b/lms/djangoapps/badges/backends/badgr.py
@@ -156,11 +156,10 @@ class BadgrBackend(BadgeBackend):
             }
         )
 
-    def _create_assertion(self, badge_class, user, evidence):
+    def _create_assertion(self, badge_class, user, evidence=None):
         """
         Register an assertion with the Badgr server for a particular user for a specific class.
         """
-        evidence = None
         evidence_key = 'evidence_items' if self.api_ver == 'v1' else 'evidence'
         evidence_url_key = 'evidence_url' if self.api_ver == 'v1' else 'url'
         if evidence is not None:

--- a/lms/djangoapps/badges/backends/badgr.py
+++ b/lms/djangoapps/badges/backends/badgr.py
@@ -161,9 +161,12 @@ class BadgrBackend(BadgeBackend):
         Register an assertion with the Badgr server for a particular user for a specific class.
         """
         evidence_url_key = 'evidence_url' if self.api_ver == 'v1' else 'url'
-        evidence = [
-            {evidence_url_key: evidence_url}
-        ]
+        if evidence_url is not None:    
+            evidence = [
+                {evidence_url_key: evidence_url}
+            ]
+        else:
+            evidence = [{"narrative": badge_class.criteria}]
         if self.api_ver == 'v1':
             data = {
             'recipient_identifier': user.email,

--- a/lms/djangoapps/badges/backends/badgr.py
+++ b/lms/djangoapps/badges/backends/badgr.py
@@ -162,8 +162,10 @@ class BadgrBackend(BadgeBackend):
         """
         evidence_key = 'evidence_items' if self.api_ver == 'v1' else 'evidence'
         evidence_url_key = 'evidence_url' if self.api_ver == 'v1' else 'url'
+        data_keys = ((evidence_url_key, 'url'), ('narrative', 'narrative'))
         if evidence is not None:
-            evidence = [{evidence_url_key: e} for e in evidence]
+            evidence = [ dict( [(key[0], e.get(key[1])) for key in data_keys if e.get(key[1]) is not None]) for e in evidence]
+            # evidence = [{evidence_url_key: e.get('url', None), "narrative": e.get('narrative', None)} for e in evidence]
         # TODO: support narrative evidence defined as a BadgeClass field
         # i.e., evidence = [{"narrative": badge_class.evidence}]
         if self.api_ver == 'v1':
@@ -185,7 +187,7 @@ class BadgrBackend(BadgeBackend):
                 'notify': settings.BADGR_API_NOTIFICATIONS_ENABLED,
             }
         if evidence is not None:
-            data.update({evidence_key: evidence, })
+            data.update({evidence_key: evidence})
         response = requests.post(
             self._assertion_url(badge_class.slug), headers=self._get_headers(), json=data,
             timeout=settings.BADGR_TIMEOUT

--- a/lms/djangoapps/badges/backends/badgr.py
+++ b/lms/djangoapps/badges/backends/badgr.py
@@ -161,12 +161,13 @@ class BadgrBackend(BadgeBackend):
         Register an assertion with the Badgr server for a particular user for a specific class.
         """
         evidence_url_key = 'evidence_url' if self.api_ver == 'v1' else 'url'
-        if evidence_url is not None:    
-            evidence = [
-                {evidence_url_key: evidence_url}
-            ]
+        if evidence_url is not None:
+            if hasattr(evidence_url, '__iter__'):
+                evidence = [{evidence_url_key: e} for e in evidence_url]
+            else:
+                evidence = [{evidence_url_key: evidence_url}]
         else:
-            evidence = [{"narrative": badge_class.criteria}]
+            evidence = [{"narrative": ""}]
         if self.api_ver == 'v1':
             data = {
             'recipient_identifier': user.email,

--- a/lms/djangoapps/badges/backends/badgr.py
+++ b/lms/djangoapps/badges/backends/badgr.py
@@ -156,15 +156,15 @@ class BadgrBackend(BadgeBackend):
             }
         )
 
-    def _create_assertion(self, badge_class, user, evidence_url):
+    def _create_assertion(self, badge_class, user, evidence):
         """
         Register an assertion with the Badgr server for a particular user for a specific class.
         """
         evidence = None
         evidence_key = 'evidence_items' if self.api_ver == 'v1' else 'evidence'
         evidence_url_key = 'evidence_url' if self.api_ver == 'v1' else 'url'
-        if evidence_url is not None:
-            evidence = [{evidence_url_key: e} for e in evidence_url]
+        if evidence is not None:
+            evidence = [{evidence_url_key: e} for e in evidence]
         # TODO: support narrative evidence defined as a BadgeClass field
         # i.e., evidence = [{"narrative": badge_class.evidence}]
         if self.api_ver == 'v1':
@@ -248,9 +248,9 @@ class BadgrBackend(BadgeBackend):
             self._create_badge(badge_class)
         BadgrBackend.badges.append(slug)
 
-    def award(self, badge_class, user, evidence_url=None):
+    def award(self, badge_class, user, evidence=None):
         """
         Make sure the badge class has been created on the backend, and then award the badge class to the user.
         """
         self._ensure_badge_created(badge_class)
-        return self._create_assertion(badge_class, user, evidence_url)
+        return self._create_assertion(badge_class, user, evidence)

--- a/lms/djangoapps/badges/backends/badgr.py
+++ b/lms/djangoapps/badges/backends/badgr.py
@@ -160,35 +160,33 @@ class BadgrBackend(BadgeBackend):
         """
         Register an assertion with the Badgr server for a particular user for a specific class.
         """
+        evidence = None
+        evidence_key = 'evidence_items' if self.api_ver == 'v1' else 'evidence'
         evidence_url_key = 'evidence_url' if self.api_ver == 'v1' else 'url'
         if evidence_url is not None:
-            if hasattr(evidence_url, '__iter__'):
-                evidence = [{evidence_url_key: e} for e in evidence_url]
-            else:
-                evidence = [{evidence_url_key: evidence_url}]
-        else:
-            evidence = [{"narrative": ""}]
+            evidence = [{evidence_url_key: e} for e in evidence_url]
+        # TODO: support narrative evidence defined as a BadgeClass field
+        # i.e., evidence = [{"narrative": badge_class.evidence}]
         if self.api_ver == 'v1':
             data = {
-            'recipient_identifier': user.email,
-            'recipient_type': 'email',
-            'evidence_items': evidence,
-            'create_notification': settings.BADGR_API_NOTIFICATIONS_ENABLED,
-        }
+                'recipient_identifier': user.email,
+                'recipient_type': 'email',
+                'create_notification': settings.BADGR_API_NOTIFICATIONS_ENABLED,
+            }
         else:
             recipient = {
                 'identity': user.email,
                 'type': 'email',
             }
-
             # note that Badgr.io requires a notification on the first award to a given recipient
             # identifier to comply with GDPR, so that will be sent regardless of settings.
             # Subsequent awards will obey the notifications setting
             data = {
                 'recipient': recipient,
                 'notify': settings.BADGR_API_NOTIFICATIONS_ENABLED,
-                'evidence': evidence
             }
+        if evidence is not None:
+            data.update({evidence_key: evidence, })
         response = requests.post(
             self._assertion_url(badge_class.slug), headers=self._get_headers(), json=data,
             timeout=settings.BADGR_TIMEOUT

--- a/lms/djangoapps/badges/backends/base.py
+++ b/lms/djangoapps/badges/backends/base.py
@@ -11,7 +11,7 @@ class BadgeBackend(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def award(self, badge_class, user, evidence_url=None):
+    def award(self, badge_class, user, evidence=None):
         """
         Create a badge assertion for the user using this backend.
         """

--- a/lms/djangoapps/badges/events/course_meta.py
+++ b/lms/djangoapps/badges/events/course_meta.py
@@ -71,8 +71,9 @@ def course_group_check(user, course_key):
                 status__in=CertificateStatuses.PASSED_STATUSES,
                 course_id__in=keys,
             )
-            if len(certs) == len(keys):
-                evidence = [evidence_url(user.id, course_key) for course_key in keys]
+            # support overlapping badge award course groups
+            if len(certs) >= len(keys):
+                evidence = [evidence_url(user.id, key) for key in keys]
                 awards.append((slug, evidence))
 
     for award in awards:

--- a/lms/djangoapps/badges/events/course_meta.py
+++ b/lms/djangoapps/badges/events/course_meta.py
@@ -77,12 +77,8 @@ def course_group_check(user, course_key):
                 # so we use course groups with a single course,
                 # in which case we can provide an evidence URL
                 # to the HTML cert for the one coursee
-                if len(keys) == 1:
-                    evidence = evidence_url(user.id, course_key)
-                    awards.append((slug, evidence))
-                else:
-                    evidence = [evidence_url(user.id, course_key) for course_key in keys]
-                    awards.append((slug,))
+                evidence = [evidence_url(user.id, course_key) for course_key in keys]
+                awards.append((slug,))
 
     for award in awards:
         badge_class = BadgeClass.get_badge_class(

--- a/lms/djangoapps/badges/events/course_meta.py
+++ b/lms/djangoapps/badges/events/course_meta.py
@@ -81,6 +81,7 @@ def course_group_check(user, course_key):
                     evidence = evidence_url(user.id, course_key)
                     awards.append((slug, evidence))
                 else:
+                    evidence = [evidence_url(user.id, course_key) for course_key in keys]
                     awards.append((slug,))
 
     for award in awards:

--- a/lms/djangoapps/badges/events/course_meta.py
+++ b/lms/djangoapps/badges/events/course_meta.py
@@ -71,7 +71,7 @@ def course_group_check(user, course_key):
                 status__in=CertificateStatuses.PASSED_STATUSES,
                 course_id__in=keys,
             )
-            # support overlapping badge award course groups
+            # >= to support case with multiple certs per course (enrollment in multiple modes)
             if len(certs) >= len(keys):
                 evidence = [evidence_url(user.id, key) for key in keys]
                 awards.append((slug, evidence))

--- a/lms/djangoapps/badges/events/course_meta.py
+++ b/lms/djangoapps/badges/events/course_meta.py
@@ -3,12 +3,15 @@ Events which have to do with a user doing something with more than one course, s
 as enrolling in a certain number, completing a certain number, or completing a specific set of courses.
 """
 
+from django.conf import settings
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
 from badges.models import CourseEventBadgesConfiguration, BadgeClass
 from badges.utils import requires_badges_enabled
 from badges.events.course_complete import evidence_url
 
 
-def award_badge(config, count, user):
+def award_badge(config, count, user, evidence=None):
     """
     Given one of the configurations for enrollments or completions, award
     the appropriate badge if one is configured.
@@ -29,16 +32,20 @@ def award_badge(config, count, user):
     if not badge_class:
         return
     if not badge_class.get_for_user(user):
-        badge_class.award(user)
+        badge_class.award(user, evidence)
 
 
+@requires_badges_enabled
 def award_enrollment_badge(user):
     """
     Awards badges based on the number of courses a user is enrolled in.
     """
+    # TODO: award badges on >= number enrolled
     config = CourseEventBadgesConfiguration.current().enrolled_settings
     enrollments = user.courseenrollment_set.filter(is_active=True).count()
-    award_badge(config, enrollments, user)
+    platform = configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+    evidence = [{"narrative": "Badge awarded for enrollment in {} courses on {}".format(enrollments, platform)}]
+    award_badge(config, enrollments, user, evidence)
 
 
 @requires_badges_enabled
@@ -51,10 +58,13 @@ def completion_check(user):
     completed courses. This badge will not work if certificate generation isn't
     enabled and run.
     """
+    # TODO: award badges on >= number completed
     from certificates.models import CertificateStatuses
     config = CourseEventBadgesConfiguration.current().completed_settings
     certificates = user.generatedcertificate_set.filter(status__in=CertificateStatuses.PASSED_STATUSES).count()
-    award_badge(config, certificates, user)
+    platform = configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+    evidence = [{"narrative": "Badge awarded for completion of {} courses on {}".format(certificates, platform)}]
+    award_badge(config, certificates, user, evidence)
 
 
 @requires_badges_enabled
@@ -73,7 +83,7 @@ def course_group_check(user, course_key):
             )
             # >= to support case with multiple certs per course (enrollment in multiple modes)
             if len(certs) >= len(keys):
-                evidence = [evidence_url(user.id, key) for key in keys]
+                evidence = [{'narrative': 'Certificate of course completion', 'url': evidence_url(user.id, key)} for key in keys]
                 awards.append((slug, evidence))
 
     for award in awards:

--- a/lms/djangoapps/badges/events/course_meta.py
+++ b/lms/djangoapps/badges/events/course_meta.py
@@ -72,20 +72,12 @@ def course_group_check(user, course_key):
                 course_id__in=keys,
             )
             if len(certs) == len(keys):
-                # course_complete Assertions are not working correctly
-                # yet with Badgr.io, while course group is working.
-                # so we use course groups with a single course,
-                # in which case we can provide an evidence URL
-                # to the HTML cert for the one coursee
                 evidence = [evidence_url(user.id, course_key) for course_key in keys]
-                awards.append((slug,))
+                awards.append((slug, evidence))
 
     for award in awards:
         badge_class = BadgeClass.get_badge_class(
             slug=award[0], create=False,
         )
         if badge_class and not badge_class.get_for_user(user):
-            try:
-                badge_class.award(user, evidence_url=award[1])
-            except IndexError:
-                badge_class.award(user)
+            badge_class.award(user, evidence=award[1])

--- a/lms/djangoapps/badges/models.py
+++ b/lms/djangoapps/badges/models.py
@@ -130,11 +130,11 @@ class BadgeClass(models.Model):
         """
         return self.badgeassertion_set.filter(user=user)
 
-    def award(self, user, evidence_url=None):
+    def award(self, user, evidence=None):
         """
         Contacts the backend to have a badge assertion created for this badge class for this user.
         """
-        return self.backend.award(self, user, evidence_url=evidence_url)
+        return self.backend.award(self, user, evidence=evidence)
 
 
     class Meta(object):

--- a/lms/djangoapps/badges/tests/test_models.py
+++ b/lms/djangoapps/badges/tests/test_models.py
@@ -233,9 +233,9 @@ class BadgeClassTest(ModuleStoreTestCase):
         """
         user = UserFactory.create()
         badge_class = BadgeClassFactory.create()
-        badge_class.award(user, evidence_url='http://example.com/evidence')
+        badge_class.award(user, evidence=['http://example.com/evidence'])
         self.assertTrue(mock_award.called)
-        mock_award.assert_called_with(badge_class, user, evidence_url='http://example.com/evidence')
+        mock_award.assert_called_with(badge_class, user, evidence=['http://example.com/evidence'])
 
     def test_runs_validator(self):
         """


### PR DESCRIPTION
Badgr/Open Badges spec support multiple evidence items per badge assertion.  Each one can provide a URL and/or a narrative description.  Fix course group meta award to send one evidence item per course key in config entry.    Include narrative 'Certificate of course completion' for course group awards along with URL, send narrative "Enrollment in X /Completion of X number of courses on PLATFORM-NAME" narrative for awards on number of enrolleed courses or completed courses.