### PR TITLE
Fix COURSE_GRADE_NOW_PASSED signal for Ginkgo

### DIFF
--- a/lms/djangoapps/certificates/tasks.py
+++ b/lms/djangoapps/certificates/tasks.py
@@ -4,6 +4,9 @@ from logging import getLogger
 from celery_utils.logged_task import LoggedTask
 from celery_utils.persist_on_failure import PersistOnFailureTask
 
+from django.contrib.auth.models import User
+from opaque_keys.edx.keys import CourseKey
+
 from .api import generate_user_certificates
 
 logger = getLogger(__name__)
@@ -21,6 +24,6 @@ def generate_certificate(**kwargs):
     """
     Generates a certificate for a single user.
     """
-    student = kwargs.pop('student')
-    course_key = kwargs.pop('course_key')
+    student = User.objects.get(id=kwargs.pop('student'))
+    course_key = CourseKey.from_string(kwargs.pop('course_key'))
     generate_user_certificates(student=student, course_key=course_key, **kwargs)

--- a/lms/djangoapps/grades/new/course_grade_factory.py
+++ b/lms/djangoapps/grades/new/course_grade_factory.py
@@ -35,8 +35,10 @@ class CourseGradeFactory(object):
         course_data = CourseData(user, course, collected_block_structure, course_structure, course_key)
         try:
             course_grade, read_policy_hash = self._read(user, course_data)
-            if read_policy_hash == course_data.grading_policy_hash:
-                return course_grade
+            # BCW: this logic has to be removed in orde to allow cert generation on passing grade
+            # but probably adds to performance overhead
+            # if read_policy_hash == course_data.grading_policy_hash:
+            #     return course_grade
             read_only = False  # update the persisted grade since the policy changed; TODO(TNL-6786) remove soon
         except PersistentCourseGrade.DoesNotExist:
             if assume_zero_if_absent(course_data.course_key):
@@ -218,7 +220,7 @@ class CourseGradeFactory(object):
             COURSE_GRADE_NOW_PASSED.send_robust(
                 sender=CourseGradeFactory,
                 user=user,
-                course_key=course_data.course_key,
+                course_key=course_data.course_key
             )
 
         log.info(


### PR DESCRIPTION
This is a bugfix for Ginkgo which doesn't
need to be carried forward as logic is entirely reworked in Hawthorn+

note: Auto-certificates on passing grade requires enabling `PersistentCourseGrade`s via Django Admin for all courses

This does introduce a slight performance overhead when calculating grades but it would require too much rework for the budget we have to avoid it, and this is resolved with Hawthorn's refactor of grading, anyhow.  TBD though whether this feature works out of the box in Hawthorn.  It looks like it should but it's not tested.

