### PR TITLE
Offboard an AMC organization from edX

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/api.py
+++ b/openedx/core/djangoapps/appsembler/sites/api.py
@@ -67,6 +67,17 @@ class SiteConfigurationViewSet(viewsets.ModelViewSet):
         return super(SiteConfigurationViewSet, self).get_serializer_class()
 
     def perform_destroy(self, instance):
+        delete_site(instance.site)
+
+
+class OffboardOrganizationAPIView(generics.DestroyAPIView):
+    authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
+    permission_classes = (IsAuthenticated, AMCAdminPermission)
+    queryset = Site.objects.all()
+    serializer_class = SiteSerializer
+    lookup_field = 'domain'
+
+    def perform_destroy(self, instance):
         delete_site(instance)
 
 

--- a/openedx/core/djangoapps/appsembler/sites/api.py
+++ b/openedx/core/djangoapps/appsembler/sites/api.py
@@ -70,17 +70,6 @@ class SiteConfigurationViewSet(viewsets.ModelViewSet):
         delete_site(instance.site)
 
 
-class OffboardOrganizationAPIView(generics.DestroyAPIView):
-    authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
-    permission_classes = (IsAuthenticated, AMCAdminPermission)
-    queryset = Site.objects.all()
-    serializer_class = SiteSerializer
-    lookup_field = 'domain'
-
-    def perform_destroy(self, instance):
-        delete_site(instance)
-
-
 class FileUploadView(views.APIView):
     parser_classes = (MultiPartParser,)
     # TODO: oauth token isn't present after step 3 in signup, fix later

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/remove_site.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/remove_site.py
@@ -1,0 +1,41 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.sites.models import Site
+
+from openedx.core.djangoapps.appsembler.sites.utils import delete_site
+
+
+class Command(BaseCommand):
+    """
+    Remove a Tahoe website from LMS records.
+
+    Must be used `remove_site` on AMC to avoid any errors there.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'domain',
+            help='The domain of the organization to be deleted.',
+            type=str,
+        )
+
+    def handle(self, *args, **options):
+        organization_domain = options['domain']
+        self.stdout.write(self.style.WARNING('Same command must be ran on the connected AMC instance'))
+
+        self.stdout.write('Removing "%s" in progress...' % organization_domain)
+        organization = self._get_site(organization_domain)
+
+        delete_site(organization)
+        self.stdout.write(self.style.SUCCESS('Successfully removed site "%s"' % organization_domain))
+
+    def _get_site(self, domain):
+        """
+        Locates the site to be deleted and return its instance.
+
+        :param domain: The domain of the site to be returned.
+        :return: Returns the site object that has the given domain.
+        """
+        try:
+            return Site.objects.get(domain=domain)
+        except Site.DoesNotExist:
+            raise CommandError('Cannot find "%s" in Sites!' % domain)

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -8,6 +8,8 @@ from django.contrib.sites.models import Site
 from django.core.management import call_command
 
 from openedx.core.djangoapps.appsembler.sites.management.commands.create_devstack_site import Command
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+from openedx.core.djangoapps.theming.models import SiteTheme
 from organizations.models import Organization
 from provider.constants import CONFIDENTIAL
 from provider.oauth2.models import AccessToken, RefreshToken, Client
@@ -68,3 +70,47 @@ class CreateDevstackSiteCommandTestCase(TestCase):
         assert fake_token == '80bfa968ffad007c79bfc603f3670c99', 'Ensure hash is identical to AMC'
         assert AccessToken.objects.get(user=user).token == fake_token, 'Access token is needed'
         assert RefreshToken.objects.get(user=user).token == fake_token, 'Refresh token is needed'
+
+
+@override_settings(
+    DEBUG=True,
+    DEFAULT_SITE_THEME='edx-theme-codebase',
+    FEATURES={
+        'AMC_APP_URL': 'http://localhost:13000',
+        "DISABLE_COURSE_CREATION": False,
+        "ENABLE_CREATOR_GROUP": True,
+    },
+    COMPREHENSIVE_THEME_DIRS=[settings.REPO_ROOT / 'common/test/appsembler'],
+)
+class RemoveSiteCommandTestCase(TestCase):
+    """
+    Test ./manage.py lms remove_site mysite
+    """
+    def setUp(self):
+        assert settings.ENABLE_COMPREHENSIVE_THEMING
+        Client.objects.create(url=settings.FEATURES['AMC_APP_URL'], client_type=CONFIDENTIAL)
+
+        self.to_be_deleted = 'delete'
+        self.shall_remain = 'keep'
+
+        # This command should be tested above
+        call_command('create_devstack_site', self.to_be_deleted)
+        call_command('create_devstack_site', self.shall_remain)
+
+    def test_create_devstack_site(self):
+        """
+        Test that `create_devstack_site` and creates the required objects.
+        """
+        call_command('remove_site', '{}.localhost:18000'.format(self.to_be_deleted))
+
+        # Ensure objects are removed correctly.
+        deleted_domain = '{}.localhost:18000'.format(self.to_be_deleted)
+        remained_domain = '{}.localhost:18000'.format(self.shall_remain)
+
+        assert not Site.objects.filter(domain=deleted_domain).exists()
+        site = Site.objects.get(domain=remained_domain)
+
+        assert SiteConfiguration.objects.count() == 1
+        assert SiteConfiguration.objects.get(site=site)
+
+        assert SiteTheme.objects.filter(site=site).count() == site.themes.count()

--- a/openedx/core/djangoapps/appsembler/sites/urls.py
+++ b/openedx/core/djangoapps/appsembler/sites/urls.py
@@ -8,7 +8,6 @@ from openedx.core.djangoapps.appsembler.sites.api import (
     DomainSwitchView,
     HostFilesView,
     FileUploadView,
-    OffboardOrganizationAPIView,
     SiteConfigurationViewSet,
     SiteCreateView,
     SiteViewSet,
@@ -29,7 +28,6 @@ urlpatterns = [
     url(r'^custom_domain/', CustomDomainView.as_view()),
     url(r'^domain_switch/', DomainSwitchView.as_view()),
     url(r'^register/', SiteCreateView.as_view()),
-    url(r'^offboard/(?P<domain>\w+(\.\w+)*(:[0-9]+)?\/?)/', OffboardOrganizationAPIView.as_view()),
     url(r'^', include(router.urls)),
 ]
 

--- a/openedx/core/djangoapps/appsembler/sites/urls.py
+++ b/openedx/core/djangoapps/appsembler/sites/urls.py
@@ -1,12 +1,14 @@
 from django.conf import settings
 from django.conf.urls import url, include
 from rest_framework.routers import DefaultRouter
+
 from openedx.core.djangoapps.appsembler.sites.api import (
     CustomDomainView,
     DomainAvailabilityView,
     DomainSwitchView,
     HostFilesView,
     FileUploadView,
+    OffboardOrganizationAPIView,
     SiteConfigurationViewSet,
     SiteCreateView,
     SiteViewSet,
@@ -27,6 +29,7 @@ urlpatterns = [
     url(r'^custom_domain/', CustomDomainView.as_view()),
     url(r'^domain_switch/', DomainSwitchView.as_view()),
     url(r'^register/', SiteCreateView.as_view()),
+    url(r'^offboard/(?P<domain>\w+(\.\w+)*(:[0-9]+)?\/?)/', OffboardOrganizationAPIView.as_view()),
     url(r'^', include(router.urls)),
 ]
 

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -306,10 +306,10 @@ def bootstrap_site(site, org_data=None, user_email=None):
     return organization, site, user
 
 
-def delete_site(site_id):
-    site = Site.objects.get(id=site_id)
+def delete_site(site):
     site.configuration.delete()
-    site.themes.delete()
+    site.themes.all().delete()
+
     site.delete()
 
 


### PR DESCRIPTION
## Background
We started this PR earlier in 2019 to help us remove a specific site from Tahoe. This step is necessary when we need to offboard a customer. However, we didn't have such a case until nw when one of our clients started working on their disaster and recovery plan. 
What we are trying to achieve here, is building a tool that removes all high-level data of a specific organization. This data include high level hooks and relations (No courses, material, or logs):
- Microsite Object.
- Organization Object.
- Tier Object


## This PR
Here we offboard an organization through a new API from edX platform by removing its data from the system. I also fixed the broken `delete_site` function that's now being used to offboard organizations.

I was thinking of keeping all deleted organizations in the database, instead of removing them we can add a new field like `is_active` or similar, but that at the end of the day depends on the business logic, the customers we have, and how deep we are planning to go.

## Steps to Reproduce
To be able to use the API, you need to
- SSH into your LMS shell; on devstack you can use `make lms-shell`.
- Run the management command `python manage.py lms <domain>. If you are running this on a local machine your domain should be `<slug>.localhost:18000`

Note: you can now create a website using `python manage.py lms create_devstack_site <slug>`
## Related PRs
- [amc#197](https://github.com/appsembler/amc/pull/197)
