### PR TITLE
Set empty defaults for Appsembler features in common envs

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1541,3 +1541,8 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS, plugin_c
 # setting for the FileWrapper class used to iterate over the export file data.
 # See: https://docs.python.org/2/library/wsgiref.html#wsgiref.util.FileWrapper
 COURSE_EXPORT_DOWNLOAD_CHUNK_SIZE = 8192
+
+
+############## Appsembler defaults for test env etc. ############################
+
+APPSEMBLER_FEATURES = {}

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3478,3 +3478,9 @@ USER_STATE_BATCH_SIZE = 5000
 from openedx.core.djangoapps.plugins import plugin_apps, plugin_settings, constants as plugin_constants
 INSTALLED_APPS.extend(plugin_apps.get_apps(plugin_constants.ProjectType.LMS))
 plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_constants.SettingsType.COMMON)
+
+
+############## Appsembler defaults for test env etc. ############################
+
+APPSEMBLER_FEATURES = {}
+CUSTOM_LOGOUT_REDIRECT_URL = None


### PR DESCRIPTION
We need to add empty defaults for these so that we can run tests; e.g., `pytest -s lms -x` etc. since we on't have a `test_appsembler.py` environment. 