### PR TITLE
Revert "Apply security patch to django wiki"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -15,7 +15,7 @@ git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f3
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@v0.0.18#egg=django-wiki
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e common/lib/dogstats
@@ -116,8 +116,8 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.5.2
-edx-enterprise==0.70.6
-edx-i18n-tools==0.4.6
+edx-enterprise==0.70.3
+edx-i18n-tools==0.4.5
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -17,7 +17,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@v0.0.18#egg=django-wiki
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e common/lib/dogstats
@@ -136,8 +136,8 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.5.2
-edx-enterprise==0.70.6
-edx-i18n-tools==0.4.6
+edx-enterprise==0.70.3
+edx-i18n-tools==0.4.5
 edx-lint==0.5.5
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
@@ -225,8 +225,8 @@ oauth2==1.9.0.post1
 oauthlib==2.0.1
 openapi-codec==1.3.2
 pa11ycrawler==1.6.2
-packaging==17.1
-parsel==1.5.0
+packaging==17.1           # via sphinx
+parsel==1.4.0
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
@@ -323,7 +323,7 @@ testfixtures==6.2.0
 testtools==2.3.0
 text-unidecode==1.2
 tox-battery==0.5.1
-tox==3.1.0
+tox==3.0.0
 traceback2==1.4.0
 transifex-client==0.13.3
 twisted==16.6.0

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -62,7 +62,7 @@
 
 # Third-party:
 -e git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@v0.0.18#egg=django-wiki
 -e git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 -e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -15,7 +15,7 @@ git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f3
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@v0.0.18#egg=django-wiki
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e common/lib/dogstats
@@ -131,8 +131,8 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.5.2
-edx-enterprise==0.70.6
-edx-i18n-tools==0.4.6
+edx-enterprise==0.70.3
+edx-i18n-tools==0.4.5
 edx-lint==0.5.5
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
@@ -216,8 +216,7 @@ oauth2==1.9.0.post1
 oauthlib==2.0.1
 openapi-codec==1.3.2
 pa11ycrawler==1.6.2
-packaging==17.1           # via tox
-parsel==1.5.0             # via scrapy
+parsel==1.4.0             # via scrapy
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
@@ -307,7 +306,7 @@ testfixtures==6.2.0
 testtools==2.3.0          # via fixtures, python-subunit
 text-unidecode==1.2       # via faker
 tox-battery==0.5.1
-tox==3.1.0
+tox==3.0.0
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.3
 twisted==16.6.0           # via pa11ycrawler, scrapy


### PR DESCRIPTION
Reverts appsembler/edx-platform#400 because it breaks the LMS.

[Trello cards](https://trello.com/c/AXIpr3S6)

Due to https://sentry.io/organizations/appsembler/issues/1075977832/?project=145493&query=is%3Aunresolved