### PR TITLE
Fix unregistered celery tasks

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -884,7 +884,8 @@ WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
 # Auto discover tasks fails to detect contentstore tasks
 CELERY_IMPORTS = (
     'cms.djangoapps.contentstore.tasks',
-    'openedx.core.djangoapps.bookmarks.tasks'
+    'openedx.core.djangoapps.bookmarks.tasks',
+    'openedx.core.djangoapps.ccxcon.tasks',
 )
 
 # Message configuration

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -882,7 +882,10 @@ WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
 ################################# CELERY ######################################
 
 # Auto discover tasks fails to detect contentstore tasks
-CELERY_IMPORTS = ('cms.djangoapps.contentstore.tasks')
+CELERY_IMPORTS = (
+    'cms.djangoapps.contentstore.tasks',
+    'openedx.core.djangoapps.bookmarks.tasks'
+)
 
 # Message configuration
 

--- a/openedx/core/djangoapps/ccxcon/tasks.py
+++ b/openedx/core/djangoapps/ccxcon/tasks.py
@@ -12,7 +12,7 @@ from openedx.core.djangoapps.ccxcon import api
 log = get_task_logger(__name__)
 
 
-@task()
+@task(name='openedx.core.djangoapps.ccxcon.tasks.update_ccxcon')
 def update_ccxcon(course_id, cur_retry=0):
     """
     Pass through function to update course information on CCXCon.


### PR DESCRIPTION
As pointed out by Anders in https://github.com/appsembler/edx-platform/pull/508. Celery tasks failure is one of the most annoying noise in our logs. This should fix the issue. I've cherry picked both https://github.com/edx/edx-platform/pull/21297 and https://github.com/edx/edx-platform/pull/21305 from upstream.

Fixes [RED-437](https://appsembler.atlassian.net/browse/RED-437).
Closes #508.