### PR TITLE
docker and cloudbuild setup for running tox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+**/__pycache__
+.pytest_cache
+.prereqs_cache
+**/*.pyc

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,3 @@
+.git
+**/__pycache__
+**/*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+FROM ubuntu:16.04
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y \
+    apt-transport-https \
+    build-essential \
+    gcc \
+    g++ \
+    gettext \
+    git \
+    git-core \
+    gfortran \
+    golang \
+    graphviz \
+    graphviz-dev \
+    language-pack-en \
+    libblas-dev \
+    liblapack-dev \
+    libatlas-base-dev \
+    libfreetype6-dev \
+    libssl-dev \
+    libffi-dev \
+    libgeos-dev \
+    libjpeg8-dev \
+    libsqlite3-dev \
+    libmysqlclient-dev \
+    libpng12-dev \
+    libpq-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libxslt1-dev \
+    memcached \
+    mongodb \
+    openssl \
+    pkg-config \
+    python-apt \
+    python-dev \
+    python-mysqldb \
+    python-cryptography \
+    python-pip \
+    python-setuptools \
+    python-virtualenv \
+    software-properties-common \
+    swig \
+  && pip install setuptools -U \
+  && pip install virtualenv \
+  && pip install more-itertools==5.0.0 \
+  && pip install tox
+
+# COPY nodesource.gpg.key /tmp/nodesource.gpg.key
+# RUN apt-key add /tmp/nodesource.gpg.key \
+#   && echo 'deb https://deb.nodesource.com/node_8.x xenial main' > /etc/apt/sources.list.d/nodesource.list \
+#   && echo 'deb-src https://deb.nodesource.com/node_8.x xenial main' >> /etc/apt/sources.list.d/nodesource.list \
+#   && apt-get update \
+#   && apt-get install -y nodejs
+
+WORKDIR /app
+COPY . /app
+
+ENTRYPOINT ["/app/scripts/docker_tox.sh"]

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,12 @@ upgrade: ## update the pip requirements files to use the latest releases satisfy
 	grep "^django==" requirements/edx/base.txt > requirements/edx/django.txt
 	sed '/^[dD]jango==/d' requirements/edx/testing.txt > requirements/edx/testing.tmp
 	mv requirements/edx/testing.tmp requirements/edx/testing.txt
+
+.PHONY: docker-tox
+docker-tox:
+	docker build . -t edx-platform-tox
+	docker run edx-platform-tox
+
+.PHONY: cloudbuild
+cloudbuild:
+	gcloud builds submit --config cloudbuild.yaml .  --project=appsembler-infrastructure

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,8 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/appsembler-infrastructure/edx-platform-tox', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['run', 'gcr.io/appsembler-infrastructure/edx-platform-tox']
+
+images: ['gcr.io/appsembler-infrastructure/edx-platform-tox']
+timeout: 7200s

--- a/scripts/docker_tox.sh
+++ b/scripts/docker_tox.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir -p /data/db
+mongod --fork --logpath /tmp/mongod.log
+
+# Clear the mongo database
+# Note that this prevents us from running jobs in parallel on a single worker.
+mongo --quiet --eval 'db.getMongo().getDBNames().forEach(function(i){db.getSiblingDB(i).dropDatabase()})'
+
+tox


### PR DESCRIPTION
OK. This might be a little pointless as it is, but I'm hoping that some day some other things come together and this will be more useful. 

Basically, since @OmarIthawi got the tox tests working nicely on Travis, that's a big improvement. It would still be really nice to be able to run them locally. The tests require a pretty specific environment with mongodb running locally.

This PR adds a docker setup so we can at least run the tox tests locally (as long as you have docker installed) by running `make docker-tox`

Of course, if you try it, you will discover that the combination of docker and tox and the gigantic edx-platform repo makes things very, very slow and not really usable. I'm going to play around with some approaches to improve that in the future (eg, mounting the `tox_env` as a volume so it can be re-used between runs) but I don't want to spend too much more time on it right now.

As a slight improvement, I also added a cloudbuild config so you can do `make cloudbuild` and it will run the whole docker/tox thing on Cloud Build instead of on your local machine. It still has to bundle up the entire local environment and upload that to google on each run though, and that's about 66MB of data that gets uploaded (gzipped) and will take a few minutes unless you have a blazing fast network connection.

Otherwise, the Dockerfile is largely cribbed from the one I put together last year when we were trying to run tests on Jenkins. I haven't gone back and stripped out dependencies that aren't needed for tox yet.