### PR TITLE
add ssl.CERT_NONE because compose has a invalid cert

### DIFF
--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -1,6 +1,7 @@
 """
 Common MongoDB connection functions.
 """
+import ssl
 import logging
 
 import pymongo
@@ -65,6 +66,7 @@ def connect_to_mongodb(
             port=port,
             tz_aware=tz_aware,
             document_class=dict,
+            ssl_cert_reqs=ssl.CERT_NONE,
             **kwargs
         ),
         db


### PR DESCRIPTION
This PR will be reverted after we move to Mongo Atlas. 

After upgrading the pymongo driver, we realized we cannot connect because compose.io has an invalid cert. This solves the problem until we move out to Atlas.