### PR TITLE
Fix account removal redirect link

### DIFF
--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -31,7 +31,8 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
     this.props.onClose();
 
     removeLoggedInCookies();
-    window.location.href = 'https://www.edx.org';
+    // Appsembler: Changed this from edx.org to the customer's site.
+    window.location.href = location.protocol + '//' + location.host + '/';
   }
 
   deleteAccount() {


### PR DESCRIPTION
When a user requests to delete their account, just redirect them to Appsembler's site instead of edX's site.