### PR TITLE
Travis cleanup + allow running any test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,14 @@ install:
   - pip install tox
 
 env:
-  - TOXENV=pep8
-  - TOXENV=py27-paver-pep8
-  - TOXENV=py27-studio
-  - TOXENV=py27-lms
+  global:
+    # Avoid caching edx-platform's entry_points
+    - TRAVIS_FIXES="pip install -r requirements/edx/local.in"
+  jobs:
+    - TOXENV=pep8
+    - TOXENV=py27-paver-pep8
+    - TOXENV=py27-studio
+    - TOXENV=py27-lms
 
 script:
   - tox $ARGS

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ usedevelop=True
 setenv =
     PYTHONHASHSEED=0
     TOXENV={envname}
+    TRAVIS_FIXES={env:TRAVIS_FIXES:echo}
 passenv =
     BOK_CHOY_CMS_PORT
     BOK_CHOY_HOSTNAME
@@ -44,19 +45,16 @@ passenv =
     SHARD
     SKIP_NPM_INSTALL
     TEST_SUITE
+    TRAVIS_FIXES
 deps =
     Django>=1.11,<2
     -r{toxinidir}/requirements/edx/testing.txt
     -r{toxinidir}/requirements/edx/appsembler.txt
 whitelist_externals =
     /bin/bash
-    /usr/bin/curl
+    /bin/echo
     /bin/tar
-commands =
-    # Upgrade sqlite to fix crashes during testing.
-    bash scripts/upgrade_pysqlite.sh
-    # Now perform testing.
-    {posargs}
+    /usr/bin/curl
 
 [testenv:py27-paver-pep8]
 commands =
@@ -68,16 +66,14 @@ commands =
 commands =
     # Upgrade sqlite to fix crashes during testing.
     bash scripts/upgrade_pysqlite.sh
-    # Avoid caching edx-platform's entry_points
-    pip install -r requirements/edx/local.in
+    {env:TRAVIS_FIXES}
     pytest cms/djangoapps/contentstore/views/tests/test_assets.py::AssetToJsonTestCase
 
 [testenv:py27-lms]
 commands =
     # Upgrade sqlite to fix crashes during testing.
     bash scripts/upgrade_pysqlite.sh
-    # Avoid caching edx-platform's entry_points
-    pip install -r requirements/edx/local.in
+    {env:TRAVIS_FIXES}
     pytest \
         lms/djangoapps/course_api/ \
         lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py \
@@ -87,6 +83,12 @@ commands =
         openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py \
         openedx/core/djangoapps/user_api/accounts/tests/test_utils.py::CompletionUtilsTestCase
 
+[testenv:pytest]
+basepython=python2.7
+commands =
+    # Upgrade sqlite to fix crashes during testing.
+    bash scripts/upgrade_pysqlite.sh
+    pytest {posargs}
 
 [testenv:pep8]
 deps =


### PR DESCRIPTION
Any tests can be run now without Docker via the command below:

```
$ tox -e pytest some_test.py
```
