### PR TITLE
(WIP) Remove courses from the dashboard after `/sysadmin` course deletion

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -6,7 +6,7 @@ import logging
 
 from django.utils.translation import ugettext as _
 
-from contentstore.utils import reverse_usage_url
+from .utils import reverse_usage_url
 from lms.lib.utils import get_parent_unit
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition
 from util.db import MYSQL_MAX_INT, generate_int_id

--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy
 from search.search_engine_base import SearchEngine
 from six import add_metaclass
 
-from contentstore.course_group_config import GroupConfiguration
+from .course_group_config import GroupConfiguration
 from course_modes.models import CourseMode
 from eventtracking import tracker
 from openedx.core.lib.courses import course_image_url

--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,7 @@ commands =
         lms/djangoapps/grades/tests/integration/test_events.py \
         lms/djangoapps/instructor/tests/test_certificates.py::CertificatesInstructorApiTest \
         openedx/core/djangoapps/appsembler \
+        openedx/core/djangoapps/content/course_overviews/tests/test_signals.py \
         openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py \
         openedx/core/djangoapps/user_api/accounts/tests/test_utils.py::CompletionUtilsTestCase
 


### PR DESCRIPTION
Fix the sysadmin course deletion issues, now course should disappear from the learner dashboard.

The `course_deleted` signal is being emitted correctly but due to an import error the elastic search entries are not being removed:

```
omar@staging-tahoe-edxapp-hawthorn-0:~$ sudo grep -e ' No module named contentstore.course_group_config' -- $(sudo find /edx/var/log -name '*.log') /edx/var/log/supervisor/lms-stderr.log:2019-11-20 09:32:31,699 INFO 12534 [xmodule.modulestore.django] django.py:198 - Sent course_deleted signal to <function _listen_for_course_delete at 0x7fc536429f50> with kwargs {'course_key': CourseLocator(u'amplify', u'DIBELSNext101', u'2018', None, None)}. 
Response was: No module named contentstore.course_group_config /edx/var/log/supervisor/lms-stderr.log:2019-11-25 12:16:48,566 INFO 27086 [xmodule.modulestore.django] django.py:198 - Sent course_deleted signal to <function _listen_for_course_delete at 0x7fc537a87f50> with kwargs {'course_key': CourseLocator(u'omarrustici', u'zzz', u'zzz', None, None)}. 
Response was: No module named contentstore.course_group_config /edx/var/log/lms/edx.log:Nov 25 17:16:48 staging-tahoe-edxapp-hawthorn-0 [service_variant=lms][xmodule.modulestore.django][env:sandbox] INFO [staging-tahoe-edxapp-hawthorn-0  27086] [django.py:198] - Sent course_deleted signal to <function _listen_for_course_delete at 0x7fc537a87f50> with kwargs {'course_key': CourseLocator(u'omarrustici', u'zzz', u'zzz', None, None)}. 
Response was: No module named contentstore.course_group_config
```

This PR fixes the issue with some tests.