### PR TITLE
TravisCI setup for running pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+
+install:
+  - pip install tox
+
+script:
+  - tox -e py27-django111 -- paver run_pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ install:
   - pip install tox
 
 script:
+  - tox -e pep8
   - tox -e py27-django111 -- paver run_pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: python
 python:
   - "2.7"
 
+before_install:
+  - sudo rm -f /etc/boto.cfg
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install python-dev libxml2-dev libxmlsec1-dev
+
 install:
   - pip install tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ before_install:
 install:
   - pip install tox
 
+env:
+  - TOXENV=pep8
+  - TOXENV=py27-django111
+    ARGS="-- paver run_pep8"
+
 script:
-  - tox -e pep8
-  - tox -e py27-django111 -- paver run_pep8
+  - tox $ARGS

--- a/pavelib/database.py
+++ b/pavelib/database.py
@@ -92,11 +92,11 @@ def update_local_bokchoy_db_from_s3(options):
     fingerprints_match = does_fingerprint_on_disk_match(fingerprint)
 
     if fingerprints_match:
-        print ("DB cache files match the current migrations.")
+        print("DB cache files match the current migrations.")
         reset_test_db(BOKCHOY_DB_FILES, update_cache_files=False)
 
     elif is_fingerprint_in_bucket(fingerprint, CACHE_BUCKET_NAME):
-        print ("Found updated bokchoy db files at S3.")
+        print("Found updated bokchoy db files at S3.")
         refresh_bokchoy_db_cache_from_s3(fingerprint, CACHE_BUCKET_NAME, BOKCHOY_DB_FILES)
         reset_test_db(BOKCHOY_DB_FILES, update_cache_files=False)
 
@@ -106,7 +106,7 @@ def update_local_bokchoy_db_from_s3(options):
             "Loading the bokchoy db files from disk",
             "and running migrations."
         )
-        print (msg)
+        print(msg)
         reset_test_db(BOKCHOY_DB_FILES, update_cache_files=True)
         # Check one last time to see if the fingerprint is present in
         # the s3 bucket. This could occur because the bokchoy job is

--- a/pavelib/i18n.py
+++ b/pavelib/i18n.py
@@ -282,6 +282,7 @@ def i18n_release_pull():
     resources = find_release_resources()
     sh("i18n_tool transifex pull " + " ".join(resources))
 
+
 @task
 @needs(
     "pavelib.i18n.i18n_clean",

--- a/pavelib/utils/db_utils.py
+++ b/pavelib/utils/db_utils.py
@@ -156,7 +156,7 @@ def get_file_from_s3(bucket_name, zipfile_name, path):
     """
     Get the file from s3 and save it to disk.
     """
-    print ("Retrieving {} from bucket {}.".format(zipfile_name, bucket_name))
+    print("Retrieving {} from bucket {}.".format(zipfile_name, bucket_name))
     conn = boto.connect_s3(anon=True)
     bucket = conn.get_bucket(bucket_name)
     key = boto.s3.key.Key(bucket=bucket, name=zipfile_name)
@@ -191,7 +191,7 @@ def refresh_bokchoy_db_cache_from_s3(fingerprint, bucket_name, bokchoy_db_files)
         zipfile_name = '{}.tar.gz'.format(fingerprint)
         get_file_from_s3(bucket_name, zipfile_name, path)
         zipfile_path = os.path.join(path, zipfile_name)
-        print ("Extracting db cache files.")
+        print("Extracting db cache files.")
         extract_files_from_zip(bokchoy_db_files, zipfile_path, path)
         os.remove(zipfile_path)
 

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -6,7 +6,7 @@ requests==2.9.1
 django-anymail==5.0
 django-tiers==0.0.19
 dj-database-url==0.4.2
-psycopg2==2.6.2
+psycopg2==2.8.3
 django-compat==1.0.14
 django-hijack==2.1.4
 django-hijack-admin==2.1.4

--- a/scripts/xblock/xblock_counts.py
+++ b/scripts/xblock/xblock_counts.py
@@ -215,7 +215,7 @@ def _get_course_block_counts(auth_token, block_url):
 
     response = requests.get(block_url, headers=headers)
     if response.status_code != 200:
-        print ("url {} returned status code {}".format(block_url, response.status_code))
+        print("url {} returned status code {}".format(block_url, response.status_code))
         return {}
     response_json = response.json()
 

--- a/tox.ini
+++ b/tox.ini
@@ -60,3 +60,9 @@ commands =
     bash scripts/upgrade_pysqlite.sh
     # Now perform testing.
     {posargs}
+
+[testenv:pep8]
+deps =
+    pycodestyle==2.3.1
+commands =
+    pycodestyle .


### PR DESCRIPTION
simplest thing we can get TravisCI to do automatically.

As usual with edX, this turned out to be a bit more complicated than it ought to.

The proper way to do the pep8 checks on `edx-platform` is with `paver run_pep8`, which I've gotten `tox` to run. The catch there is that it requires installing the whole universe because `paver` seems to need everything. That takes a long time. It also triggers a few weird bugs with the TravisCI environment (hence some of the bits like removing `/etc/boto.cfg`, installing some extra packages, and upgrading `psycopg2` (2.6.x has an installation bug on Travis). I fought through those and got it running because, eventually, if we want to run actual unit tests on Travis, we will need to work them out anyway.

Still, 10 minutes or so just to run a quick pep8 check is annoying, so I also dug into `pavelib/quality.py` and saw that it eventually (after installing the entire universe of packages) just runs `pycodestyle .`. So I added an extra `tox` command that just installs `pycodestyle` and runs that. That completes very quickly. It's redundant here on a PR, but if you want to do a quick lint locally, it will be much faster to do `tox -e pep8` than `tox -e py27-django111 -- paver run_pep8` and is almost identical in its results. The exception is that *somehow*, for reasons that I don't understand at all, the simpler version also checks the `pavelib` and `scripts` directory while the more complicated one doesn't. So I had to fix a few small pep8 issues in those directories as well.

The `psycopg2` update *should* be safe. It's something that we probably want to double check on staging though. If it turns out that we can't update it just for the sake of Travis tests, we can probably figure out a way to work around it.