### PR TITLE
Hide intercom widget from beta_tester users

### DIFF
--- a/openedx/core/djangoapps/appsembler/intercom_integration/context_processors.py
+++ b/openedx/core/djangoapps/appsembler/intercom_integration/context_processors.py
@@ -6,6 +6,8 @@ from student.auth import user_has_role
 from student.models import CourseAccessRole
 from student.roles import CourseCreatorRole
 
+from openedx.core.djangoapps.appsembler.intercom_integration.helpers import should_show_intercom_widget
+
 
 def intercom(request):
     data = {'show_intercom_widget': False}
@@ -15,10 +17,7 @@ def intercom(request):
         return data
 
     user = request.user
-    if user.is_authenticated() and (
-        user_has_role(user, CourseCreatorRole())  # Course authors, which is given by default for AMC site admins
-        or CourseAccessRole.objects.filter(user=user).exists()  # Course staff, of any type
-    ):
+    if should_show_intercom_widget(user):
         data['show_intercom_widget'] = True
         user_hash = hmac.new(
             str(settings.INTERCOM_APP_SECRET),

--- a/openedx/core/djangoapps/appsembler/intercom_integration/helpers.py
+++ b/openedx/core/djangoapps/appsembler/intercom_integration/helpers.py
@@ -1,0 +1,31 @@
+"""
+Helpers for Intercom integration.
+"""
+
+from student.auth import user_has_role
+from student.models import CourseAccessRole
+from student.roles import CourseCreatorRole, CourseInstructorRole, CourseStaffRole
+
+
+def should_show_intercom_widget(user):
+    """
+    Show or hide the Intercom chat widget to different users.
+
+    The widget should be displayed only for course creators, course staff and course admins.
+
+    :param user: User object to check for.
+    :return: bool
+    """
+    if not user.is_authenticated:
+        return False
+
+    if user.is_superuser:
+        return False
+
+    if user_has_role(user, CourseCreatorRole()):
+        return True
+
+    return CourseAccessRole.objects.filter(user=user, role__in=[
+        CourseStaffRole.ROLE,
+        CourseInstructorRole.ROLE,
+    ]).exists()

--- a/openedx/core/djangoapps/appsembler/intercom_integration/tests/test_should_show_intercom_widget.py
+++ b/openedx/core/djangoapps/appsembler/intercom_integration/tests/test_should_show_intercom_widget.py
@@ -1,0 +1,55 @@
+"""
+Tests for the intercom should_show_intercom_widget helper.
+"""
+
+from mock import patch, Mock
+import ddt
+from django.test import TestCase
+from django.conf import settings
+from opaque_keys.edx.keys import CourseKey
+from student.roles import CourseCreatorRole, CourseInstructorRole, CourseStaffRole, CourseBetaTesterRole
+from student.tests.factories import UserFactory
+
+from openedx.core.djangoapps.appsembler.intercom_integration.helpers import should_show_intercom_widget
+
+
+@ddt.ddt
+@patch.dict(settings.FEATURES, ENABLE_CREATOR_GROUP=True)
+class TestShouldShowIntercomWidgetHelperTestCase(TestCase):
+    """
+    Tests for the `should_show_intercom_widget` helper.
+    """
+
+    def test_should_hide_for_non_authenticated(self):
+        anonymous_user = Mock(is_authenticated=False)
+        assert not should_show_intercom_widget(anonymous_user)
+
+    def test_should_hide_for_superusers(self):
+        superuser = UserFactory.create(is_superuser=True)
+        assert not should_show_intercom_widget(superuser)
+
+    def test_should_show_for_site_wide_staff(self):
+        staff = UserFactory.create(is_staff=True)
+        assert should_show_intercom_widget(staff)
+
+    def test_should_show_for_course_creators(self):
+        course_creator = UserFactory.create()
+        CourseCreatorRole().add_users(course_creator)
+        assert should_show_intercom_widget(course_creator)
+
+    @ddt.unpack
+    @ddt.data({
+        'course_role_class': CourseStaffRole,
+        'should_show': True,
+    }, {
+        'course_role_class': CourseInstructorRole,
+        'should_show': True,
+    }, {
+        'course_role_class': CourseBetaTesterRole,
+        'should_show': False,
+    })
+    def test_should_show_for_course_staff(self, course_role_class, should_show):
+        course_staff = UserFactory.create(is_staff=False, is_superuser=False)
+        course_key = CourseKey.from_string('course-v1:Demo+Course+2017')
+        course_role_class(course_key).add_users(course_staff)
+        assert should_show_intercom_widget(course_staff) == should_show


### PR DESCRIPTION
[**RED-768:** Redis: Non-AMC (e.g. beta tester) user is seeing the Intercom widget](https://appsembler.atlassian.net/browse/RED-768).

### TODO

 - [x] Remove the `is_staff` check