### PR TITLE
Add Django signal for email verification

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -66,6 +66,7 @@ from enrollment.api import _default_course_mode
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.request_cache import clear_cache, get_cache
+from openedx.core.djangoapps.signals.signals import USER_ACCOUNT_ACTIVATED
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
@@ -728,6 +729,7 @@ class Registration(models.Model):
         self.user.is_active = True
         self._track_activation()
         self.user.save()
+        USER_ACCOUNT_ACTIVATED.send_robust(self.__class__, user=self.user)
         log.info(u'User %s (%s) account is successfully activated.', self.user.username, self.user.email)
 
     def _track_activation(self):

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -98,6 +98,19 @@ class TestActivateAccount(TestCase):
             expected_segment_mailchimp_list
         )
 
+    @patch('student.models.USER_ACCOUNT_ACTIVATED')
+    def test_activation_signal(self, mock_signal):
+        """
+        Verify that USER_ACCOUNT_ACTIVATED is emitted upon account email activation.
+
+        Appsembler: This is a custom code to be pushed upstream.
+        """
+        assert not self.user.is_active, 'Ensure that the user starts inactive'
+        assert not mock_signal.send_robust.call_count, 'Ensure no signal is fired before activation'
+        self.registration.activate()  # Until you explicitly activate it
+        assert self.user.is_active, 'Sanity check for .activate()'
+        mock_signal.send_robust.assert_called_once_with(Registration, user=self.user), 'Ensure the signal is emitted'
+
     @override_settings(LMS_SEGMENT_KEY="testkey")
     @patch('student.models.analytics.identify')
     def test_activation_without_mailchimp_key(self, mock_segment_identify):

--- a/openedx/core/djangoapps/signals/signals.py
+++ b/openedx/core/djangoapps/signals/signals.py
@@ -21,5 +21,7 @@ COURSE_GRADE_NOW_PASSED = Signal(
     ]
 )
 
-# Signal that indicates that a user has become verified
+# Signal that indicates that a user has become verified for certificate purposes
 LEARNER_NOW_VERIFIED = Signal(providing_args=['user'])
+
+USER_ACCOUNT_ACTIVATED = Signal(providing_args=["user"])  # Signal indicating email verification

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ commands =
     bash scripts/upgrade_pysqlite.sh
     {env:TRAVIS_FIXES}
     pytest \
+        common/djangoapps/student/tests/test_activate_account.py \
         common/djangoapps/util/tests/test_milestones_helpers.py \
         common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
 


### PR DESCRIPTION
This helps plugins to listen to this signal and perform custom logic without the need to hardcode it inside the platform. To be used for CAG auto enrollment: https://github.com/appsembler/course-access-groups/pull/15.

### TODO

 - [x] Add tests
 - [x] Finish the implementation
 - [ ] ~Test with Course Access Groups auto enrollment~ out of scope of this PR. We'll test it later.

Jira: [**RED-707:** Automatic domain-name-based enrollment for Course Access Groups](https://appsembler.atlassian.net/browse/RED-707)