### PR TITLE
Conditionally enable Django REST framework browsable renderer

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1094,6 +1094,14 @@ RETIREMENT_SERVICE_WORKER_USERNAME = ENV_TOKENS.get(
 )
 RETIREMENT_STATES = ENV_TOKENS.get('RETIREMENT_STATES', RETIREMENT_STATES)
 
+##################### Settings for Django REST framework #####################
+if FEATURES.get('ENABLE_DRF_BROWSABLE_API', False):
+    drf_renderers = list(REST_FRAMEWORK.get('DEFAULT_RENDERER_CLASSES', []))
+    browsable_renderer = 'rest_framework.renderers.BrowsableAPIRenderer'
+    if browsable_renderer not in drf_renderers:
+        drf_renderers.append(browsable_renderer)
+        REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = drf_renderers
+
 ############################### Plugin Settings ###############################
 
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2337,9 +2337,9 @@ CSRF_COOKIE_SECURE = False
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'edx_rest_framework_extensions.paginators.DefaultPagination',
-    'DEFAULT_RENDERER_CLASSES': (
+    'DEFAULT_RENDERER_CLASSES': [
         'rest_framework.renderers.JSONRenderer',
-    ),
+    ],
     'PAGE_SIZE': 10,
     'URL_FORMAT_OVERRIDE': None,
     'DEFAULT_THROTTLE_RATES': {


### PR DESCRIPTION
If the 'FEATURE' 'ENABLE_DRF_BROWSABLE_API' is enabled in
server-vars.yml, then it will be added to the DRF renderers


I need to test this in cloud devstack