### PR TITLE
Django 1.11.23 for Hawthorn Enterprise

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -33,7 +33,7 @@ botocore==1.8.17                    # via boto3, s3transfer
 celery==3.1.25                      # Asynchronous task execution library
 ddt==0.8.0                          # via xblock-drag-and-drop-v2 (which probably shouldn't require it)
 defusedxml==0.4.1                   # XML bomb protection for common XML parsers
-Django==1.11.15                     # Web application framework
+Django==1.11.23                     # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
 django-config-models==0.1.8         # Configuration models for Django allowing config management with auditing
 django-cors-headers==2.1.0          # Used to allow to configure CORS headers for cross-domain requests


### PR DESCRIPTION
Recent security release: https://www.djangoproject.com/weblog/2019/aug/01/security-releases/