### PR TITLE
Really set `KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS` to a sane default

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -383,7 +383,7 @@ def destroy_oauth_tokens(user):
     dop_access_query = dop_access_token.objects.filter(user=user.id)
     dop_refresh_query = dop_refresh_token.objects.filter(user=user.id)
 
-    if not settings.FEATURES.get('KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS', True):
+    if not settings.FEATURES.get('KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS', False):
         # Appsembler: Avoid deleting the trusted confidential clients such as the Appsembler Management Console
         trusted_clients = Client.objects.filter(
             client_type=CONFIDENTIAL,


### PR DESCRIPTION
I've made a mistake by setting the default variable to an unsafe default in #416. This PR fixes it by making the feature revert to the Open edX default behaviour:

 - Delete all tokens on a password reset.

## Reviewers
Please checkout this pull request as well as (https://github.com/appsembler/edx-configs/pull/644) and review it critically for proper feature name and Boolean values.

## Background
Please checkout this upstream pull request for more info (https://github.com/edx/edx-platform/pull/20836). Also the Trello Card :point_down:.