### PR TITLE
WIP ISC add "Export as Markdown" to Studio course tools nav

### DIFF
--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -39,6 +39,11 @@ from openedx.core.djangolib.markup import HTML, Text
             ${_("New Library")}</a>
           % endif
 
+          % if user.is_staff:
+          <a href="/export/all/markdown" class="button new-button"><span class="icon fa fa-plus icon-inline" aria-hidden="true"></span>
+            ${_("Export ALL courses as Markdown")}</a>
+          % endif
+
           % if is_programs_enabled:
             <a href=${program_authoring_url + 'new'} class="button new-button new-program-button"><span class="icon fa fa-plus icon-inline" aria-hidden="true"></span>
             ${_("New Program")}</a>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -27,7 +27,7 @@
             import_url = reverse('contentstore.views.import_handler', kwargs={'course_key_string': unicode(course_key)})
             course_info_url = reverse('contentstore.views.course_info_handler', kwargs={'course_key_string': unicode(course_key)})
             export_url = reverse('contentstore.views.export_handler', kwargs={'course_key_string': unicode(course_key)})
-            export_markdown_url = reverse('openedx_export_plugins.views.plugin_export_handler', kwargs={'plugin_name': 'markdown', course_key_string': unicode(course_key)})
+            export_markdown_url = reverse('openedx_export_plugins.views.plugin_export_handler', kwargs={'plugin_name': 'markdown', 'course_key_string': unicode(course_key)})
             settings_url = reverse('contentstore.views.settings_handler', kwargs={'course_key_string': unicode(course_key)})
             grading_url = reverse('contentstore.views.grading_handler', kwargs={'course_key_string': unicode(course_key)})
             advanced_settings_url = reverse('contentstore.views.advanced_settings_handler', kwargs={'course_key_string': unicode(course_key)})

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -27,6 +27,7 @@
             import_url = reverse('contentstore.views.import_handler', kwargs={'course_key_string': unicode(course_key)})
             course_info_url = reverse('contentstore.views.course_info_handler', kwargs={'course_key_string': unicode(course_key)})
             export_url = reverse('contentstore.views.export_handler', kwargs={'course_key_string': unicode(course_key)})
+            export_markdown_url = reverse('openedx_export_plugins.views.plugin_export_handler', kwargs={'plugin_name': 'markdown', course_key_string': unicode(course_key)})
             settings_url = reverse('contentstore.views.settings_handler', kwargs={'course_key_string': unicode(course_key)})
             grading_url = reverse('contentstore.views.grading_handler', kwargs={'course_key_string': unicode(course_key)})
             advanced_settings_url = reverse('contentstore.views.advanced_settings_handler', kwargs={'course_key_string': unicode(course_key)})
@@ -119,6 +120,9 @@
                   <li class="nav-item nav-course-tools-export">
                     <a href="${export_url}">${_("Export")}</a>
                   </li>
+                  <li class="nav-item nav-course-tools-export">
+                    <a href="${export_markdown_url}">${_("Export as Markdown")}</a>
+                  </li>                  
                   % if settings.FEATURES.get('ENABLE_EXPORT_GIT') and context_course.giturl:
                   <li class="nav-item nav-course-tools-export-git">
                     <a href="${reverse('export_git', kwargs=dict(course_key_string=unicode(course_key)))}">${_("Export to Git")}</a>


### PR DESCRIPTION
Not ready to merge.

Once `openedx_export_plugins` is added to ISC configs and ready to use, we can merge this.  

Adds a button to Studio to generate a `.md` export of a course.  
Unfortunately, there's really no way to insert other tools/links here without overriding edx-platform.