### PR TITLE
Figures cleanup: Use hawthorn plugins URLs

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1100,8 +1100,3 @@ urlpatterns += (
         include('openedx.core.djangoapps.appsembler.api.urls',
                 namespace='tahoe-api')),
 )
-
-if 'figures' in settings.INSTALLED_APPS:
-    urlpatterns += (
-        url(r'^figures/', include('figures.urls', namespace='figures')),
-    )


### PR DESCRIPTION
Instead of hardcoding it in the LMS. Figures already adds those [URLs](https://github.com/appsembler/figures/blob/5fc3de0bdf885aa53e464649e5084519c25403ca/figures/apps.py#L39-L40).