### PR TITLE
get tox test setup working for our environment

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -2,7 +2,7 @@ django-extensions==1.5.9
 libsass==0.11.1
 python-intercom==0.2.13
 raven==5.21.0
-requests==2.8.1
+requests==2.9.1
 django-anymail==5.0
 git+https://github.com/appsembler/django-tiers.git@v0.0.19#egg=django-tiers==0.0.19
 dj-database-url==0.4.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -189,7 +189,7 @@ kombu==3.0.37
 lazy-object-proxy==1.3.1  # via astroid
 lazy==1.1
 lepl==5.1.3
-libsass==0.10.0
+libsass==0.11.1
 linecache2==1.0.0         # via traceback2
 loremipsum==1.0.5
 lxml==3.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2
     -r requirements/edx/testing.txt
+    -r requirements/edx/appsembler.txt
 whitelist_externals =
     /bin/bash
     /usr/bin/curl


### PR DESCRIPTION
Couple very small changes to get `tox` tests started in our environment.

Mostly, it's just adding our deps to `tox.ini` so tox knows to install them. Then there are a few conflicts with library versions that had to be resolved.

With this, you *should* be able to install `tox`, then run something like:

```
$ tox -e py27-django111 -- paver test_python
```

(if you want to see *lots* of tests fail). Basically, you should be able to run any of the commands mentioned on https://github.com/edx/edx-platform/blob/master/docs/testing/testing.rst this way. Most fail at this point (most of the core tests require some additional system setup, mongo, etc). But this gives us somewhere to start. If we have a couple tests that we get reliably passing, we can run them explicitly and add to them from there.