### PR TITLE
Prevent 500 error when staff tries to see discussion as specific student

### DIFF
--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion.py
@@ -36,6 +36,10 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):
     """
     Provides a discussion forum that is inline with other content in the courseware.
     """
+
+    # Enable view as specific student
+    show_in_read_only_mode = True
+
     discussion_id = String(scope=Scope.settings, default=UNIQUE_ID)
     display_name = String(
         display_name=_("Display Name"),


### PR DESCRIPTION
NYIF is using, view as a specific student functionality on units that are a mix of different XBlocks. We applied this fix to PDF and Scorm but They have discussion units with other XBlock and to make the whole subsection visible as a specific student we need to turn on this flag on built-in discussion XBlock as well.