### PR TITLE
Fix inconsistent line breaks while creating course updates

### DIFF
--- a/common/static/js/vendor/CodeMirror/codemirror.css
+++ b/common/static/js/vendor/CodeMirror/codemirror.css
@@ -195,7 +195,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 .CodeMirror-wrap pre {
   word-wrap: break-word;
   white-space: pre-wrap;
-  word-break: normal;
+  word-break: break-word;
 }
 .CodeMirror-code pre {
   border-right: 30px solid transparent;


### PR DESCRIPTION
Cherry picks https://github.com/edx/edx-platform/pull/19561 to fix the CodeMirror issue https://github.com/codemirror/CodeMirror/issues/1642.

Coucidently it's @MHaton's nemeses.

This is shared in all of the Hawthorn (and pre-hawthorn) sites. So I created this issue in Black Team:

 - 