### PR TITLE
Enable Django REST Framework Auth Tokens for Enterprise Hawthorn

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2163,6 +2163,7 @@ INSTALLED_APPS = [
 
     # User API
     'rest_framework',
+    'rest_framework.authtoken',
     'openedx.core.djangoapps.user_api',
 
     # Shopping cart


### PR DESCRIPTION
See here: https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication

We enable DRF auth tokens in Tahoe: https://github.com/appsembler/edx-platform/blob/appsembler/tahoe/master/lms/envs/common.py#L2171

This PR enables remote backends to use Django REST Framework's auth tokens to retrieve data
