### PR TITLE
fix stale edx-search pip package

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -124,7 +124,7 @@ edx-opaque-keys[django]==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4  # edx-organizations==0.4.12
 edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
-git+https://github.com/appsembler/edx-search.git@appsembler-beta-release-2020-01-07_4  # edx-search==1.2.1
+-e git+https://github.com/appsembler/edx-search.git@appsembler-beta-release-2020-01-07_4#egg=edx-search  # edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
 edxval==0.1.16

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -145,7 +145,7 @@ edx-opaque-keys[django]==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4  # edx-organizations==0.4.12
 edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
-git+https://github.com/appsembler/edx-search.git@appsembler-beta-release-2020-01-07_4  # edx-search==1.2.1
+-e git+https://github.com/appsembler/edx-search.git@appsembler-beta-release-2020-01-07_4#egg=edx-search  # edx-search==1.2.1
 edx-sphinx-theme==1.3.0
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -140,7 +140,7 @@ edx-opaque-keys[django]==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4  # edx-organizations==0.4.12
 edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
-git+https://github.com/appsembler/edx-search.git@appsembler-beta-release-2020-01-07_4  # edx-search==1.2.1
+-e git+https://github.com/appsembler/edx-search.git@appsembler-beta-release-2020-01-07_4#egg=edx-search  # edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
 edxval==0.1.16


### PR DESCRIPTION
by enforcing to install from the git repo instead of the installed package from pypi.

This is a follow up to #515 which didn't work until I SSH'ed into the Staging servers and installed it manually.