### PR TITLE
Making the regex that gets the index courses more secure

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -576,7 +576,7 @@ class CourseOverview(TimeStampedModel):
             # In rare cases, courses belonging to the same org may be accidentally assigned
             # an org code with a different casing (e.g., Harvardx as opposed to HarvardX).
             # Case-insensitive matching allows us to deal with this kind of dirty data.
-            course_overviews = course_overviews.filter(org__iregex=r'(' + '|'.join(orgs) + ')')
+            course_overviews = course_overviews.filter(org__iregex=r'(^' + '$|^'.join(orgs) + '$)')
 
         if filter_:
             course_overviews = course_overviews.filter(**filter_)


### PR DESCRIPTION
So https://red.staging-tahoe.appsembler.com/api/courses/v1/courses/ won't show up `redislabs` courses.

It used to match `redislabs` orgs as if it was `red`. https://github.com/edx/edx-platform/pull/21220 fixes that issues and this pull request cherry pick it.