### PR TITLE
Django command to create devstack demo site

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/management/commands/create_devstack_site.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/create_devstack_site.py
@@ -1,0 +1,123 @@
+import hashlib
+import inspect
+import json
+import uuid
+
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User
+from django.core.validators import validate_slug, ValidationError
+from django.conf import settings
+
+from openedx.core.djangoapps.appsembler.sites.serializers import RegistrationSerializer
+from openedx.core.djangoapps.appsembler.sites.utils import reset_amc_tokens
+from student.models import UserProfile
+from student.roles import CourseCreatorRole
+
+
+class Command(BaseCommand):
+    """
+    Create the demo something.localhost:18000 site for devstack.
+
+    Needs the corresponding `create_devstack_site` AMC command to be run as well.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'name',
+            help='A slug for the username and used as a site name prefix e.g. something.localhost:18000',
+            nargs=1,
+            type=str,
+        )
+
+    def congrats(self, **kwargs):
+        """
+        Write a congrats message.
+
+        :param kwargs: congrats message format keyword arguments.
+        """
+        self.stdout.write(inspect.cleandoc(
+            """
+            Congrats, Your site is ready!
+
+            Username: "{name}"
+            Email: "{email}"
+            Password: "{password}"
+
+            Site URL: "http://{site}/"
+
+            Please add the following entry to your /etc/hosts file:
+
+                127.0.0.1 {domain}
+
+            Remember to run the corresponding AMC command.
+
+            Enjoy!
+            """.format(**kwargs)
+        ))
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError('This only works on devstack.')
+
+        name = options['name'][0].lower()
+        try:
+            validate_slug(name)
+        except ValidationError:
+            raise CommandError('Please enter a valid slug')
+
+        if User.objects.filter(username=name).exists():
+            raise CommandError('User exists with the username: "{}". Please choose another name.'.format(name))
+
+        domain = '{}.localhost'.format(name)
+        site_name = '{}:18000'.format(domain)
+
+        user = User.objects.create_user(
+            username=name,
+            email='{}@example.com'.format(name),
+            password=name,
+        )
+        CourseCreatorRole().add_users(user)
+        UserProfile.objects.create(user=user, name=name)
+
+        # Calculated access tokens to the AMC devstack can have them without needing to communicate with the LMS.
+        # Just making it easier to automate this without having cross-dependency in devstack
+        fake_token = hashlib.md5(user.username).hexdigest()
+        reset_amc_tokens(user, access_token=fake_token, refresh_token=fake_token)
+
+        data = {
+            'site': {
+                'domain': site_name,
+                'name': site_name,
+            },
+            'user_email': user.email,
+            'organization': {
+                'name': name,
+                'short_name': name,
+                'edx_uuid': uuid.uuid4(),
+            },
+            'initial_values': {
+                'SITE_NAME': site_name,
+                'platform_name': '{} Academy'.format(name),
+                'logo_positive': None,
+                'logo_negative': None,
+                'font': 'Roboto',
+                'accent-font': 'Delius Unicase',
+                'primary_brand_color': '#F00',
+                'base_text_color': '#000',
+                'cta_button_bg': '#00F',
+            }
+        }
+        serializer = RegistrationSerializer(data=data)
+        if not serializer.is_valid():
+            raise CommandError('Something went wrong with the process: \n{errors}'.format(
+                errors=json.dumps(serializer.errors, indent=4)
+            ))
+        serializer.save()
+
+        self.congrats(
+            name=user.username,
+            email=user.email,
+            password=name,
+            site=site_name,
+            domain=domain,
+        )

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -1,0 +1,70 @@
+import hashlib
+from mock import patch
+
+from django.test import override_settings, TestCase
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+
+from openedx.core.djangoapps.appsembler.sites.management.commands.create_devstack_site import Command
+from organizations.models import Organization
+from provider.constants import CONFIDENTIAL
+from provider.oauth2.models import AccessToken, RefreshToken, Client
+from student.roles import CourseCreatorRole
+
+
+@override_settings(
+    DEBUG=True,
+    DEFAULT_SITE_THEME='edx-theme-codebase',
+    FEATURES={
+        'AMC_APP_URL': 'http://localhost:13000',
+        "DISABLE_COURSE_CREATION": False,
+        "ENABLE_CREATOR_GROUP": True,
+    },
+    COMPREHENSIVE_THEME_DIRS=[settings.REPO_ROOT / 'common/test/appsembler'],
+)
+class CreateDevstackSiteCommandTestCase(TestCase):
+    """
+    Test ./manage.py lms create_devstack_site mydevstack
+    """
+    name = 'mydevstack'  # Used for both username, email and domain prefix.
+    site_name = '{}.localhost:18000'.format(name)
+
+    def setUp(self):
+        assert settings.ENABLE_COMPREHENSIVE_THEMING
+        Client.objects.create(url=settings.FEATURES['AMC_APP_URL'], client_type=CONFIDENTIAL)
+
+    def test_no_sites(self):
+        """
+        Ensure nothing exists prior to the site creation.
+
+        If something exists, it means Open edX have changed something in the sites so this
+        test needs to be refactored.
+        """
+        assert not Site.objects.filter(domain=self.site_name).count()
+        assert not Organization.objects.count()
+        assert not get_user_model().objects.count()
+
+    def test_create_devstack_site(self):
+        """
+        Test that `create_devstack_site` and creates the required objects.
+        """
+        with patch.object(Command, 'congrats') as mock_congrats:
+            call_command('create_devstack_site', self.name)
+
+        mock_congrats.assert_called_once()  # Ensure that congrats message is printed
+
+        # Ensure objects are created correctly.
+        assert Site.objects.get(domain=self.site_name)
+        assert Organization.objects.get(name=self.name)
+        user = get_user_model().objects.get()
+        assert user.check_password(self.name)
+        assert user.profile.name == self.name
+
+        assert CourseCreatorRole().has_user(user), 'User should be a course creator'
+
+        fake_token = hashlib.md5(user.username).hexdigest()  # Using a fake token so AMC devstack can guess it
+        assert fake_token == '80bfa968ffad007c79bfc603f3670c99', 'Ensure hash is identical to AMC'
+        assert AccessToken.objects.get(user=user).token == fake_token, 'Access token is needed'
+        assert RefreshToken.objects.get(user=user).token == fake_token, 'Refresh token is needed'

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -80,7 +80,7 @@ def get_amc_tokens(user):
     return tokens
 
 
-def reset_amc_tokens(user):
+def reset_amc_tokens(user, access_token=None, refresh_token=None):
     """
     Create and return new tokens, or extend existing ones to one year in the future.
     """
@@ -94,6 +94,8 @@ def reset_amc_tokens(user):
         )
 
     access.expires = access.client.get_default_token_expiry()
+    if access_token:
+        access.token = access_token
     access.save()
 
     try:
@@ -105,7 +107,9 @@ def reset_amc_tokens(user):
             access_token=access,
         )
 
-    refresh.expired = True
+    if refresh_token:
+        refresh.token = refresh_token
+    refresh.expired = False
     refresh.save()
 
     return get_amc_tokens(user)


### PR DESCRIPTION
This allows us to create demo sites super quickly. That should save us a couple of minutes and more importantly having to pass through the trial steps after a devstack wipe out.

Example:

```
$ ./manage.py lms create_devstack_site red
```

Would make the following:

 - Site with the domain `red.localhost:18000` with the organization name: `red`
 - User with the username: `red`, email: `red@example.com`, password: `red`

Another site could be `$ ./manage.py lms create_devstack_site somethingelse`. 

The same command has to run also in AMC (see https://github.com/appsembler/amc/pull/293):

```
$ ./manage.py create_devstack_site red
```

#### Why not automating this in devstack?
Why not!

#### TL; DR;

It's finally happening! I needed to learn a lot to make this happen. It turns out this command can be made simple by using the `RegistrationSerializer` which encapsulates the logic of the entire site-create steps. Thanks Filip!