### PR TITLE
Support access control backends in edx-search

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -124,7 +124,7 @@ edx-opaque-keys[django]==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4  # edx-organizations==0.4.12
 edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
-edx-search==1.2.1
+git+https://github.com/appsembler/edx-search.git@appsembler-beta-release-2020-01-07_4  # edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
 edxval==0.1.16

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -145,7 +145,7 @@ edx-opaque-keys[django]==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4  # edx-organizations==0.4.12
 edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
-edx-search==1.2.1
+git+https://github.com/appsembler/edx-search.git@appsembler-beta-release-2020-01-07_4  # edx-search==1.2.1
 edx-sphinx-theme==1.3.0
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -140,7 +140,7 @@ edx-opaque-keys[django]==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4  # edx-organizations==0.4.12
 edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
-edx-search==1.2.1
+git+https://github.com/appsembler/edx-search.git@appsembler-beta-release-2020-01-07_4  # edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
 edxval==0.1.16


### PR DESCRIPTION
Ensure that search results are checked by `has_access` to allow for Access Control Backends to ensure we have a foundation for Course Access Groups.

This is meant to be a temporary hack that we'll stop using later on. The full reasoning behind this is available in this [decision document](https://appsembler.atlassian.net/wiki/spaces/RT/pages/65568897/Draft+Decision+How+should+we+combine+Course+Access+Groups+and+edX+Search). Also see the https://github.com/appsembler/edx-search/pull/12 .