### PR TITLE
Fixed typo import statement for Tahoe API v1 views

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -3,7 +3,7 @@
 Only include view classes here. See the tests/test_permissions.py:get_api_classes()
 method.
 """
-from distutils.util import strtoobool
+from distutils.util import strtobool
 from functools import partial
 import logging
 import random


### PR DESCRIPTION
One concern is that any one of the Tahoe v1 API view tests should have caught this just by importing the `v1.views` module and they didn't