### PR TITLE
Tahoe Registration API fix and updated tests

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
@@ -76,6 +76,7 @@ class RegistrationApiViewTests(TestCase):
             'password': 'some-password',
             'send_activation_email': send_activation_email,
         }
+
         def fake_send(user, profile, user_registration=None):
             assert send_activation_email in [True, 'True', 'true'], 'activation email should not be called'
 
@@ -93,6 +94,7 @@ class RegistrationApiViewTests(TestCase):
             'name': 'Mr Potato Head',
             'send_activation_email': send_activation_email,
         }
+
         def fake_send(user, profile, user_registration=None):
             assert False, 'Should not call fake_send when no password'
 
@@ -115,4 +117,3 @@ class RegistrationApiViewTests(TestCase):
         res = self.client.post(self.url, params)
         self.assertContains(
             res, 'Invalid parameters on user creation', status_code=400)
-

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -177,8 +177,9 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
         if password_provided:
             try:
                 # Default behavior is True - send the email
-                data['send_activation_email'] = bool(strtobool(
-                    str(data.get('send_activation_email', True))))
+
+                data['send_activation_email'] == self._normalize_bool_param(
+                    data.get('send_activation_email', True))
             except ValueError:
                 errors = {
                     'user_message': '{0} is not a valid value for "send_activation_email"'.format(
@@ -227,20 +228,16 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
             return Response(errors, status=400)
         return Response({'user_id ': user_id}, status=200)
 
-    def _normalize_send_activation_email(self, value):
+    def _normalize_bool_param(self, value):
         """
         Allow string `False`/`True` to be used by the API caller.
         """
-        if value == "False":
-            value == False
-        elif value == "True":
-            value = True
-
-        if not (value == False or value == True):
-            # Return 400 Bad Request to the API caller
-            raise SomeKindOfException("Invalid request")
-
-        return value
+        # data['send_activation_email'] = bool(strtobool(
+            # str(data.get('send_activation_email', True))))
+        value = str(value)
+        if not value.lower() in ['false', 'true']:
+            raise ValidationError('invalid value {0} for boolean type'.format(value))
+        return True if value == 'true' else False
 
 
 class CourseViewSet(TahoeAuthMixin, viewsets.ReadOnlyModelViewSet):

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -171,14 +171,14 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
 
         # set the honor_code and honor_code like checked,
         # so we can use the already defined methods for creating an user
-        data['honor_code'] = True
-        data['terms_of_service'] = True
+        data['honor_code'] = 'True'
+        data['terms_of_service'] = 'True'
 
         if password_provided:
             try:
                 # Default behavior is True - send the email
-                data['send_activation_email'] = strtobool(
-                    str(data.get('send_activation_email', True)))
+                data['send_activation_email'] = bool(strtobool(
+                    str(data.get('send_activation_email', True))))
             except ValueError:
                 errors = {
                     'user_message': '{0} is not a valid value for "send_activation_email"'.format(

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -177,7 +177,26 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
         if password_provided:
             try:
                 # Default behavior is True - send the email
-                data['send_activation_email'] = bool(strtobool(
+    def _normalize_send_activation_email(self, value):
+        """
+        Allow string `False`/`True` to be used by the API caller.
+        """
+        if value == "False":
+            value == False
+        elif value == "True":
+            value = True
+
+        if not (value == False or value == True):
+            # Return 400 Bad Request to the API caller
+            raise SomeKindOfException("Invalid request")
+
+        return value
+
+    def create(self, request):
+        # ...
+        data['send_activation_email'] == _normalize_send_activation_email(data['send_activation_email'])
+        # ...
+
                     str(data.get('send_activation_email', True))))
             except ValueError:
                 errors = {

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -227,6 +227,21 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
             return Response(errors, status=400)
         return Response({'user_id ': user_id}, status=200)
 
+    def _normalize_send_activation_email(self, value):
+        """
+        Allow string `False`/`True` to be used by the API caller.
+        """
+        if value == "False":
+            value == False
+        elif value == "True":
+            value = True
+
+        if not (value == False or value == True):
+            # Return 400 Bad Request to the API caller
+            raise SomeKindOfException("Invalid request")
+
+        return value
+
 
 class CourseViewSet(TahoeAuthMixin, viewsets.ReadOnlyModelViewSet):
     """Provides course information

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -230,10 +230,9 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
 
     def _normalize_bool_param(self, value):
         """
-        Allow string `False`/`True` to be used by the API caller.
+        Allow strings of any case (upper/lower) to be used by the API caller.
+        For example "False", "false", "TRUE"
         """
-        # data['send_activation_email'] = bool(strtobool(
-            # str(data.get('send_activation_email', True))))
         value = str(value)
         if not value.lower() in ['false', 'true']:
             raise ValidationError('invalid value {0} for boolean type'.format(value))

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -177,26 +177,7 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
         if password_provided:
             try:
                 # Default behavior is True - send the email
-    def _normalize_send_activation_email(self, value):
-        """
-        Allow string `False`/`True` to be used by the API caller.
-        """
-        if value == "False":
-            value == False
-        elif value == "True":
-            value = True
-
-        if not (value == False or value == True):
-            # Return 400 Bad Request to the API caller
-            raise SomeKindOfException("Invalid request")
-
-        return value
-
-    def create(self, request):
-        # ...
-        data['send_activation_email'] == _normalize_send_activation_email(data['send_activation_email'])
-        # ...
-
+                data['send_activation_email'] = bool(strtobool(
                     str(data.get('send_activation_email', True))))
             except ValueError:
                 errors = {

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -228,14 +228,14 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
             return Response(errors, status=400)
         return Response({'user_id ': user_id}, status=200)
 
-    def _normalize_bool_param(self, value):
+    def _normalize_bool_param(self, unnormalized):
         """
         Allow strings of any case (upper/lower) to be used by the API caller.
         For example "False", "false", "TRUE"
         """
-        value = str(value)
-        if not value.lower() in ['false', 'true']:
-            raise ValidationError('invalid value {0} for boolean type'.format(value))
+        normalized = str(unnormalized).lower()
+        if normalized not in ['false', 'true']:
+            raise ValidationError('invalid value {unnormalized} for boolean type'.format(unnormalized))
         return True if value == 'true' else False
 
 


### PR DESCRIPTION
1. Fixed invalid `send_activation_email` values

`distutils.utils.stritobool` returns a `0` or `1` instead of `False` or `True`. This fix casts the result of `strtobool` to a boolean type.

2. Updated registration api tests for `send_activation_email`

Added a couple of mock functions in `test_registration_api.py` to make sure
that the activation email is not sent if `send_activation_email` is set to `False`, 'False', or 'false' and that the activation email is not sent if password is not provided in the registration "create account" API call.
