### PR TITLE
Amir/ginkgo.master.feature/username replacement api

### DIFF
--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -10,6 +10,10 @@ import httpretty
 import mock
 from django.core.urlresolvers import reverse
 from nose.plugins.attrib import attr
+from django.conf import settings
+from django.urls import reverse
+from edx_oauth2_provider.tests.factories import ClientFactory, AccessTokenFactory
+from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from rest_framework.parsers import JSONParser
 from rest_framework.test import APIClient
@@ -150,6 +154,155 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
                 "topics_url": "http://testserver/api/discussion/v1/course_topics/x/y/z",
             }
         )
+
+
+@httpretty.activate
+@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
+    """Tests for CourseView"""
+    def setUp(self):
+        super(RetireViewTest, self).setUp()
+        RetirementState.objects.create(state_name='PENDING', state_execution_order=1)
+        self.retire_forums_state = RetirementState.objects.create(state_name='RETIRE_FORUMS', state_execution_order=11)
+
+        self.retirement = UserRetirementStatus.create_retirement(self.user)
+        self.retirement.current_state = self.retire_forums_state
+        self.retirement.save()
+
+        self.superuser = SuperuserFactory()
+        self.retired_username = get_retired_username_by_username(self.user.username)
+        self.url = reverse("retire_discussion_user")
+
+    def assert_response_correct(self, response, expected_status, expected_content):
+        """
+        Assert that the response has the given status code and content
+        """
+        self.assertEqual(response.status_code, expected_status)
+
+        if expected_content:
+            self.assertEqual(text_type(response.content), expected_content)
+
+    def build_jwt_headers(self, user):
+        """
+        Helper function for creating headers for the JWT authentication.
+        """
+        token = create_jwt_for_user(user)
+        headers = {'HTTP_AUTHORIZATION': 'JWT ' + token}
+        return headers
+
+    def test_basic(self):
+        """
+        Check successful retirement case
+        """
+        self.register_get_user_retire_response(self.user)
+        headers = self.build_jwt_headers(self.superuser)
+        data = {'username': self.user.username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 204, "")
+
+    def test_downstream_forums_error(self):
+        """
+        Check that we bubble up errors from the comments service
+        """
+        self.register_get_user_retire_response(self.user, status=500, body="Server error")
+        headers = self.build_jwt_headers(self.superuser)
+        data = {'username': self.user.username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 500, '"Server error"')
+
+    def test_nonexistent_user(self):
+        """
+        Check that we handle unknown users appropriately
+        """
+        nonexistent_username = "nonexistent user"
+        self.retired_username = get_retired_username_by_username(nonexistent_username)
+        data = {'username': nonexistent_username}
+        headers = self.build_jwt_headers(self.superuser)
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 404, None)
+
+    def test_not_authenticated(self):
+        """
+        Override the parent implementation of this, we JWT auth for this API
+        """
+        pass
+
+
+@httpretty.activate
+@mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
+@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+class ReplaceUsernameViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
+    """Tests for ReplaceUsernameView"""
+    def setUp(self):
+        super(ReplaceUsernameViewTest, self).setUp()
+        self.client_user = UserFactory()
+        self.client_user.username = "test_replace_username_service_worker"
+        self.new_username = "test_username_replacement"
+        self.url = reverse("replace_discussion_username")
+
+    def assert_response_correct(self, response, expected_status, expected_content):
+        """
+        Assert that the response has the given status code and content
+        """
+        self.assertEqual(response.status_code, expected_status)
+
+        if expected_content:
+            self.assertEqual(text_type(response.content), expected_content)
+
+    def build_jwt_headers(self, user):
+        """
+        Helper function for creating headers for the JWT authentication.
+        """
+        token = create_jwt_for_user(user)
+        headers = {'HTTP_AUTHORIZATION': 'JWT ' + token}
+        return headers
+
+    def test_missing_params(self):
+        headers = self.build_jwt_headers(self.client_user)
+        # Using this instead of ddt so we can access self.user
+        bad_post_contents = (
+            {},
+            {"current_username": self.user.username},
+            {"new_username": "test_username_replacement"},
+        )
+        for data in bad_post_contents:
+            response = self.client.post(self.url, data, **headers)
+            self.assert_response_correct(response, 400, "")
+
+    def test_basic(self):
+        """ Check successful replacement """
+        self.register_get_username_replacement_response(self.user)
+        headers = self.build_jwt_headers(self.client_user)
+        data = {"current_username": self.user.username, "new_username": self.new_username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 204, "")
+
+    def test_nonexistant_user(self):
+        self.register_get_username_replacement_response(self.user)
+        headers = self.build_jwt_headers(self.client_user)
+        data = {"current_username": "non-existant-user", "new_username": self.new_username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 404, "")
+
+    def test_client_404(self):
+        self.register_get_username_replacement_response(self.user, status=404)
+        headers = self.build_jwt_headers(self.client_user)
+        data = {"current_username": self.user.username, "new_username": self.new_username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 404, "")
+
+    def test_client_500(self):
+        self.register_get_username_replacement_response(self.user, status=500)
+        headers = self.build_jwt_headers(self.client_user)
+        data = {"current_username": self.user.username, "new_username": self.new_username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 500, "")
+
+    def test_not_authenticated(self):
+        """
+        Override the parent implementation of this, we JWT auth for this API
+        """
+        pass
 
 
 @ddt.ddt

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -202,6 +202,25 @@ class CommentsServiceMockMixin(object):
             status=200
         )
 
+    def register_get_user_retire_response(self, user, status=200, body=""):
+        """Register a mock response for GET on the CS user retirement endpoint"""
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
+        httpretty.register_uri(
+            httpretty.POST,
+            "http://localhost:4567/api/v1/users/{id}/retire".format(id=user.id),
+            body=body,
+            status=status
+        )
+
+    def register_get_username_replacement_response(self, user, status=200, body=""):
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
+        httpretty.register_uri(
+            httpretty.POST,
+            "http://localhost:4567/api/v1/users/{id}/replace_username".format(id=user.id),
+            body=body,
+            status=status
+        )
+
     def register_subscribed_threads_response(self, user, threads, page, num_pages):
         """Register a mock response for GET on the CS user instance endpoint"""
         httpretty.register_uri(

--- a/lms/djangoapps/discussion_api/urls.py
+++ b/lms/djangoapps/discussion_api/urls.py
@@ -5,7 +5,13 @@ from django.conf import settings
 from django.conf.urls import include, patterns, url
 from rest_framework.routers import SimpleRouter
 
-from discussion_api.views import CommentViewSet, CourseTopicsView, CourseView, ThreadViewSet
+from discussion_api.views import (
+    CommentViewSet,
+    CourseTopicsView,
+    CourseView,
+    ThreadViewSet,
+    ReplaceUsernameView,
+)
 
 ROUTER = SimpleRouter()
 ROUTER.register("threads", ThreadViewSet, base_name="thread")
@@ -18,6 +24,7 @@ urlpatterns = patterns(
         CourseView.as_view(),
         name="discussion_course"
     ),
+    url(r"^v1/accounts/replace_username", ReplaceUsernameView.as_view(), name="replace_discussion_username"),
     url(
         r"^v1/course_topics/{}".format(settings.COURSE_ID_PATTERN),
         CourseTopicsView.as_view(),

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -1,6 +1,8 @@
 """
 Discussion API views
 """
+import logging
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.exceptions import UnsupportedMediaType
@@ -8,6 +10,7 @@ from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
+from rest_framework import permissions
 
 from discussion_api.api import (
     create_comment,
@@ -24,9 +27,15 @@ from discussion_api.api import (
     update_thread
 )
 from discussion_api.forms import CommentGetForm, CommentListGetForm, ThreadListGetForm
+from lms.lib import comment_client
 from openedx.core.lib.api.parsers import MergePatchParser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
+from openedx.core.djangoapps.user_api.accounts.permissions import CanReplaceUsername
+from edx_rest_framework_extensions.authentication import JwtAuthentication
+from util.json_request import JsonResponse
 from xmodule.modulestore.django import modulestore
+
+log = logging.getLogger(__name__)
 
 
 @view_auth_classes()
@@ -512,3 +521,87 @@ class CommentViewSet(DeveloperErrorViewMixin, ViewSet):
         if request.content_type != MergePatchParser.media_type:
             raise UnsupportedMediaType(request.content_type)
         return Response(update_comment(request, comment_id, request.data))
+
+
+class ReplaceUsernameView(APIView):
+    """
+    WARNING: This API is only meant to be used as part of a larger job that
+    updates usernames across all services. DO NOT run this alone or users will
+    not match across the system and things will be broken.
+    API will recieve a list of current usernames and their new username.
+    POST /api/discussion/v1/accounts/replace_usernames/
+        {
+            "username_mappings": [
+                {"current_username_1": "desired_username_1"},
+                {"current_username_2": "desired_username_2"}
+            ]
+        }
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
+
+    def post(self, request):
+        """
+        Implements the username replacement endpoint
+        """
+
+        username_mappings = request.data.get("username_mappings")
+
+        if not self._has_valid_schema(username_mappings):
+            raise ValidationError("Request data does not match schema")
+
+        successful_replacements, failed_replacements = [], []
+
+        for username_pair in username_mappings:
+            current_username = list(username_pair.keys())[0]
+            new_username = list(username_pair.values())[0]
+            successfully_replaced = self._replace_username(current_username, new_username)
+            if successfully_replaced:
+                successful_replacements += {current_username: new_username}
+            else:
+                failed_replacements += {current_username: new_username}
+        return JsonResponse({
+            "successful_replacements": successful_replacements,
+            "failed_replacements": failed_replacements,
+        })
+
+    def _replace_username(self, current_username, new_username):
+        try:
+            # This API will be called after the regular LMS API, so the username in
+            # the DB will have already been updated to new_username
+            current_user = User.objects.get(username=new_username)
+            cc_user = comment_client.User.from_django_user(current_user)
+            cc_user.replace_username(new_username)
+        except User.DoesNotExist:
+            log.warning(
+                u"Unable to change username from %s to %s in forums because %s doesn't exist in LMS DB.",
+                current_username,
+                new_username,
+                new_username,
+            )
+            return False
+        except comment_client.CommentClientRequestError as exc:
+            log.exception(
+                u"Unable to change username from %s to %s in forums because forums API call failed with: %s.",
+                current_username,
+                new_username,
+                exc,
+            )
+            return False
+
+        log.info(
+            u"Successfully changed username from %s to %s in forums.",
+            current_username,
+            new_username,
+        )
+        return True
+
+    def _has_valid_schema(self, post_data):
+        """ Verifies the data is a list of objects with a single key:value pair """
+        if not isinstance(post_data, list):
+            return False
+        for obj in post_data:
+            if not (isinstance(obj, dict) and len(obj) == 1):
+                return False
+        return True

--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -1,6 +1,6 @@
 """ User model wrapper for comment service"""
 import settings
-
+import utils
 import models
 
 from .utils import CommentClientPaginatedResult, CommentClientRequestError, merge_dict, perform_request
@@ -167,6 +167,17 @@ class User(models.Model):
                 raise
         self._update_from_response(response)
 
+    def replace_username(self, new_username):
+        url = _url_for_username_replacement(self.id)
+        params = {"new_username": new_username}
+
+        utils.perform_request(
+            'post',
+            url,
+            params,
+            raw=True,
+        )
+
 
 def _url_for_vote_comment(comment_id):
     return "{prefix}/comments/{comment_id}/votes".format(prefix=settings.PREFIX, comment_id=comment_id)
@@ -193,3 +204,10 @@ def _url_for_read(user_id):
     Returns cs_comments_service url endpoint to mark thread as read for given user_id
     """
     return "{prefix}/users/{user_id}/read".format(prefix=settings.PREFIX, user_id=user_id)
+
+
+def _url_for_username_replacement(user_id):
+    """
+    Returns cs_comments_servuce url endpoint to replace the username of a user
+    """
+    return "{prefix}/users/{user_id}/replace_username".format(prefix=settings.PREFIX, user_id=user_id)

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -7,6 +7,7 @@ from rest_framework import permissions
 
 USERNAME_REPLACEMENT_GROUP = "username_replacement_admin"
 
+
 class CanDeactivateUser(permissions.BasePermission):
     """
     Grants access to AccountDeactivationView if the requesting user is a superuser
@@ -14,6 +15,7 @@ class CanDeactivateUser(permissions.BasePermission):
     """
     def has_permission(self, request, view):
         return request.user.has_perm('student.can_deactivate_users')
+
 
 class CanReplaceUsername(permissions.BasePermission):
     """

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 from rest_framework import permissions
 
+USERNAME_REPLACEMENT_GROUP = "username_replacement_admin"
 
 class CanDeactivateUser(permissions.BasePermission):
     """
@@ -13,3 +14,11 @@ class CanDeactivateUser(permissions.BasePermission):
     """
     def has_permission(self, request, view):
         return request.user.has_perm('student.can_deactivate_users')
+
+class CanReplaceUsername(permissions.BasePermission):
+    """
+    Grants access to the Username Replacement API for anyone in the group,
+    including the service user.
+    """
+    def has_permission(self, request, view):
+        return request.user.groups.filter(name=USERNAME_REPLACEMENT_GROUP).exists()

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -4,25 +4,37 @@ An API for retrieving user account information.
 For additional information and historical context, see:
 https://openedx.atlassian.net/wiki/display/TNL/User+API
 """
+import datetime
+import logging
+from functools import wraps
+import uuid
 
+import pytz
+from django.apps import apps
+from django.conf import settings
+from django.contrib.auth import authenticate, get_user_model, logout
+from django.contrib.sites.models import Site
+from django.core.cache import cache
 from django.db import transaction
 from edx_rest_framework_extensions.authentication import JwtAuthentication
 from rest_framework import permissions
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
 from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
 
 from .api import get_account_settings, update_account_settings
-from .permissions import CanDeactivateUser
 from ..errors import UserNotFound, UserNotAuthorized, AccountUpdateError, AccountValidationError
 from openedx.core.lib.api.authentication import (
     SessionAuthenticationAllowInactiveUser,
     OAuth2AuthenticationAllowInactiveUser,
 )
+from .permissions import CanDeactivateUser, CanReplaceUsername
 from openedx.core.lib.api.parsers import MergePatchParser
 from student.models import User
 
+log = logging.getLogger(__name__)
 
 class AccountViewSet(ViewSet):
     """
@@ -243,3 +255,162 @@ class AccountDeactivationView(APIView):
         user.save()
         account_settings = get_account_settings(request, [username])[0]
         return Response(account_settings)
+        _set_unusable_password(User.objects.get(username=username))
+        return Response(get_account_settings(request, [username])[0])
+
+
+class UsernameReplacementView(APIView):
+    """
+    WARNING: This API is only meant to be used as part of a larger job that
+    updates usernames across all services. DO NOT run this alone or users will
+    not match across the system and things will be broken.
+
+    API will recieve a list of current usernames and their requested new
+    username. If their new username is taken, it will randomly assign a new username.
+    """
+    authentication_classes = (JwtAuthentication, )
+    permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
+
+    def post(self, request):
+        """
+        POST /api/user/v1/accounts/replace_usernames/
+        {
+            "username_mappings": [
+                {"current_username_1": "desired_username_1"},
+                {"current_username_2": "desired_username_2"}
+            ]
+        }
+
+        **POST Parameters**
+
+        A POST request must include the following parameter.
+
+        * username_mappings: Required. A list of objects that map the current username (key)
+          to the desired username (value)
+
+        **POST Response Values**
+
+        As long as data validation passes, the request will return a 200 with a new mapping
+        of old usernames (key) to new username (value)
+
+        {
+            "successful_replacements": [
+                {"old_username_1": "new_username_1"}
+            ],
+            "failed_replacements": [
+                {"old_username_2": "new_username_2"}
+            ]
+        }
+
+        TODO: Determine if we need an audit trail outside of logging and API response.
+        """
+
+        # (model_name, column_name)
+        MODELS_WITH_USERNAME = (
+            ('auth.user', 'username'),
+            ('consent.DataSharingConsent', 'username'),
+            ('consent.HistoricalDataSharingConsent', 'username'),
+            ('credit.CreditEligibility', 'username'),
+            ('credit.CreditRequest', 'username'),
+            ('credit.CreditRequirementStatus', 'username'),
+            ('user_api.UserRetirementPartnerReportingStatus', 'original_username'),
+            ('user_api.UserRetirementStatus', 'original_username')
+        )
+        UNIQUE_SUFFIX_LENGTH = getattr(settings, 'SOCIAL_AUTH_UUID_LENGTH', 4)
+
+        username_mappings = request.data.get("username_mappings")
+        replacement_locations = self._load_models(MODELS_WITH_USERNAME)
+
+        if not self._has_valid_schema(username_mappings):
+            raise ValidationError("Request data does not match schema")
+
+        successful_replacements, failed_replacements = [], []
+
+        for username_pair in username_mappings:
+            current_username = list(username_pair.keys())[0]
+            desired_username = list(username_pair.values())[0]
+            new_username = self._generate_unique_username(desired_username, suffix_length=UNIQUE_SUFFIX_LENGTH)
+            successfully_replaced = self._replace_username_for_all_models(
+                current_username,
+                new_username,
+                replacement_locations
+            )
+            if successfully_replaced:
+                successful_replacements.append({current_username: new_username})
+            else:
+                failed_replacements.append({current_username: new_username})
+        return Response(
+            status=status.HTTP_200_OK,
+            data={
+                "successful_replacements": successful_replacements,
+                "failed_replacements": failed_replacements
+            }
+        )
+
+    def _load_models(self, models_with_fields):
+        """ Takes tuples that contain a model path and returns the list with a loaded version of the model """
+        try:
+            replacement_locations = [(apps.get_model(model), column) for (model, column) in models_with_fields]
+        except LookupError:
+            log.exception("Unable to load models for username replacement")
+            raise
+        return replacement_locations
+
+    def _has_valid_schema(self, post_data):
+        """ Verifies the data is a list of objects with a single key:value pair """
+        if not isinstance(post_data, list):
+            return False
+        for obj in post_data:
+            if not (isinstance(obj, dict) and len(obj) == 1):
+                return False
+        return True
+
+    def _generate_unique_username(self, desired_username, suffix_length=4):
+        """ Accepts a username and returns a unique username if the requested is taken """
+        User = apps.get_model('auth.user')
+        new_username = desired_username
+        # Keep checking usernames in case desired_username + random suffix is already taken
+        while True:
+            if User.objects.filter(username=new_username).exists():
+                unique_suffix = uuid.uuid4().hex[:suffix_length]
+                new_username = desired_username + unique_suffix
+            else:
+                break
+        return new_username
+
+    def _replace_username_for_all_models(self, current_username, new_username, replacement_locations):
+        """
+        Replaces current_username with new_username for all (model, column) pairs in replacement locations.
+        Returns if it was successful or not. Will return successful even if no matching
+
+        TODO: Determine if logs of username are a PII issue.
+        """
+        try:
+            with transaction.atomic():
+                num_rows_changed = 0
+                for (model, column) in replacement_locations:
+                    num_rows_changed += model.objects.filter(
+                        **{column: current_username}
+                    ).update(
+                        **{column: new_username}
+                    )
+        except Exception as exc:
+            log.exception("Unable to change username from {current} to {new}. Reason: {error}".format(
+                current=current_username,
+                new=new_username,
+                error=exc
+            ))
+            return False
+        if num_rows_changed == 0:
+            log.warning("Unable to change username from {current} to {new} because {current} doesn't exist.".format(
+                current=current_username,
+                new=new_username,
+            ))
+            return False
+
+        log.info("Successfully changed username from {current} to {new}.".format(
+            current=current_username,
+            new=new_username,
+        ))
+        return True
+

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -36,6 +36,7 @@ from student.models import User
 
 log = logging.getLogger(__name__)
 
+
 class AccountViewSet(ViewSet):
     """
         **Use Cases**
@@ -267,6 +268,9 @@ class UsernameReplacementView(APIView):
 
     API will recieve a list of current usernames and their requested new
     username. If their new username is taken, it will randomly assign a new username.
+
+    This API will be called first, before calling the APIs in other services as this
+    one handles the checks on the usernames provided.
     """
     authentication_classes = (JwtAuthentication, )
     permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
@@ -308,13 +312,9 @@ class UsernameReplacementView(APIView):
         # (model_name, column_name)
         MODELS_WITH_USERNAME = (
             ('auth.user', 'username'),
-            ('consent.DataSharingConsent', 'username'),
-            ('consent.HistoricalDataSharingConsent', 'username'),
             ('credit.CreditEligibility', 'username'),
             ('credit.CreditRequest', 'username'),
-            ('credit.CreditRequirementStatus', 'username'),
-            ('user_api.UserRetirementPartnerReportingStatus', 'original_username'),
-            ('user_api.UserRetirementStatus', 'original_username')
+            ('credit.CreditRequirementStatus', 'username')
         )
         UNIQUE_SUFFIX_LENGTH = getattr(settings, 'SOCIAL_AUTH_UUID_LENGTH', 4)
 
@@ -413,4 +413,3 @@ class UsernameReplacementView(APIView):
             new=new_username,
         ))
         return True
-

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -6,7 +6,11 @@ from django.conf import settings
 from django.conf.urls import patterns, url
 
 from ..profile_images.views import ProfileImageView
-from .accounts.views import AccountDeactivationView, AccountViewSet
+from .accounts.views import (
+    AccountDeactivationView,
+    AccountViewSet,
+    UsernameReplacementView
+)
 from .preferences.views import PreferencesDetailView, PreferencesView
 from .verification_api.views import PhotoVerificationStatusView
 
@@ -43,6 +47,12 @@ urlpatterns = patterns(
         PhotoVerificationStatusView.as_view(),
         name='verification_status'
     ),
+    url(
+        r'^v1/accounts/replace_usernames/$',
+        UsernameReplacementView.as_view(),
+        name='username_replacement'
+    ),
+
     url(
         r'^v1/preferences/{}$'.format(settings.USERNAME_PATTERN),
         PreferencesView.as_view(),


### PR DESCRIPTION
New API replaces all copies of the username in LMS the desired username. Requires users to be in the username_replacement_admin group. It should only be run as a larger job to update usernames across all services, otherwise, the system will be left in a broken state for those users.
We received a request from ASU to change a username, this can be a solution for the famous change my username request. I tested it and it worked. Only issue I saw was old discussion thread made by my user still has my old username.
https://appsembler.atlassian.net/browse/BLACK-680?atlOrigin=eyJpIjoiY2YzZTViNDA2ODNlNGM3N2I2OTQ5ZmQ5MTkxZmExYTciLCJwIjoiaiJ9