### PR TITLE
hide instructor dasboard cdertificates tab if html certs not enabled

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -190,7 +190,7 @@ def instructor_dashboard_2(request, course_id):
     # and enable self-generated certificates for a course.
     # Note: This is hidden for all CCXs
     certs_enabled = CertificateGenerationConfiguration.current().enabled and not hasattr(course_key, 'ccx')
-    if certs_enabled and (access['admin'] or access['staff']):
+    if certs_enabled and (access['admin'] or access['staff']) and configuration_helpers.get_value("CERTIFICATES_HTML_VIEW", False):
         sections.append(_section_certificates(course))
 
     openassessment_blocks = modulestore().get_items(

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -190,7 +190,7 @@ def instructor_dashboard_2(request, course_id):
     # and enable self-generated certificates for a course.
     # Note: This is hidden for all CCXs
     certs_enabled = CertificateGenerationConfiguration.current().enabled and not hasattr(course_key, 'ccx')
-    if certs_enabled and (access['admin'] or access['staff']) and configuration_helpers.get_value("CERTIFICATES_HTML_VIEW", False):
+    if certs_enabled and (access['admin'] or access['staff']) and configuration_helpers.get_value('CERTIFICATES_HTML_VIEW', False):
         sections.append(_section_certificates(course))
 
     openassessment_blocks = modulestore().get_items(


### PR DESCRIPTION
For context: https://appsembler.atlassian.net/wiki/spaces/RT/pages/45252758/Instructor+Dashboard+Hiding+Certificates+tab+until+HTML+certificates+are+enabled+in+AMC