### PR TITLE
Hide the re-index button for non-global staff

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -626,7 +626,7 @@ def course_index(request, course_key):
         reindex_link = None
         if settings.FEATURES.get('ENABLE_COURSEWARE_INDEX', False):
             if GlobalStaff().has_user(request.user):
-                reindex_link = "/course/{course_id}/search_reindex".format(course_id=unicode(course_key))
+                reindex_link = "/course/{course_id}/search_reindex".format(course_id=six.text_type(course_key))
         sections = course_module.get_children()
         course_structure = _course_outline_json(request, course_module)
         locator_to_show = request.GET.get('show', None)

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,9 @@ commands =
     # Upgrade sqlite to fix crashes during testing.
     bash scripts/upgrade_pysqlite.sh
     {env:TRAVIS_FIXES}
-    pytest cms/djangoapps/contentstore/views/tests/test_assets.py::AssetToJsonTestCase
+    pytest \
+        cms/djangoapps/contentstore/views/tests/test_assets.py::AssetToJsonTestCase \
+        cms/djangoapps/contentstore/views/tests/test_course_index.py::TestCourseReIndex
 
 [testenv:py27-lms]
 commands =


### PR DESCRIPTION
Includes minor Python 3 fixes from https://github.com/edx/edx-platform/pull/19610

Upstream needed some changes, backporting those changes to avoid future git conflicts.