### PR TITLE
Fix broken KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS feature + refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
   - TOXENV=pep8
   - TOXENV=py27-django111
     ARGS="-- paver run_pep8"
+  - TOXENV=py27-django111
+    ARGS="-- pytest common/djangoapps/student/tests/test_helpers.py::TestDestroyOAuthTokensHelper"
 
 script:
   - tox $ARGS

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -383,7 +383,7 @@ def destroy_oauth_tokens(user):
     dop_access_query = dop_access_token.objects.filter(user=user.id)
     dop_refresh_query = dop_refresh_token.objects.filter(user=user.id)
 
-    if not settings.FEATURES.get('KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS', False):
+    if settings.FEATURES.get('KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS', False):
         # Appsembler: Avoid deleting the trusted confidential clients such as the Appsembler Management Console
         trusted_clients = Client.objects.filter(
             client_type=CONFIDENTIAL,

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -123,7 +123,6 @@ class TestLoginHelper(TestCase):
             validate_login()
 
 
-@patch.dict(settings.FEATURES, {'KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS': True})
 class TestDestroyOAuthTokensHelper(TestCase):
     def setUp(self):
         super(TestDestroyOAuthTokensHelper, self).setUp()
@@ -153,6 +152,7 @@ class TestDestroyOAuthTokensHelper(TestCase):
             message='Tokens of a trusted confidential client should be deleted if the feature is disabled',
         )
 
+    @patch.dict(settings.FEATURES, {'KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS': True})
     def test_confidential_trusted_client(self):
         """
         Tokens that have a confidential TrustedClient shouldn't be removed.
@@ -163,6 +163,7 @@ class TestDestroyOAuthTokensHelper(TestCase):
             message='Tokens of a trusted confidential client should be kept',
         )
 
+    @patch.dict(settings.FEATURES, {'KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS': True})
     def test_no_trusted_client(self):
         """
         Only tokens that don't have a TrustedClient should be removed.
@@ -173,6 +174,7 @@ class TestDestroyOAuthTokensHelper(TestCase):
             message='Tokens of an untrusted client should be deleted',
         )
 
+    @patch.dict(settings.FEATURES, {'KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS': True})
     def test_public_trusted_client(self):
         """
         Tokens for public clients are removed, even if they're trusted.


### PR DESCRIPTION
“The simplest things are the hardest to understand.”
 ― [Kevin Wilson, The Family Fang](https://www.goodreads.com/quotes/754076-the-simplest-things-are-the-hardest-to-understand)

The `not` was incorrect and stale, it's been the case since #429 

Please, run the tests before approving this pull request:

```shell
$ pytest common/djangoapps/student/tests/test_helpers.py::TestDestroyOAuthTokensHelper
```

This is the fourth pull request after the following: #398, #416 and #429 so I've got to get right this time, right?