### PR TITLE
Disable mongo debug pannel on django debug toolbar

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -71,7 +71,7 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.signals.SignalsPanel',
     'debug_toolbar.panels.logging.LoggingPanel',
 
-    # MongoDebugPanel has been intentionally disabled by maxi@appsembler.com
+    # Appsembler: MongoDebugPanel has been intentionally disabled by maxi@appsembler.com
     # since it was breaking the mongo connections. Probably it's because we
     # upgraded pymongo and DjangoDebugToolbar is some versions behind.
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -70,7 +70,11 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.sql.SQLPanel',
     'debug_toolbar.panels.signals.SignalsPanel',
     'debug_toolbar.panels.logging.LoggingPanel',
-    'debug_toolbar_mongo.panel.MongoDebugPanel',
+
+    # MongoDebugPanel has been intentionally disabled by maxi@appsembler.com
+    # since it was breaking the mongo connections. Probably it's because we
+    # upgraded pymongo and DjangoDebugToolbar is some versions behind.
+
     # ProfilingPanel has been intentionally removed for default devstack.py
     # runtimes for performance reasons. If you wish to re-enable it in your
     # local development environment, please create a new settings file


### PR DESCRIPTION
This panel is already disabled in the CMS because it breaks every mongo query, but it still enabled in the LMS, since the LMS doesn't need to query mongo.

Working on the course import feature, now we need to the course import function from the LMS, and it started to break. 