### PR TITLE
install django-tiers from pypi package

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -4,7 +4,7 @@ python-intercom==0.2.13
 raven==5.21.0
 requests==2.8.1
 django-anymail==5.0
-git+https://github.com/appsembler/django-tiers.git@v0.0.19#egg=django-tiers==0.0.19
+django-tiers==0.0.19
 dj-database-url==0.4.2
 psycopg2==2.6.2
 django-compat==1.0.14


### PR DESCRIPTION
`django-tiers` is on PyPI now. We should eat our own dogfood and install the official package from there.