### PR TITLE
(WIP) Tahoe API key management api

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/sites.py
+++ b/openedx/core/djangoapps/appsembler/api/sites.py
@@ -1,6 +1,12 @@
 
+from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-from organizations.models import Organization, OrganizationCourse
+
+from organizations.models import (
+    Organization,
+    OrganizationCourse,
+    UserOrganizationMapping,
+)
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
@@ -67,3 +73,15 @@ def course_belongs_to_site(site, course_id):
 def get_enrollments_for_site(site):
     course_keys = get_course_keys_for_site(site)
     return CourseEnrollment.objects.filter(course_id__in=course_keys)
+
+
+def get_user_ids_for_site(site):
+    orgs = Organization.objects.filter(sites__in=[site])
+    mappings = UserOrganizationMapping.objects.filter(
+            organization__in=orgs)
+    return mappings.values_list('user_id', flat=True)
+
+
+def get_users_for_site(site):
+    user_ids = get_user_ids_for_site(site)
+    return get_user_model().objects.filter(id__in=user_ids)

--- a/openedx/core/djangoapps/appsembler/api/tests/factories.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/factories.py
@@ -123,7 +123,7 @@ class TokenFactory(factory.DjangoModelFactory):
     #     settings.AUTH_USER_MODEL, related_name='auth_token',
     #     on_delete=models.CASCADE, verbose_name=_("User")
     # )
-    created = fuzzy.FuzzyDateTime(datetime.datetime(
+    created = factory.fuzzy.FuzzyDateTime(datetime.datetime(
         2018, 2, 1, tzinfo=factory.compat.UTC))
     # created = models.DateTimeField(_("Created"), auto_now_add=True)
     # generate_key

--- a/openedx/core/djangoapps/appsembler/api/tests/factories.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/factories.py
@@ -1,7 +1,11 @@
 
+import binascii
 import datetime
 
 import factory
+
+from rest_framework.authtoken.models import Token
+
 from openedx.core.djangoapps.content.course_overviews.models import (
     CourseOverview,
 )
@@ -19,6 +23,11 @@ from openedx.core.djangoapps.appsembler.api.helpers import as_course_key
 
 
 COURSE_ID_STR_TEMPLATE = 'course-v1:StarFleetAcademy+SFA{}+2161'
+
+class FuzzyDrfToken(factory.fuzzy.BaseFuzzyAttribute):
+    def fuzz(self):
+        return binascii.hexlify(
+            bytearray(random.getrandbits(8) for _ in xrange(20)))
 
 
 class CourseOverviewFactory(factory.DjangoModelFactory):
@@ -101,3 +110,21 @@ class OrganizationCourseFactory(factory.DjangoModelFactory):
     course_id = factory.Sequence(lambda n: COURSE_ID_STR_TEMPLATE.format(n))
     organization = factory.SubFactory(OrganizationFactory)
     active = True
+
+
+class TokenFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Token
+
+    key = FuzzyDrfToken()
+    # key = models.CharField(_("Key"), max_length=40, primary_key=True)
+    user = factory.SubFactory(UserFactory)
+    # user = models.OneToOneField(
+    #     settings.AUTH_USER_MODEL, related_name='auth_token',
+    #     on_delete=models.CASCADE, verbose_name=_("User")
+    # )
+    created = fuzzy.FuzzyDateTime(datetime.datetime(
+        2018, 2, 1, tzinfo=factory.compat.UTC))
+    # created = models.DateTimeField(_("Created"), auto_now_add=True)
+    # generate_key
+    # binascii.hexlify(os.urandom(20)).decode()

--- a/openedx/core/djangoapps/appsembler/api/tests/test_api_key_management_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_api_key_management_api.py
@@ -1,14 +1,19 @@
 
 from django.test import TestCase
+
+from django.core.urlresolvers import resolve, reverse
+from rest_framework import status
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 import ddt
+import mock
 
 from rest_framework.authtoken.models import Token
 
 from openedx.core.djangoapps.site_configuration.tests.factories import (
     SiteFactory,
 )
+from student.tests.factories import UserFactory
 
 from openedx.core.djangoapps.appsembler.api.tests.factories import (
     OrganizationFactory,
@@ -31,9 +36,10 @@ class TahoeApiBaseViewTest(TestCase):
         UserOrganizationMappingFactory(user=self.caller,
                                        organization=self.my_site_org,
                                        is_amc_admin=True)
+        self.api_request_factory = APIRequestFactory()
 
-    def do_get(self, url, query_params):
-        request = APIRequestFactory().get(url)
+    def create_get_request(self, url, query_params):
+        request = self.api_request_factory.get(url)
         request.META['HTTP_HOST'] = self.my_site.domain
         force_authenticate(request, user=self.caller)
         view = resolve(url).func
@@ -43,10 +49,24 @@ class TahoeApiBaseViewTest(TestCase):
 class TahoeApiKeyGetTest(TahoeApiBaseViewTest):
 
     def setUp(self):
-        super(TahoeApiGetTest, self).setUp()
-        self.
+        super(TahoeApiKeyGetTest, self).setUp()
+
+        self.my_site_users = [UserFactory() for i in range(3)]
+        for user in self.my_site_users:
+            UserOrganizationMappingFactory(user=user,
+                                           organization=self.my_site_org)
+
+        self.other_site_users = [UserFactory()]
+        for user in self.other_site_users:
+            UserOrganizationMappingFactory(user=user,
+                                           organization=self.other_site_org)
+
     def test_get_all_tokens(self):
-        pass
+        url = reverse('tahoe-api:v1:api-keys-list')
+        request = self.api_request_factory.get(url)
+        request.META['HTTP_HOST'] = self.my_site.domain
+        force_authenticate(request, user=self.caller)
+        view = resolve(url).func
 
     def test_get_token_for_logged_in_user(self):
         pass
@@ -55,13 +75,13 @@ class TahoeApiKeyGetTest(TahoeApiBaseViewTest):
         pass
 
 
-class TahoeApiPostTest(TestCase):
-    def setUp(self):
-        super(TokenApiPostTest, self).setUp()
+# class TahoeApiKeyPostTest(TestCase):
+#     def setUp(self):
+#         super(TokenApiKeyPostTest, self).setUp()
 
-    def test_create_apik_key(self):
-        pass
+#     def test_create_apik_key(self):
+#         pass
 
-    def test_revoke_api_key(self):
-        pass
+#     def test_revoke_api_key(self):
+#         pass
 

--- a/openedx/core/djangoapps/appsembler/api/tests/test_api_key_management_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_api_key_management_api.py
@@ -1,0 +1,67 @@
+
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+import ddt
+
+from rest_framework.authtoken.models import Token
+
+from openedx.core.djangoapps.site_configuration.tests.factories import (
+    SiteFactory,
+)
+
+from openedx.core.djangoapps.appsembler.api.tests.factories import (
+    OrganizationFactory,
+    TokenFactory,
+    UserOrganizationMappingFactory,
+)
+
+
+APPSEMBLER_API_VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.api.v1.views'
+
+
+class TahoeApiBaseViewTest(TestCase):
+    def setUp(self):
+        super(TahoeApiBaseViewTest, self).setUp()
+        self.my_site = SiteFactory(domain='my-site.test')
+        self.other_site = SiteFactory(domain='other-site.test')
+        self.other_site_org = OrganizationFactory(sites=[self.other_site])
+        self.my_site_org = OrganizationFactory(sites=[self.my_site])
+        self.caller = UserFactory()
+        UserOrganizationMappingFactory(user=self.caller,
+                                       organization=self.my_site_org,
+                                       is_amc_admin=True)
+
+    def do_get(self, url, query_params):
+        request = APIRequestFactory().get(url)
+        request.META['HTTP_HOST'] = self.my_site.domain
+        force_authenticate(request, user=self.caller)
+        view = resolve(url).func
+
+@ddt.ddt
+@mock.patch(APPSEMBLER_API_VIEWS_MODULE + '.TahoeApiKeyViewSet.throttle_classes', [])
+class TahoeApiKeyGetTest(TahoeApiBaseViewTest):
+
+    def setUp(self):
+        super(TahoeApiGetTest, self).setUp()
+        self.
+    def test_get_all_tokens(self):
+        pass
+
+    def test_get_token_for_logged_in_user(self):
+        pass
+
+    def test_get_token_for_user_without_token(self):
+        pass
+
+
+class TahoeApiPostTest(TestCase):
+    def setUp(self):
+        super(TokenApiPostTest, self).setUp()
+
+    def test_create_apik_key(self):
+        pass
+
+    def test_revoke_api_key(self):
+        pass
+

--- a/openedx/core/djangoapps/appsembler/api/v1/serializers.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/serializers.py
@@ -1,5 +1,6 @@
 
 from rest_framework import serializers
+from rest_framework.authtoken.models import Token
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -57,3 +58,7 @@ class BulkEnrollmentSerializer(serializers.Serializer):
                 'identifiers must be a list, not a {}'.format(type(value)))
         # TODO: Do we want to enforce identifier type (like email, username)
         return value
+
+class TahoeApiKeySerializer(serializers.Serializer):
+    class Meta:
+        model = Token

--- a/openedx/core/djangoapps/appsembler/api/v1/urls.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/urls.py
@@ -13,6 +13,12 @@ from openedx.core.djangoapps.appsembler.api.v1 import views
 router = routers.DefaultRouter()
 
 router.register(
+    r'api-keys',
+    views.TahoeApiKeyViewSet,
+    'api-keys',
+)
+
+router.register(
     r'courses',
     views.CourseViewSet,
     'courses',


### PR DESCRIPTION
This is the early stage in the Tahoe API key management api

* Very much a work in progress!
* We still have to determine if we're showing keys for the api key list call or just the users who have keys (almost certainly the later)

* We probably need to implement different serializers for
** get list (show users who have keys)
** get retrieve (show the key(s) for the logged in user)
** create - Add a key for the user. Need to decide if we fail (already exists) if key already exists or if we replace the key
** delete - remove the key for the specified user


