### PR TITLE
bugfix remove course pre requisite only if is not entrance exam Fixes RED-512

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -401,6 +401,79 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         self.assertTrue(course.entrance_exam_enabled)
         self.assertEquals(course.entrance_exam_minimum_score_pct, .5)
 
+    @unittest.skipUnless(settings.FEATURES.get('ENTRANCE_EXAMS', False), True)
+    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
+    def test_entrance_after_changing_other_setting(self):
+        """
+       Test entrance exam is not deactivated when prerequisites removed.
+
+        This test ensures that the entrance milestone is not deactivated after
+        course details are saves without pre requisite courses active.
+
+        The test was implemented after a bug fixing, correcting the behaviour
+        that every time course details were saved,
+        if there wasn't any pre requisite course in the POST
+        the view just deleted all the pre requisite courses, including entrance exam,
+        despite the fact that the entrance_exam_enabled was True.
+        This test ensures that the entrance milestone is not deactivated after
+        course details are saves without pre requisite courses active. The test was
+        implemented after a bug fixing, correcting the behaviour that every time
+        course details were saved, if there wasn't any pre requisite course in the POST
+        the view just deleted all the pre requisite courses, including entrance exam,
+        despite the fact that the entrance_exam_enabled was True.
+        """
+        self.assertFalse(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
+                         msg='The initial empty state should be: no entrance exam')
+
+        settings_details_url = get_url(self.course.id)
+        data = {
+            'entrance_exam_enabled': 'true',
+            'entrance_exam_minimum_score_pct': '60',
+            'syllabus': 'none',
+            'short_description': 'empty',
+            'overview': '',
+            'effort': '',
+            'intro_video': '',
+            'start_date': '2012-01-01',
+            'end_date': '2012-12-31',
+        }
+        response = self.client.post(
+            settings_details_url,
+            data=json.dumps(data),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json'
+        )
+
+        self.assertEquals(response.status_code, 200)
+        course = modulestore().get_course(self.course.id)
+        self.assertTrue(course.entrance_exam_enabled)
+        self.assertEquals(course.entrance_exam_minimum_score_pct, .60)
+
+        self.assertTrue(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
+                        msg='The entrance exam should be required.')
+
+        data_date = {
+            'entrance_exam_enabled': 'true',
+            'entrance_exam_minimum_score_pct': '60',
+            'syllabus': 'none',
+            'short_description': 'empty',
+            'overview': '',
+            'effort': '',
+            'intro_video': '',
+            'start_date': '2018-01-01',
+            'end_date': '{year}-12-31'.format(year=datetime.datetime.now().year + 4),
+        }
+        response = self.client.post(
+            settings_details_url,
+            data=json.dumps(data_date),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json'
+        )
+        self.assertEquals(response.status_code, 200)
+
+        self.assertTrue(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
+                        msg='The entrance exam should be required.')
+
     def test_editable_short_description_fetch(self):
         settings_details_url = get_url(self.course.id)
 

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -77,7 +77,9 @@ from util.milestones_helpers import (
     is_prerequisite_courses_enabled,
     is_valid_course_key,
     remove_prerequisite_course,
-    set_prerequisite_courses
+    set_prerequisite_courses,
+    get_namespace_choices,
+    generate_milestone_namespace
 )
 from util.organizations_helpers import add_organization_course, get_organization_by_short_name, organizations_enabled
 from util.string_utils import _has_non_ascii_characters
@@ -1136,7 +1138,12 @@ def settings_handler(request, course_key_string):
                         # None is chosen, so remove the course prerequisites
                         course_milestones = milestones_api.get_course_milestones(course_key=course_key, relationship="requires")
                         for milestone in course_milestones:
-                            remove_prerequisite_course(course_key, milestone)
+                            ee_milestone_namespace = generate_milestone_namespace(
+                                get_namespace_choices().get('ENTRANCE_EXAM'),
+                                course_key
+                            )
+                            if not milestone["namespace"] == ee_milestone_namespace:
+                                remove_prerequisite_course(course_key, milestone)
 
                 # If the entrance exams feature has been enabled, we'll need to check for some
                 # feature-specific settings and handle them accordingly


### PR DESCRIPTION
This error is easy to reproduce in staging. 

Go to or create a new course, then go to "Schedule and Details" , enable an entrance exam for the course, you can leave the default score or change it.
Go to Content -> Outline and fill the entrance exam with a couple of courses, then create a normal unit in the course.

Go to the LMS and Enroll in the course with a new learner (without any staff privilege). You will only be able to see the entrance exam. 

Go to Studio again, same course and then "Schedule and Details" change the enrollment date or any other data and save. When you go back to the LMS, you will find out that the entrance exam is disabled now, and you can see all the course content, but in the "Schedule and Details" is still active.

All this is related to the Milestones app, which is pretty messy. This bug is produce by a bugfix that @ahmedaljazzar contributed upstream while ago. Is a race condition between normal course pre requisites and entrance exams, who are technically a pre requisite too. Basically if there isn't any pre requisite course set, the backend logically deletes all the pre requisites, and the entrance exam too. 