### PR TITLE
Users API: Filter by email

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/v1/filters.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/filters.py
@@ -1,5 +1,6 @@
 
 import django_filters
+from django.contrib.auth import get_user_model
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import (
     CourseOverview,
@@ -68,3 +69,15 @@ class CourseEnrollmentFilter(django_filters.FilterSet):
     class Meta:
         model = CourseEnrollment
         fields = ['course_id', 'user_id', 'username', 'is_active', ]
+
+
+class UserIndexFilter(django_filters.FilterSet):
+    '''Provides filtering for the User model objects in the UserIndexViewSet.
+
+    '''
+
+    email_exact = django_filters.CharFilter(name='email', lookup_expr='iexact')
+
+    class Meta:
+        model = get_user_model()
+        fields = ['email_exact']

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -50,7 +50,8 @@ from openedx.core.djangoapps.appsembler.api.helpers import as_course_key
 from openedx.core.djangoapps.appsembler.api.v1.api import enroll_learners_in_course
 from openedx.core.djangoapps.appsembler.api.v1.filters import (
     CourseEnrollmentFilter,
-    CourseOverviewFilter
+    CourseOverviewFilter,
+    UserIndexFilter,
 )
 from openedx.core.djangoapps.appsembler.api.v1.pagination import (
     TahoeLimitOffsetPagination
@@ -397,6 +398,7 @@ class UserIndexViewSet(TahoeAuthMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = UserIndexSerializer
     throttle_classes = (TahoeAPIUserThrottle,)
     filter_backends = (DjangoFilterBackend, )
+    filter_class = UserIndexFilter
 
     def get_queryset(self):
         site = django.contrib.sites.shortcuts.get_current_site(self.request)


### PR DESCRIPTION
This change makes it possible to know whether a specific user is registered in a site or not.

```
GET /tahoe/api/v1/users/?email_exact=someone@example.com
```

Returning either a list of one user, or no one at all:

```
{
    "count": 0,
    "next": null,
    "previous": null,
    "results": []
}
```

[**RED-594**: Enrollment API update epic.](https://appsembler.atlassian.net/browse/RED-594)