### PR TITLE
Added user endpoint for the enrollments API and user filtering on enrollments endpoint (take 2)

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/sites.py
+++ b/openedx/core/djangoapps/appsembler/api/sites.py
@@ -1,6 +1,11 @@
 
+from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-from organizations.models import Organization, OrganizationCourse
+from organizations.models import (
+    Organization,
+    OrganizationCourse,
+    UserOrganizationMapping,
+)
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
@@ -67,3 +72,14 @@ def course_belongs_to_site(site, course_id):
 def get_enrollments_for_site(site):
     course_keys = get_course_keys_for_site(site)
     return CourseEnrollment.objects.filter(course_id__in=course_keys)
+
+
+def get_user_ids_for_site(site):
+    orgs = Organization.objects.filter(sites__in=[site])
+    mappings = UserOrganizationMapping.objects.filter(organization__in=orgs)
+    return mappings.values_list('user_id', flat=True)
+
+
+def get_users_for_site(site):
+    user_ids = get_user_ids_for_site(site)
+    return get_user_model().objects.filter(id__in=user_ids)

--- a/openedx/core/djangoapps/appsembler/api/tests/test_sites.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_sites.py
@@ -24,6 +24,8 @@ from openedx.core.djangoapps.site_configuration.tests.factories import (
     SiteFactory,
 )
 
+from student.tests.factories import UserFactory
+
 from openedx.core.djangoapps.appsembler.api import sites as aapi_sites
 from openedx.core.djangoapps.appsembler.api.helpers import as_course_key
 
@@ -33,6 +35,11 @@ from openedx.core.djangoapps.appsembler.api.tests.factories import (
     OrganizationCourseFactory,
     UserOrganizationMappingFactory,
 )
+
+
+def create_org_users(org, new_user_count):
+    return [UserOrganizationMappingFactory(
+        organization=org).user for i in xrange(new_user_count)]
 
 
 class SitesModuleTests(TestCase):
@@ -102,3 +109,17 @@ class SitesModuleTests(TestCase):
             with self.assertRaises(ValueError):
                 aapi_sites.course_belongs_to_site(site=site,
                                                   course_id=self.my_course_overviews[0])
+
+    def test_get_users_ids_for_site(self):
+        my_users = create_org_users(org=self.my_site_org, new_user_count=3)
+        other_users = create_org_users(org=self.other_site_org, new_user_count=2)
+        retrieved_user_ids = aapi_sites.get_user_ids_for_site(self.my_site)
+        assert set(retrieved_user_ids) == set([obj.id for obj in my_users])
+        assert set(retrieved_user_ids).isdisjoint(set([obj.id for obj in other_users]))
+
+    def test_get_users_for_site(self):
+        my_users = create_org_users(org=self.my_site_org, new_user_count=3)
+        other_users = create_org_users(org=self.other_site_org, new_user_count=2)
+        retrieved_users = aapi_sites.get_users_for_site(self.my_site)
+        assert set(retrieved_users) == set(my_users)
+        assert set(retrieved_users).isdisjoint(set(other_users))

--- a/openedx/core/djangoapps/appsembler/api/tests/test_user_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_user_api.py
@@ -1,0 +1,110 @@
+
+from unittest import skip
+
+from django.contrib.sites.models import Site
+from django.core.urlresolvers import resolve, reverse
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
+
+import ddt
+import mock
+
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
+
+from openedx.core.djangoapps.appsembler.api.sites import (
+    get_users_for_site,
+)
+
+from openedx.core.djangoapps.appsembler.api.v1.serializers import UserIndexSerializer
+
+from openedx.core.djangoapps.appsembler.api.tests.factories import (
+    CourseOverviewFactory,
+    OrganizationFactory,
+    UserOrganizationMappingFactory,
+)
+
+APPSEMBLER_API_VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.api.v1.views'
+
+
+@ddt.ddt
+@mock.patch(APPSEMBLER_API_VIEWS_MODULE + '.UserIndexViewSet.throttle_classes', [])
+class UserIndexViewSetTest(TestCase):
+
+    def setUp(self):
+        """
+        Set up test data for site isolation
+        - two sites, our site and the other site
+        - two orgs, one per site
+        - set of learners in our site
+        - one learner in the other site
+        - one learner in both sites
+
+        - caller user in our site with admin rights
+
+        """
+        super(UserIndexViewSetTest, self).setUp()
+        self.my_site = Site.objects.get(domain=u'example.com')
+        self.other_site = SiteFactory(domain='other-site.test')
+        self.other_site_org = OrganizationFactory(sites=[self.other_site])
+        self.my_site_org = OrganizationFactory(sites=[self.my_site])
+
+        # Set up users and enrollments for 'my site'
+        self.my_site_users = [UserFactory() for i in range(3)]
+        for user in self.my_site_users:
+            UserOrganizationMappingFactory(user=user,
+                                           organization=self.my_site_org)
+
+        self.other_site_users = [UserFactory()]
+        for user in self.other_site_users:
+            UserOrganizationMappingFactory(user=user,
+                                           organization=self.other_site_org)
+
+        self.caller = UserFactory()
+        UserOrganizationMappingFactory(user=self.caller,
+                                       organization=self.my_site_org,
+                                       is_amc_admin=True)
+
+    def test_serializer(self):
+        user = self.my_site_users[0]
+        data = UserIndexSerializer(instance=user).data
+        assert data['username'] == user.username
+        assert data['fullname'] == user.profile.name
+        assert data['email'] == user.email
+
+    def test_get_all_users_for_site(self):
+        url = reverse('tahoe-api:v1:users-list')
+        request = APIRequestFactory().get(url)
+        request.META['HTTP_HOST'] = self.my_site.domain
+        force_authenticate(request, user=self.caller)
+
+        view = resolve(url).func
+        response = view(request)
+        response.render()
+        results = response.data['results']
+
+        response_count = len(results)
+        expected_users = get_users_for_site(self.my_site)
+
+        user_ids = [rec['id'] for rec in results]
+        assert set(user_ids) == set([obj.id for obj in expected_users])
+
+    @skip("Need to implement user filter")
+    def test_get_all_enrolled_learners_for_site(self):
+
+        # Set up enrollment data
+
+        url = reverse('tahoe-api:v1:users-list')
+        request = APIRequestFactory().get(url)
+        request.META['HTTP_HOST'] = self.my_site.domain
+        force_authenticate(request, user=self.caller)
+
+        view = resolve(url).func
+        response = view(request)
+        response.render()
+        results = response.data['results']
+
+        response_count = len(results)
+        user_ids = [rec['id'] for rec in results]
+        assert set(user_ids) == set([obj.id for obj in self.my_site_users])

--- a/openedx/core/djangoapps/appsembler/api/v1/filters.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/filters.py
@@ -48,6 +48,8 @@ class CourseEnrollmentFilter(django_filters.FilterSet):
     '''
     course_id = django_filters.CharFilter(method='filter_course_id')
     is_active = django_filters.BooleanFilter(name='is_active',)
+    user_id = django_filters.CharFilter(name='user__id')
+    username = django_filters.CharFilter(name='user__username')
 
     def filter_course_id(self, queryset, name, value):
         '''
@@ -65,4 +67,4 @@ class CourseEnrollmentFilter(django_filters.FilterSet):
 
     class Meta:
         model = CourseEnrollment
-        fields = ['course_id', 'user_id', 'is_active', ]
+        fields = ['course_id', 'user_id', 'username', 'is_active', ]

--- a/openedx/core/djangoapps/appsembler/api/v1/serializers.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/serializers.py
@@ -1,4 +1,6 @@
 
+from django.contrib.auth import get_user_model
+
 from rest_framework import serializers
 
 from opaque_keys import InvalidKeyError
@@ -57,3 +59,18 @@ class BulkEnrollmentSerializer(serializers.Serializer):
                 'identifiers must be a list, not a {}'.format(type(value)))
         # TODO: Do we want to enforce identifier type (like email, username)
         return value
+
+
+class UserIndexSerializer(serializers.ModelSerializer):
+    """Provides a limited set of user information for summary display
+    """
+    id = serializers.IntegerField(read_only=True)
+    username = serializers.CharField(read_only=True)
+    fullname = serializers.CharField(
+        source='profile.name', default=None, read_only=True)
+
+    class Meta:
+        model = get_user_model()
+        fields = (
+            'id', 'username', 'fullname', 'email',
+        )

--- a/openedx/core/djangoapps/appsembler/api/v1/urls.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/urls.py
@@ -30,6 +30,12 @@ router.register(
     'registrations',
 )
 
+router.register(
+    r'users',
+    views.UserIndexViewSet,
+    'users',
+)
+
 urlpatterns = [
     url(r'', include(router.urls, )),
 ]


### PR DESCRIPTION
This PR replaces this PR: https://github.com/appsembler/edx-platform/pull/418

* This is the initial version of the user data API to support the enrollment API.
* Added UserIndexViewSet to provide user information via the Tahoe API
* Includes tests for the user viewset
* Updated enrollment test to support user filtering

I followed @OmarIthawi 's suggestion to just add `?user=<user id>` approach. However to do this with the course, we'd need to filter courses on the site, which would require passing the site to the filter, which requires investigating to make it work. Might be really simple, but I'd still have to investigate it.

So instead, I added `?user_id=<user-id>` and `?username=<username>` to the `/tahoe/api/v1/enrollments/` endpoint


This PR addresses the following comments from PR #418 

* https://github.com/appsembler/edx-platform/pull/418#pullrequestreview-259023694

which suggests using `user_id` instead of `user` in the `sites.get_user_ids_for_site` method

* https://github.com/appsembler/edx-platform/pull/418#discussion_r301193738
which uses `self.my_site_users` to validate the expected response set

Thanks @OmarIthawi !!!
