### PR TITLE
Site-Configurable registration behavior for activation of user in organization

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -132,6 +132,11 @@ from openedx.core.djangoapps.catalog.utils import get_programs_data
 # try to import appsembler fork of edx-organizations (if it's installed)
 try:
     from organizations.models import Organization, UserOrganizationMapping
+    USERORGMAPPING_AVAILABLE = True
+except ImportError:
+    USERORGMAPPING_AVAILABLE = False
+
+try:
     from hr_management.views import send_microsite_request_email_to_managers
 except ImportError:
     pass
@@ -1866,7 +1871,7 @@ def create_account_with_params(request, params):
         _enroll_user_in_pending_courses(user)  # Enroll student in any pending courses
 
     #if using custom Appsembler backend from edx-organizations
-    if u'organizations.backends.OrganizationMemberBackend' in settings.AUTHENTICATION_BACKENDS:
+    if u'organizations.backends.OrganizationMemberBackend' in settings.AUTHENTICATION_BACKENDS and USERORGMAPPING_AVAILABLE:
         org = configuration_helpers.get_value('course_org_filter')
         organization = Organization.objects.filter(name=org).first()
         if organization:

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -138,8 +138,9 @@ except ImportError:
 
 try:
     from hr_management.views import send_microsite_request_email_to_managers
+    HR_MANAGEMENT_INSTALLED = True
 except ImportError:
-    pass
+    HR_MANAGEMENT_INSTALLED = False
 
 log = logging.getLogger("edx.student")
 AUDIT_LOG = logging.getLogger("audit")
@@ -1875,8 +1876,10 @@ def create_account_with_params(request, params):
         org = configuration_helpers.get_value('course_org_filter')
         organization = Organization.objects.filter(name=org).first()
         if organization:
-            UserOrganizationMapping.objects.get_or_create(user=user, organization=organization, is_active=False)
-            send_microsite_request_email_to_managers(request, user)
+            activate_org_access = get_value('set_new_org_member_active', True)
+            UserOrganizationMapping.objects.get_or_create(user=user, organization=organization, is_active=activate_org_access)
+            if not activate_org_access and HR_MANAGEMENT_INSTALLED:  # activation must be approved
+                send_microsite_request_email_to_managers(request, user)
 
     # Immediately after a user creates an account, we log them in. They are only
     # logged in until they close the browser. They can't log in again until they click

--- a/lms/templates/emails/activation_held_email.txt
+++ b/lms/templates/emails/activation_held_email.txt
@@ -1,0 +1,28 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
+
+${_("Thank you for creating an account with {platform_name}!").format(
+    platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+)}
+
+${_("We've received your request to access {platform_name}.  "
+"Requests to join {platform_name} require approval from its manager. "
+"They have been notified and will contact you by email when they have reviewed your request. "
+"Once you receive that email, you must also activate your {platform_name} account. "
+"To activate your account, click the following link. If that doesn't work, copy and paste the link into your browser's address bar.").format(
+      platform_name=configuration_helpers.get_value(
+      'PLATFORM_NAME', settings.PLATFORM_NAME)
+  )
+}
+
+<% base_url=configuration_helpers.get_value('SITE_NAME', settings.SITE_NAME) %>
+% if is_secure:
+  https://${ base_url }/activate/${ key }
+% else:
+  http://${ base_url }/activate/${ key }
+% endif
+
+${_("If you didn't create an account, you don't need to do anything; you "
+      "won't receive any more email from us. If you need assistance, please "
+      "do not reply to this email message. Check the help section of the "
+      "{platform_name} website.").format(platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME))}

--- a/lms/templates/emails/activation_held_email_subject.txt
+++ b/lms/templates/emails/activation_held_email_subject.txt
@@ -1,0 +1,6 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
+
+${_("Your request for access to {platform_name}").format(
+    platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME
+))}


### PR DESCRIPTION
Work done for https://appsembler.atlassian.net/browse/BLACK-352

Looks for a new SiteConfiguration variable "set_new_org_member_active", defaulting to True if absent, to determine whether a new registrant user should be activated for the Organization associated with the Site.  

Add new activation email templates for the False case, to let user know they will also have to be approved for the Site (that apprioval functionality relies on add-on app hr_management, currently only in use by NYIF). 

Clean-up/defensive coding around presence of HR Management app and UserOrganizationMapping model.

