### PR TITLE
Fix unregistered celery task: course_structures

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -886,6 +886,9 @@ CELERY_IMPORTS = (
     'cms.djangoapps.contentstore.tasks',
     'openedx.core.djangoapps.bookmarks.tasks',
     'openedx.core.djangoapps.ccxcon.tasks',
+
+    # TODO: Remove after Hawthorn because the `course_structures` app will no longer exist.
+    'openedx.core.djangoapps.content.course_structures.tasks',
 )
 
 # Message configuration


### PR DESCRIPTION
Mainly to fix `KeyError` exceptions when the task `course_structures.tasks.update_course_structure` is received.

This is similar to: #510 but the `course_structures` app is no longer there after Hawthorn, so we're not pushing this upstream.