### PR TITLE
feat: migrate from PSA to social-auth-core and social-auth-app-django

### DIFF
--- a/common/djangoapps/auth_exchange/forms.py
+++ b/common/djangoapps/auth_exchange/forms.py
@@ -10,8 +10,8 @@ from provider.oauth2.forms import ScopeChoiceField, ScopeMixin
 from provider.oauth2.models import Client
 from oauth2_provider.models import Application
 from requests import HTTPError
-from social.backends import oauth as social_oauth
-from social.exceptions import AuthException
+from social_core.backends import oauth as social_oauth
+from social_core.exceptions import AuthException
 
 from third_party_auth import pipeline
 
@@ -90,15 +90,16 @@ class AccessTokenExchangeForm(ScopeMixin, OAuthForm):
         self.cleaned_data["client"] = client
 
         user = None
+        access_token = self.cleaned_data.get("access_token")
         try:
-            user = backend.do_auth(self.cleaned_data.get("access_token"), allow_inactive_user=True)
+             user = backend.do_auth(access_token, allow_inactive_user=True)
         except (HTTPError, AuthException):
             pass
         if user and isinstance(user, User):
             self.cleaned_data["user"] = user
         else:
             # Ensure user does not re-enter the pipeline
-            self.request.social_strategy.clean_partial_pipeline()
+            self.request.social_strategy.clean_partial_pipeline(access_token)
             raise OAuthValidationError(
                 {
                     "error": "invalid_grant",

--- a/common/djangoapps/auth_exchange/views.py
+++ b/common/djangoapps/auth_exchange/views.py
@@ -24,7 +24,7 @@ from provider.oauth2.views import AccessTokenView as DOPAccessTokenView
 from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
-import social.apps.django_app.utils as social_utils
+import social_django.utils as social_utils
 
 from auth_exchange.forms import AccessTokenExchangeForm
 from lms.djangoapps.oauth_dispatch import adapters
@@ -37,7 +37,7 @@ class AccessTokenExchangeBase(APIView):
     OAuth access token.
     """
     @method_decorator(csrf_exempt)
-    @method_decorator(social_utils.strategy("social:complete"))
+    @method_decorator(social_utils.psa("social:complete"))
     def dispatch(self, *args, **kwargs):
         return super(AccessTokenExchangeBase, self).dispatch(*args, **kwargs)
 
@@ -137,11 +137,11 @@ class DOTAccessTokenExchangeView(AccessTokenExchangeBase, DOTAccessTokenView):
         request.extra_credentials = None
         request.grant_type = client.authorization_grant_type
 
-    def error_response(self, form_errors):
+    def error_response(self, form_errors, **kwargs):
         """
         Return an error response consisting of the errors in the form
         """
-        return Response(status=400, data=form_errors)
+        return Response(status=400, data=form_errors, **kwargs)
 
 
 class LoginWithAccessTokenView(APIView):

--- a/common/djangoapps/monkey_patch/third_party_auth.py
+++ b/common/djangoapps/monkey_patch/third_party_auth.py
@@ -4,8 +4,8 @@ Remove once the module fully supports Django 1.8!
 """
 
 from django.db import transaction
-from social.storage.django_orm import DjangoUserMixin
-from social.apps.django_app.default.models import (
+from social_django.storage import DjangoUserMixin
+from social_django.models import (
     UserSocialAuth, Nonce, Association, Code
 )
 
@@ -29,10 +29,3 @@ def patch():
         return classmethod(_create_social_auth)
 
     DjangoUserMixin.create_social_auth = create_social_auth_wrapper(DjangoUserMixin.create_social_auth)
-
-    # Monkey-patch some social auth models' Meta class to squelch Django19 warnings.
-    # pylint: disable=protected-access
-    UserSocialAuth._meta.app_label = "default"
-    Nonce._meta.app_label = "default"
-    Association._meta.app_label = "default"
-    Code._meta.app_label = "default"

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -14,7 +14,7 @@ from django.core.urlresolvers import reverse, NoReverseMatch
 from django.http import HttpResponseBadRequest, HttpResponse
 import httpretty
 from mock import patch
-from social.apps.django_app.default.models import UserSocialAuth
+from social_django.models import UserSocialAuth
 
 from external_auth.models import ExternalAuthMap
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
@@ -543,7 +543,6 @@ class LoginOAuthTokenMixin(ThirdPartyOAuthTestMixin):
         """Assert that the given response was a 400 with the given error code"""
         self.assertEqual(response.status_code, status_code)
         self.assertEqual(json.loads(response.content), {"error": error})
-        self.assertNotIn("partial_pipeline", self.client.session)
 
     def test_success(self):
         self._setup_provider_response(success=True)

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -40,9 +40,9 @@ from django.template.response import TemplateResponse
 from provider.oauth2.models import Client
 from ratelimitbackend.exceptions import RateLimitException
 
-from social.apps.django_app import utils as social_utils
-from social.backends import oauth as social_oauth
-from social.exceptions import AuthException, AuthAlreadyAssociated
+from social_django import utils as social_utils
+from social_core.backends import oauth as social_oauth
+from social_core.exceptions import AuthAlreadyAssociated, AuthException
 
 from edxmako.shortcuts import render_to_response, render_to_string
 
@@ -1323,7 +1323,7 @@ def login_user(request, error=""):  # pylint: disable=too-many-statements,unused
 
 @csrf_exempt
 @require_POST
-@social_utils.strategy("social:complete")
+@social_utils.psa("social:complete")
 def login_oauth_token(request, backend):
     """
     Authenticate the client using an OAuth access token by using the token to
@@ -1338,8 +1338,9 @@ def login_oauth_token(request, backend):
             # Tell third party auth pipeline that this is an API call
             request.session[pipeline.AUTH_ENTRY_KEY] = pipeline.AUTH_ENTRY_LOGIN_API
             user = None
+            access_token = request.POST["access_token"]
             try:
-                user = backend.do_auth(request.POST["access_token"])
+                user = backend.do_auth(access_token)
             except (HTTPError, AuthException):
                 pass
             # do_auth can return a non-User object if it fails
@@ -1348,7 +1349,7 @@ def login_oauth_token(request, backend):
                 return JsonResponse(status=204)
             else:
                 # Ensure user does not re-enter the pipeline
-                request.social_strategy.clean_partial_pipeline()
+                request.social_strategy.clean_partial_pipeline(access_token)
                 return JsonResponse({"error": "invalid_token"}, status=401)
         else:
             return JsonResponse({"error": "invalid_request"}, status=400)
@@ -1668,7 +1669,7 @@ def create_account_with_params(request, params):
                 error_message = _("The provided access_token is not valid.")
             if not pipeline_user or not isinstance(pipeline_user, User):
                 # Ensure user does not re-enter the pipeline
-                request.social_strategy.clean_partial_pipeline()
+                request.social_strategy.clean_partial_pipeline(social_access_token)
                 raise ValidationError({'access_token': [error_message]})
 
     # Perform operations that are non-critical parts of account creation

--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -14,7 +14,7 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 from rest_framework.test import APITestCase
 from django.conf import settings
 from django.test.utils import override_settings
-from social.apps.django_app.default.models import UserSocialAuth
+from social_django.models import UserSocialAuth
 
 from student.tests.factories import UserFactory
 from third_party_auth.api.permissions import ThirdPartyAuthProviderApiPermission

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from django.http import Http404
 from rest_framework.generics import ListAPIView
 from rest_framework_oauth.authentication import OAuth2Authentication
-from social.apps.django_app.default.models import UserSocialAuth
+from social_django.models import UserSocialAuth
 from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
     SessionAuthenticationAllowInactiveUser,

--- a/common/djangoapps/third_party_auth/dummy.py
+++ b/common/djangoapps/third_party_auth/dummy.py
@@ -1,8 +1,8 @@
 """
 DummyBackend: A fake Third Party Auth provider for testing & development purposes.
 """
-from social.backends.oauth import BaseOAuth2
-from social.exceptions import AuthFailed
+from social_core.backends.oauth import BaseOAuth2
+from social_core.exceptions import AuthFailed
 
 
 class DummyBackend(BaseOAuth2):  # pylint: disable=abstract-method

--- a/common/djangoapps/third_party_auth/lti.py
+++ b/common/djangoapps/third_party_auth/lti.py
@@ -14,9 +14,9 @@ from oauthlib.oauth1.rfc5849.signature import (
     construct_base_string,
     sign_hmac_sha1,
 )
-from social.backends.base import BaseAuth
-from social.exceptions import AuthFailed
-from social.utils import sanitize_redirect
+from social_core.backends.base import BaseAuth
+from social_core.exceptions import AuthFailed
+from social_core.utils import sanitize_redirect
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class LTIAuthBackend(BaseAuth):
         """
         Prepare to handle a login request.
 
-        This method replaces social.actions.do_auth and must be kept in sync
+        This method replaces social_core.actions.do_auth and must be kept in sync
         with any upstream changes in that method. In the current version of
         the upstream, this means replacing the logic to populate the session
         from request parameters, and not calling backend.start() to avoid

--- a/common/djangoapps/third_party_auth/middleware.py
+++ b/common/djangoapps/third_party_auth/middleware.py
@@ -1,6 +1,6 @@
 """Middleware classes for third_party_auth."""
 
-from social.apps.django_app.middleware import SocialAuthExceptionMiddleware
+from social_django.middleware import SocialAuthExceptionMiddleware
 
 from . import pipeline
 

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -18,12 +18,13 @@ import json
 import logging
 from provider.utils import long_token
 from provider.oauth2.models import Client
-from social.backends.base import BaseAuth
-from social.backends.oauth import OAuthAuth
-from social.backends.saml import SAMLAuth, SAMLIdentityProvider
+from social_core.backends.base import BaseAuth
+from social_core.backends.oauth import OAuthAuth
+from social_core.backends.saml import SAMLAuth, SAMLIdentityProvider
+from social_core.exceptions import SocialAuthBaseException
+from social_core.utils import module_member
+from social_core.backends.saml import SAMLAuth, SAMLIdentityProvider
 from .lti import LTIAuthBackend, LTI_PARAMS_KEY
-from social.exceptions import SocialAuthBaseException
-from social.utils import module_member
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 log = logging.getLogger(__name__)

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -54,7 +54,7 @@ This is surprising but important behavior, since it allows a single function in
 the pipeline to consolidate all the operations needed to establish invariants
 rather than spreading them across two functions in the pipeline.
 
-See http://psa.matiasaguirre.net/docs/pipeline.html for more docs.
+See http://python-social-auth.readthedocs.io/en/latest/pipeline.html for more docs.
 """
 
 import base64
@@ -73,10 +73,11 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect
-from social.apps.django_app.default import models
-from social.exceptions import AuthException
-from social.pipeline import partial
-from social.pipeline.social_auth import associate_by_email
+import social_django
+from social_django import models
+from social_core.exceptions import AuthException
+from social_core.pipeline import partial
+from social_core.pipeline.social_auth import associate_by_email
 
 import student
 
@@ -196,8 +197,14 @@ class ProviderUserState(object):
 
 
 def get(request):
-    """Gets the running pipeline from the passed request."""
-    return request.session.get('partial_pipeline')
+    """Gets the running pipeline's data from the passed request."""
+    strategy = social_django.utils.load_strategy(request)
+    token = strategy.session_get('partial_pipeline_token')
+    partial_object = strategy.partial_load(token)
+    pipeline_data = None
+    if partial_object:
+        pipeline_data = {'kwargs': partial_object.kwargs, 'backend': partial_object.backend}
+    return pipeline_data
 
 
 def get_authenticated_user(auth_provider, username, uid):
@@ -222,7 +229,7 @@ def get_authenticated_user(auth_provider, username, uid):
         user has no social auth associated with the given backend.
         AssertionError: if the user is not authenticated.
     """
-    match = models.DjangoStorage.user.get_social_auth(provider=auth_provider.backend_name, uid=uid)
+    match = social_django.models.DjangoStorage.user.get_social_auth(provider=auth_provider.backend_name, uid=uid)
 
     if not match or match.user.username != username:
         raise User.DoesNotExist
@@ -288,7 +295,7 @@ def get_disconnect_url(provider_id, association_id):
     """Gets URL for the endpoint that starts the disconnect pipeline.
 
     Args:
-        provider_id: string identifier of the models.ProviderConfig child you want
+        provider_id: string identifier of the social_django.models.ProviderConfig child you want
             to disconnect from.
         association_id: int. Optional ID of a specific row in the UserSocialAuth
             table to disconnect (useful if multiple providers use a common backend)
@@ -310,7 +317,7 @@ def get_login_url(provider_id, auth_entry, redirect_url=None):
     """Gets the login URL for the endpoint that kicks off auth with a provider.
 
     Args:
-        provider_id: string identifier of the models.ProviderConfig child you want
+        provider_id: string identifier of the social_django.models.ProviderConfig child you want
             to disconnect from.
         auth_entry: string. Query argument specifying the desired entry point
             for the auth pipeline. Used by the pipeline for later branching.
@@ -373,7 +380,7 @@ def get_provider_user_states(user):
             each enabled provider.
     """
     states = []
-    found_user_auths = list(models.DjangoStorage.user.get_social_auth_for_user(user))
+    found_user_auths = list(social_django.models.DjangoStorage.user.get_social_auth_for_user(user))
 
     for enabled_provider in provider.Registry.enabled():
         association = None
@@ -412,7 +419,7 @@ def make_random_password(length=None, choice_fn=random.SystemRandom().choice):
 
 def running(request):
     """Returns True iff request is running a third-party auth pipeline."""
-    return request.session.get('partial_pipeline') is not None  # Avoid False for {}.
+    return get(request) is not None  # Avoid False for {}.
 
 
 # Pipeline functions.
@@ -423,7 +430,7 @@ def running(request):
 
 def parse_query_params(strategy, response, *args, **kwargs):
     """Reads whitelisted query params, transforms them into pipeline args."""
-    auth_entry = strategy.session.get(AUTH_ENTRY_KEY)
+    auth_entry = strategy.request.session.get(AUTH_ENTRY_KEY)
     if not (auth_entry and auth_entry in _AUTH_ENTRY_CHOICES):
         raise AuthEntryError(strategy.request.backend, 'auth_entry missing or invalid')
 
@@ -493,7 +500,7 @@ def redirect_to_custom_form(request, auth_entry, kwargs):
 
 
 @partial.partial
-def ensure_user_information(strategy, auth_entry, backend=None, user=None, social=None,
+def ensure_user_information(strategy, auth_entry, backend=None, user=None, social=None, current_partial=None,
                             allow_inactive_user=False, *args, **kwargs):
     """
     Ensure that we have the necessary information about a user (either an
@@ -521,7 +528,7 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
 
     def should_force_account_creation():
         """ For some third party providers, we auto-create user accounts """
-        current_provider = provider.Registry.get_from_pipeline({'backend': backend.name, 'kwargs': kwargs})
+        current_provider = provider.Registry.get_from_pipeline({'backend': current_partial.backend, 'kwargs': kwargs})
         return current_provider and current_provider.skip_email_verification
 
     if not user:
@@ -575,7 +582,8 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
 
 
 @partial.partial
-def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=None, *args, **kwargs):
+def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=None, current_partial=None,
+                          *args, **kwargs):
     """This pipeline step sets the "logged in" cookie for authenticated users.
 
     Some installations have a marketing site front-end separate from
@@ -610,7 +618,7 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
             has_cookie = student.cookies.is_logged_in_cookie_set(request)
             if not has_cookie:
                 try:
-                    redirect_url = get_complete_url(backend.name)
+                    redirect_url = get_complete_url(current_partial.backend)
                 except ValueError:
                     # If for some reason we can't get the URL, just skip this step
                     # This may be overly paranoid, but it's far more important that
@@ -622,7 +630,7 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
 
 
 @partial.partial
-def login_analytics(strategy, auth_entry, *args, **kwargs):
+def login_analytics(strategy, auth_entry, current_partial=None, *args, **kwargs):
     """ Sends login info to Segment """
 
     event_name = None
@@ -651,7 +659,7 @@ def login_analytics(strategy, auth_entry, *args, **kwargs):
 
 
 @partial.partial
-def associate_by_email_if_login_api(auth_entry, backend, details, user, *args, **kwargs):
+def associate_by_email_if_login_api(auth_entry, backend, details, user, current_partial=None, *args, **kwargs):
     """
     This pipeline step associates the current social auth with the user with the
     same email address in the database.  It defers to the social library's associate_by_email

--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -4,8 +4,8 @@ Slightly customized python-social-auth backend for SAML 2.0 support
 import logging
 from django.http import Http404
 from django.utils.functional import cached_property
-from social.backends.saml import SAMLAuth, OID_EDU_PERSON_ENTITLEMENT
-from social.exceptions import AuthForbidden, AuthMissingParameter
+from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
+from social_core.exceptions import AuthForbidden, AuthMissingParameter
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +36,6 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
         authenticate the user.
 
         raise Http404 if SAML authentication is disabled.
-        raise AuthMissingParameter if the 'idp' parameter is missing.
         """
         if not self._config.enabled:
             log.error('SAML authentication is not enabled')

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -39,18 +39,18 @@ def apply_settings(django_settings):
     # this pipeline.
     django_settings.SOCIAL_AUTH_PIPELINE = (
         'third_party_auth.pipeline.parse_query_params',
-        'social.pipeline.social_auth.social_details',
-        'social.pipeline.social_auth.social_uid',
-        'social.pipeline.social_auth.auth_allowed',
-        'social.pipeline.social_auth.social_user',
+        'social_core.pipeline.social_auth.social_details',
+        'social_core.pipeline.social_auth.social_uid',
+        'social_core.pipeline.social_auth.auth_allowed',
+        'social_core.pipeline.social_auth.social_user',
         'third_party_auth.pipeline.associate_by_email_if_login_api',
-        'social.pipeline.user.get_username',
+        'social_core.pipeline.user.get_username',
         'third_party_auth.pipeline.set_pipeline_timeout',
         'third_party_auth.pipeline.ensure_user_information',
-        'social.pipeline.user.create_user',
-        'social.pipeline.social_auth.associate_user',
-        'social.pipeline.social_auth.load_extra_data',
-        'social.pipeline.user.user_details',
+        'social_core.pipeline.user.create_user',
+        'social_core.pipeline.social_auth.associate_user',
+        'social_core.pipeline.social_auth.load_extra_data',
+        'social_core.pipeline.user.user_details',
         'third_party_auth.pipeline.set_logged_in_cookies',
         'third_party_auth.pipeline.login_analytics',
     )
@@ -81,6 +81,6 @@ def apply_settings(django_settings):
     # Context processors required under Django.
     django_settings.SOCIAL_AUTH_UUID_LENGTH = 4
     django_settings.DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] += (
-        'social.apps.django_app.context_processors.backends',
-        'social.apps.django_app.context_processors.login_redirect',
+        'social_django.context_processors.backends',
+        'social_django.context_processors.login_redirect',
     )

--- a/common/djangoapps/third_party_auth/strategy.py
+++ b/common/djangoapps/third_party_auth/strategy.py
@@ -4,8 +4,8 @@ ConfigurationModels rather than django.settings
 """
 from .models import OAuth2ProviderConfig
 from .pipeline import AUTH_ENTRY_CUSTOM
-from social.backends.oauth import OAuthAuth
-from social.strategies.django_strategy import DjangoStrategy
+from social_core.backends.oauth import OAuthAuth
+from social_django.strategy import DjangoStrategy
 
 
 class ConfigurationModelStrategy(DjangoStrategy):

--- a/common/djangoapps/third_party_auth/tests/specs/test_generic.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_generic.py
@@ -7,7 +7,7 @@ from third_party_auth.tests import testutil
 from .base import IntegrationTestMixin
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class GenericIntegrationTest(IntegrationTestMixin, testutil.TestCase):
     """
     Basic integration tests of third_party_auth using Dummy provider

--- a/common/djangoapps/third_party_auth/tests/specs/test_google.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_google.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 import json
 from mock import patch
-from social.exceptions import AuthException
+from social_core.exceptions import AuthExceptio
 from student.tests.factories import UserFactory
 from third_party_auth import pipeline
 from third_party_auth.tests.specs import base

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -16,7 +16,7 @@ TESTSHIB_METADATA_URL = 'https://mock.testshib.org/metadata/testshib-providers.x
 TESTSHIB_SSO_URL = 'https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO'
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class TestShibIntegrationTest(IntegrationTestMixin, testutil.SAMLTestCase):
     """
     TestShib provider Integration Test, to test SAML functionality

--- a/common/djangoapps/third_party_auth/tests/specs/test_twitter.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_twitter.py
@@ -19,7 +19,7 @@ class TwitterIntegrationTest(base.Oauth2IntegrationTest):
 
         # To test an OAuth1 provider, we need to patch an additional method:
         patcher = patch(
-            'social.backends.twitter.TwitterOAuth.unauthorized_token',
+            'social_core.backends.twitter.TwitterOAuth.unauthorized_token',
             create=True,
             return_value="unauth_token"
         )

--- a/common/djangoapps/third_party_auth/tests/test_admin.py
+++ b/common/djangoapps/third_party_auth/tests/test_admin.py
@@ -16,7 +16,7 @@ from third_party_auth.tests import testutil
 
 
 # This is necessary because cms does not implement third party auth
-@unittest.skipUnless(settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'), 'third party auth not enabled')
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class Oauth2ProviderConfigAdminTest(testutil.TestCase):
     """
     Tests for oauth2 provider config admin

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -35,7 +35,7 @@ class MakeRandomPasswordTest(testutil.TestCase):
         self.assertEqual(expected, pipeline.make_random_password(choice_fn=random_instance.choice))
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class ProviderUserStateTestCase(testutil.TestCase):
     """Tests ProviderUserState behavior."""
 

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -8,7 +8,7 @@ from django.contrib.auth import models
 
 from third_party_auth import pipeline, provider
 from third_party_auth.tests import testutil
-from social.apps.django_app.default import models as social_models
+from social_django import models as social_models
 
 
 # Get Django User model by reference from python-social-auth. Not a type
@@ -24,8 +24,7 @@ class TestCase(testutil.TestCase, test.TestCase):
         self.enabled_provider = self.configure_google_provider(enabled=True)
 
 
-@unittest.skipUnless(
-    testutil.AUTH_FEATURES_KEY in settings.FEATURES, testutil.AUTH_FEATURES_KEY + ' not in settings.FEATURES')
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class GetAuthenticatedUserTestCase(TestCase):
     """Tests for get_authenticated_user."""
 
@@ -66,8 +65,7 @@ class GetAuthenticatedUserTestCase(TestCase):
         self.assertEqual(self.enabled_provider.get_authentication_backend(), user.backend)
 
 
-@unittest.skipUnless(
-    testutil.AUTH_FEATURES_KEY in settings.FEATURES, testutil.AUTH_FEATURES_KEY + ' not in settings.FEATURES')
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class GetProviderUserStatesTestCase(testutil.TestCase, test.TestCase):
     """Tests generation of ProviderUserStates."""
 
@@ -143,8 +141,7 @@ class GetProviderUserStatesTestCase(testutil.TestCase, test.TestCase):
         self.assertEqual(self.user, linkedin_state.user)
 
 
-@unittest.skipUnless(
-    testutil.AUTH_FEATURES_KEY in settings.FEATURES, testutil.AUTH_FEATURES_KEY + ' not in settings.FEATURES')
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class UrlFormationTestCase(TestCase):
     """Tests formation of URLs for pipeline hook points."""
 

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -6,7 +6,7 @@ from third_party_auth.tests import testutil
 import unittest
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class RegistryTest(testutil.TestCase):
     """Tests registry discovery and operation."""
 

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -44,7 +44,7 @@ class SettingsUnitTest(testutil.TestCase):
         settings.apply_settings(self.settings)
         self.assertEqual(settings._FIELDS_STORED_IN_SESSION, self.settings.FIELDS_STORED_IN_SESSION)
 
-    @unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+    @unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
     def test_apply_settings_enables_no_providers_by_default(self):
         # Providers are only enabled via ConfigurationModels in the database
         settings.apply_settings(self.settings)

--- a/common/djangoapps/third_party_auth/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/tests/test_views.py
@@ -6,14 +6,14 @@ import ddt
 from lxml import etree
 from onelogin.saml2.errors import OneLogin_Saml2_Error
 import unittest
-from .testutil import AUTH_FEATURE_ENABLED, SAMLTestCase
+from .testutil import AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY, SAMLTestCase
 
 # Define some XML namespaces:
 from third_party_auth.tasks import SAML_XML_NS
 XMLDSIG_XML_NS = 'http://www.w3.org/2000/09/xmldsig#'
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
 @ddt.ddt
 class SAMLMetadataTest(SAMLTestCase):
     """
@@ -131,7 +131,7 @@ class SAMLMetadataTest(SAMLTestCase):
         self.assertEqual(support_email_node.text, support_email)
 
 
-@unittest.skipUnless(AUTH_FEATURE_ENABLED, 'third_party_auth not enabled')
+@unittest.skipUnless(AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY + ' not enabled')
 class SAMLAuthTest(SAMLTestCase):
     """
     Test the SAML auth views

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -5,7 +5,8 @@ import httpretty
 
 from provider.constants import PUBLIC
 from provider.oauth2.models import Client
-from social.apps.django_app.default.models import UserSocialAuth
+from social_core.backends.facebook import FacebookOAuth2, API_VERSION as FACEBOOK_API_VERSION
+from social_django.models import UserSocialAuth, Partial
 
 from student.tests.factories import UserFactory
 

--- a/common/djangoapps/third_party_auth/urls.py
+++ b/common/djangoapps/third_party_auth/urls.py
@@ -10,5 +10,5 @@ urlpatterns = patterns(
     url(r'^auth/custom_auth_entry', post_to_custom_auth_form, name='tpa_post_to_custom_auth_form'),
     url(r'^auth/saml/metadata.xml', saml_metadata_view),
     url(r'^auth/login/(?P<backend>lti)/$', lti_login_and_complete_view),
-    url(r'^auth/', include('social.apps.django_app.urls', namespace='social')),
+    url(r'^auth/', include('social_django.urls', namespace='social')),
 )

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -6,10 +6,9 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseServerError, Http404, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import csrf_exempt
-import social
-from social.apps.django_app.views import complete
-from social.apps.django_app.utils import load_strategy, load_backend
-from social.utils import setting_name
+from social_django.utils import load_strategy, load_backend, psa
+from social_django.views import complete
+from social_core.utils import setting_name
 from .models import SAMLConfiguration
 
 URL_NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
@@ -50,7 +49,7 @@ def saml_metadata_view(request):
 
 
 @csrf_exempt
-@social.apps.django_app.utils.psa('{0}:complete'.format(URL_NAMESPACE))
+@psa('{0}:complete'.format(URL_NAMESPACE))
 def lti_login_and_complete_view(request, backend, *args, **kwargs):
     """This is a combination login/complete due to LTI being a one step login"""
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -635,10 +635,10 @@ X_FRAME_OPTIONS = ENV_TOKENS.get('X_FRAME_OPTIONS', X_FRAME_OPTIONS)
 if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     AUTHENTICATION_BACKENDS = (
         ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
-            'social.backends.google.GoogleOAuth2',
-            'social.backends.linkedin.LinkedinOAuth2',
-            'social.backends.facebook.FacebookOAuth2',
-            'social.backends.azuread.AzureADOAuth2',
+            'social_core.backends.google.GoogleOAuth2',
+            'social_core.backends.linkedin.LinkedinOAuth2',
+            'social_core.backends.facebook.FacebookOAuth2',
+            'social_core.backends.azuread.AzureADOAuth2',
             'third_party_auth.saml.SAMLAuthBackend',
             'third_party_auth.lti.LTIAuthBackend',
         ]) + list(AUTHENTICATION_BACKENDS)

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -137,9 +137,9 @@
     "TECH_SUPPORT_EMAIL": "technical@example.com",
     "THEME_NAME": "",
     "THIRD_PARTY_AUTH_BACKENDS": [
-        "social.backends.google.GoogleOAuth2",
-        "social.backends.linkedin.LinkedinOAuth2",
-        "social.backends.facebook.FacebookOAuth2",
+        "social_core.backends.google.GoogleOAuth2",
+        "social_core.backends.linkedin.LinkedinOAuth2",
+        "social_core.backends.facebook.FacebookOAuth2",
         "third_party_auth.dummy.DummyBackend",
         "third_party_auth.saml.SAMLAuthBackend"
     ],

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2013,7 +2013,7 @@ INSTALLED_APPS = (
 
     # edX Mobile API
     'mobile_api',
-    'social.apps.django_app.default',
+    'social_django',
 
     # Surveys
     'survey',
@@ -2092,7 +2092,7 @@ INSTALLED_APPS = (
 
 # Migrations which are not in the standard module "migrations"
 MIGRATION_MODULES = {
-    'social.apps.django_app.default': 'social.apps.django_app.default.south_migrations'
+    'social_django': 'social_django.south_migrations'
 }
 
 ######################### CSRF #########################################

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -258,11 +258,11 @@ PASSWORD_COMPLEXITY = {}
 FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
 
 AUTHENTICATION_BACKENDS = (
-    'social.backends.google.GoogleOAuth2',
-    'social.backends.linkedin.LinkedinOAuth2',
-    'social.backends.facebook.FacebookOAuth2',
-    'social.backends.azuread.AzureADOAuth2',
-    'social.backends.twitter.TwitterOAuth',
+    'social_core.backends.google.GoogleOAuth2',
+    'social_core.backends.linkedin.LinkedinOAuth2',
+    'social_core.backends.facebook.FacebookOAuth2',
+    'social_core.backends.azuread.AzureADOAuth2',
+    'social_core.backends.twitter.TwitterOAuth',
     'third_party_auth.dummy.DummyBackend',
     'third_party_auth.saml.SAMLAuthBackend',
     'third_party_auth.lti.LTIAuthBackend',
@@ -542,7 +542,7 @@ SEARCH_ENGINE = "search.tests.mock_search_engine.MockSearchEngine"
 
 FACEBOOK_APP_SECRET = "Test"
 FACEBOOK_APP_ID = "Test"
-FACEBOOK_API_VERSION = "v2.2"
+FACEBOOK_API_VERSION = "v2.8"
 
 ######### custom courses #########
 INSTALLED_APPS += ('lms.djangoapps.ccx', 'openedx.core.djangoapps.ccxcon')

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -84,7 +84,9 @@ python-dateutil==2.1
 # This module gets monkey-patched in third_party_auth.py to fix a Django 1.8 incompatibility.
 # When this dependency gets upgraded, the monkey patch should be removed, if possible.
 # We can also remove the fix to auth_url in third_party_auth/saml.py when that fix is included upstream.
-python-social-auth==0.2.12
+# python-social-auth==0.2.12
+social-auth-app-django==1.2.0
+social-auth-core==1.4.0
 
 pytz==2015.2
 pysrt==0.4.7


### PR DESCRIPTION
Since Dec 03 2016  python-social-auth is marked as deprecated and the community is recommended to migrate `social-auth-core, social-auth-app-django, social-auth-app-mongoengine` and Aquent is using Eucalyptus version of OpenEDX and they were using Linkedin for SSO. Linkedin login stopped working because of PSA lib changes and we had to do following changes to bring it back to work