### PR TITLE
(WIP) A hack to translate the XBlock default data.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -156,6 +156,7 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
     get_theme_base_dirs_from_settings
 )
 from openedx.core.lib.license import LicenseMixin
+from openedx.core.lib.i18n_mixins import TranslatableXBlockMixin
 from openedx.core.lib.derived import derived, derived_collection_entry
 from openedx.core.release import doc_version
 
@@ -547,6 +548,7 @@ from xmodule.x_module import XModuleMixin
 # once the responsibility of XBlock creation is moved out of modulestore - cpennington
 XBLOCK_MIXINS = (
     LmsBlockMixin,
+    TranslatableXBlockMixin,
     InheritanceMixin,
     XModuleMixin,
     EditInfoMixin,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -46,6 +46,7 @@ from openedx.core.release import doc_version
 from xmodule.modulestore.modulestore_settings import update_module_store_settings
 from xmodule.modulestore.edit_info import EditInfoMixin
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
+from openedx.core.lib.i18n_mixins import TranslatableXBlockMixin
 
 ################################### FEATURES ###################################
 # The display name of the platform to be used in templates/emails/etc.
@@ -831,7 +832,7 @@ from xmodule.x_module import XModuleMixin
 # These are the Mixins that should be added to every XBlock.
 # This should be moved into an XBlock Runtime/Application object
 # once the responsibility of XBlock creation is moved out of modulestore - cpennington
-XBLOCK_MIXINS = (LmsBlockMixin, InheritanceMixin, XModuleMixin, EditInfoMixin)
+XBLOCK_MIXINS = (LmsBlockMixin, TranslatableXBlockMixin, InheritanceMixin, XModuleMixin, EditInfoMixin)
 
 # Allow any XBlock in the LMS
 XBLOCK_SELECT_FUNCTION = prefer_xmodules

--- a/openedx/core/lib/i18n_mixins.py
+++ b/openedx/core/lib/i18n_mixins.py
@@ -6,18 +6,18 @@ class TranslatableXBlockMixin(XBlockMixin):
 
     def __init__(self, runtime, *args, **kwargs):
         from xblock.fields import UNSET, UNIQUE_ID, Field
-        from django.utils.translation import ugettext
 
         def apply(f, prop, func):
             try:
                 raw = getattr(f, prop)
                 setattr(f, prop, func(raw))
-            except AttributeError:
+            except AttributeError as e:
+                print 'AttributeError i18n', e
                 pass
 
         def trans(s):
-            if s is not None and isinstance(s, basestring) and s is not UNSET and s is not UNIQUE_ID:
-                return ugettext(s)
+            if s and isinstance(s, basestring) and s is not UNSET and s is not UNIQUE_ID:
+                return self.ugettext(s)
             return s
 
         def trans_struct(s):
@@ -32,39 +32,11 @@ class TranslatableXBlockMixin(XBlockMixin):
 
         super(TranslatableXBlockMixin, self).__init__(runtime, *args, **kwargs)
 
-        if hasattr(self, 'editable_fields'):
+        if hasattr(self, 'editable_fields') or True:
             # for field_name in getattr(self, 'editable_fields', []):
             #     field = self.fields[field_name]
             for _field_name, field in self.fields.iteritems():
-                # apply(field, '_display_name', trans)
-                # apply(field, '_default', trans_struct)
-                # apply(field, 'help', trans)
-                # apply(field, '_values', trans_struct)
-                try:
-                    field._display_name = trans(field._display_name)
-                except AttributeError as e:
-                    print field, e
-                    pass
-
-                try:
-                    field._default = trans_struct(field._default)
-                except AttributeError as e:
-                    print field, e
-                    pass
-
-                try:
-                    field._values = trans_struct(field._values)
-                except AttributeError as e:
-                    print field, e
-                    pass
-
-                try:
-                    field.help = trans(field.help)
-                except AttributeError as e:
-                    print field, e
-                    pass
-                # field._display_name = trans(field._display_name)
-                # # field._default = trans_struct(field._default)
-                # # field._default = trans(field._default)
-                # # field.help = trans(field.help)
-                # # field._values = trans_struct(field._values)
+                apply(field, '_display_name', trans)
+                apply(field, '_default', trans_struct)
+                apply(field, 'help', trans)
+                apply(field, '_values', trans_struct)

--- a/openedx/core/lib/i18n_mixins.py
+++ b/openedx/core/lib/i18n_mixins.py
@@ -1,0 +1,49 @@
+import six
+
+
+class TranslatableXBlockMixin(object):
+    def __init__(self, runtime, *args, **kwargs):
+        from xblock.fields import UNSET, UNIQUE_ID, Field
+        from django.utils.translation import ugettext
+        _self = self
+
+        def trans(s):
+            if s == "Are you enjoying the course?":
+                raise Exception(s)
+
+            if s is not None and isinstance(s, basestring) and s is not UNSET and s is not UNIQUE_ID:
+                return ugettext(s)
+                return _self.ugettext(s)
+            return s
+
+        def trans_struct(s):
+            if isinstance(s, tuple):
+                return tuple(trans_struct(i) for i in s)
+            if isinstance(s, list):
+                return [trans_struct(i) for i in s]
+            elif isinstance(s, dict):
+                return {k: trans_struct(v) for k, v in six.iteritems(s)}
+            else:
+                return trans(s)
+
+        super(TranslatableXBlockMixin, self).__init__(runtime, *args, **kwargs)
+
+        # for field_name in getattr(self, 'editable_fields', []):
+        #     field = self.fields[field_name]
+        for field in self.fields:
+            # apply(field, '_display_name', trans)
+            # apply(field, '_default', trans_struct)
+            # apply(field, 'help', trans)
+            # apply(field, '_values', trans_struct)
+
+            field._display_name = trans(field._display_name)
+            field._default = trans_struct(field._default)
+            field.help = trans(field.help)
+            field._values = trans_struct(field._values)
+
+    @property
+    def name(self):
+        """Returns the name of this field."""
+        # This is set by ModelMetaclass
+        from django.utils.translation import ugettext
+        return ugettext(self.__name__) or 'unknown'

--- a/openedx/core/lib/i18n_mixins.py
+++ b/openedx/core/lib/i18n_mixins.py
@@ -5,12 +5,19 @@ from xblock.core import XBlockMixin
 class TranslatableXBlockMixin(XBlockMixin):
 
     def __init__(self, runtime, *args, **kwargs):
-        from xblock.fields import UNSET, UNIQUE_ID, Field
+        super(TranslatableXBlockMixin, self).__init__(runtime, *args, **kwargs)
+        from xblock.fields import UNSET, UNIQUE_ID
 
-        def apply(f, prop, func):
+        def apply(f, attr_name, func):
             try:
-                raw = getattr(f, prop)
-                setattr(f, prop, func(raw))
+                raw_attr_name = '_raw_{}'.format(attr_name)
+                if hasattr(f, raw_attr_name):
+                    raw = getattr(f, raw_attr_name)
+                else:
+                    raw = getattr(f, attr_name)
+                    setattr(f, raw_attr_name, raw)
+
+                setattr(f, attr_name, func(raw))
             except AttributeError as e:
                 print 'AttributeError i18n', e
                 pass
@@ -30,11 +37,7 @@ class TranslatableXBlockMixin(XBlockMixin):
             else:
                 return trans(s)
 
-        super(TranslatableXBlockMixin, self).__init__(runtime, *args, **kwargs)
-
         if hasattr(self, 'editable_fields') or True:
-            # for field_name in getattr(self, 'editable_fields', []):
-            #     field = self.fields[field_name]
             for _field_name, field in self.fields.iteritems():
                 apply(field, '_display_name', trans)
                 apply(field, '_default', trans_struct)


### PR DESCRIPTION
Making it possible to use a the Japanese Studio UI (among other languages) and create new XBlocks with localized default data:

<kbd><img src="https://user-images.githubusercontent.com/645156/62638183-91b5bf00-b945-11e9-9aaf-ddb1f75898a7.png" width="350" /></kbd>

### What's Next?
 - This is still a dirty hack that works
 - Please head over to [Open edX Discussion forums](https://discuss.openedx.org/t/translate-the-default-xblock-data/213) to discuss the issue.
 - I'd like to make it a [Open edX plugin](https://github.com/edx/edx-platform/tree/926cb5b/openedx/core/djangoapps/plugins) that we can ship for forks to use.