### PR TITLE
Show the hubspot integration only for AMC admins

### DIFF
--- a/openedx/core/djangoapps/appsembler/analytics/context_processors.py
+++ b/openedx/core/djangoapps/appsembler/analytics/context_processors.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from student.auth import user_has_role
 from student.roles import CourseCreatorRole
 
+from openedx.core.djangoapps.appsembler.analytics.helpers import should_show_hubspot
+
 
 def google_analytics(request):
     data = {
@@ -28,10 +30,9 @@ def mixpanel(request):
 
 
 def hubspot(request):
-    user = request.user
     hubspot_portal_id = getattr(settings, 'HUBSPOT_PORTAL_ID', None)
     data = {
         'HUBSPOT_PORTAL_ID': hubspot_portal_id,
-        'SHOW_HUBSPOT': hubspot_portal_id and user.is_authenticated() and user_has_role(user, CourseCreatorRole()),
+        'SHOW_HUBSPOT': hubspot_portal_id and should_show_hubspot(request.user),
     }
     return data

--- a/openedx/core/djangoapps/appsembler/analytics/helpers.py
+++ b/openedx/core/djangoapps/appsembler/analytics/helpers.py
@@ -1,0 +1,22 @@
+"""
+Helpers for the Appsembler Analytics app.
+"""
+
+from organizations.models import UserOrganizationMapping
+
+
+def should_show_hubspot(user):
+    if not user or not user.is_authenticated():
+        return False
+
+    if not user.is_active:
+        return False
+
+    if user.is_superuser or user.is_staff:
+        return False
+
+    mapping = UserOrganizationMapping.objects.get(user=user)
+    if not (mapping.is_amc_admin and mapping.is_active):
+        return False
+
+    return True

--- a/openedx/core/djangoapps/appsembler/analytics/tests.py
+++ b/openedx/core/djangoapps/appsembler/analytics/tests.py
@@ -1,0 +1,56 @@
+"""
+Tests for the Appsembler Analytics app.
+"""
+
+from django.test import TestCase
+from openedx.core.djangoapps.appsembler.analytics.helpers import should_show_hubspot
+from openedx.core.djangoapps.appsembler.api.tests.factories import UserOrganizationMappingFactory
+from mock import patch
+from django.contrib.auth.models import User
+
+
+@patch.object(User, 'is_authenticated', return_value=True)
+class AnalyticsHelpersTests(TestCase):
+    def setUp(self):
+        super(AnalyticsHelpersTests, self).setUp()
+        self.mapping = UserOrganizationMappingFactory.create(is_amc_admin=True, is_active=True)
+        self.user = self.mapping.user
+        self.org = self.mapping.organization
+
+    def test_happy_scenario(self, _is_authd):
+        assert self.user.is_authenticated()
+        assert should_show_hubspot(self.user)
+
+    def test_disable_for_non_auth(self, is_authd):
+        is_authd.return_value = False
+        assert not self.user.is_authenticated()
+        assert not should_show_hubspot(self.user)
+
+    def test_disable_for_none(self, _is_authd):
+        assert not should_show_hubspot(None)
+
+    def test_disable_for_super_users(self, _is_authd):
+        self.user.is_superuser = True
+        assert not should_show_hubspot(self.user)
+
+    def test_disable_for_staff_users(self, _is_authd):
+        self.user.is_staff = True
+        assert not should_show_hubspot(self.user)
+
+    def test_disable_for_non_staff(self, _is_authd):
+        self.user.is_staff = True
+        assert not should_show_hubspot(self.user)
+
+    def test_disable_for_non_amc_admin(self, _is_authd):
+        self.mapping.is_amc_admin = False
+        self.mapping.save()
+        assert not should_show_hubspot(self.user)
+
+    def test_disable_for_non_active_amc_membership(self, _is_authd):
+        self.mapping.is_active = False
+        self.mapping.save()
+        assert not should_show_hubspot(self.user)
+
+    def test_disable_for_non_active(self, _is_authd):
+        self.user.is_active = False
+        assert not should_show_hubspot(self.user)


### PR DESCRIPTION
Otherwise it'd be showing a ton of false HubSpot leads.

Jira: [Intercom on Tahoe: Course members are appearing as new leads in HubSpot](https://appsembler.atlassian.net/browse/RED-431).