### PR TITLE
fix uploaded image aspect ratio in tinymce

### DIFF
--- a/common/static/css/tinymce-studio-content.css
+++ b/common/static/css/tinymce-studio-content.css
@@ -109,6 +109,7 @@
 
 .mce-content-body img {
     max-width: 100%;
+    height: auto;
 }
 
 .mce-content-body pre {


### PR DESCRIPTION
This fixes the following bug: "Super annoying when working in studio. Images look fine in the LMS, but in Studio they're squashed."

So, the problem:
<img width="1680" alt="Screenshot 2019-12-10 at 13 11 37" src="https://user-images.githubusercontent.com/10602234/70529615-43156d00-1b51-11ea-96b2-7526c3a9d466.png">

And now - TA DA!
<img width="1680" alt="Screenshot 2019-12-10 at 13 26 09" src="https://user-images.githubusercontent.com/10602234/70529623-4c063e80-1b51-11ea-9343-24a6ef97aca4.png">
