### PR TITLE
make bookmarks update_xblocks_cache task name match function

### DIFF
--- a/openedx/core/djangoapps/bookmarks/tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tasks.py
@@ -141,7 +141,7 @@ def _update_xblocks_cache(course_key):
                 update_block_cache_if_needed(block_cache, block_data)
 
 
-@task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblock_cache')
+@task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblocks_cache')
 def update_xblocks_cache(course_id):
     """
     Update the XBlocks cache for a course.


### PR DESCRIPTION
Investigating some of the celery related sentry errors like this one: https://sentry.io/organizations/appsembler/issues/1024724752/events/61b07188c79d4a579fafc712953e3a85/?project=87786

I still don't know exactly what's causing them, but I did notice that in this case, the name assigned to the task `....update_xblock_cache` didn't match the actual function name, `update_xblocks_cache()`. Everywhere that it's called elsewhere in the codebase, eg here: https://github.com/appsembler/edx-platform/blob/appsembler/tahoe/master/openedx/core/djangoapps/bookmarks/signals.py#L20 it is referenced as `update_xblocks_cache`.

So, I don't know if this will actually fix that error (it probably won't; there are a bunch of similar exceptions that lead me to believe it's something more related to how the celery workers are configured), but it certainly *seems* like it was a typo and wouldn't hurt to make it more consistent.