### PR TITLE
Fixed Reg API 'send_activation_email' normalization

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -178,7 +178,7 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
             try:
                 # Default behavior is True - send the email
 
-                data['send_activation_email'] == self._normalize_bool_param(
+                data['send_activation_email'] = self._normalize_bool_param(
                     data.get('send_activation_email', True))
             except ValueError:
                 errors = {


### PR DESCRIPTION
Had a comparison operator instead of assignment for the 'send_activation_email' normalization assignment