### PR TITLE
Set empty defaults for Appsembler features in common envs

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1339,3 +1339,6 @@ RECALCULATE_GRADES_ROUTING_KEY = LOW_PRIORITY_QUEUE
 
 ############## Settings for CourseGraph ############################
 COURSEGRAPH_JOB_QUEUE = LOW_PRIORITY_QUEUE
+
+############## Appsembler defaults for test env etc. ############################
+APPSEMBLER_FEATURES = {}

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3222,3 +3222,9 @@ COURSES_API_CACHE_TIMEOUT = 3600  # Value is in seconds
 
 ############## Settings for CourseGraph ############################
 COURSEGRAPH_JOB_QUEUE = LOW_PRIORITY_QUEUE
+
+
+############## Appsembler defaults for test env etc. ############################
+
+APPSEMBLER_FEATURES = {}
+CUSTOM_LOGOUT_REDIRECT_URL = None


### PR DESCRIPTION
We need empty defaults for some Appsembler specific features in common.py, so that tests don't fail from those settings not being defined by inheritance in the test env.