### PR TITLE
django-storages 1.6.5

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -22,6 +22,9 @@ import os
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 
+# force S3 v4 (temporary until we can upgrade to django-storages 1.9)
+S3_USE_SIGV4 = True
+
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON
 # configuration files are read during startup.
 SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', None)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -30,6 +30,9 @@ import os
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 
+# force S3 v4 (temporary until we can upgrade to django-storages 1.9)
+S3_USE_SIGV4 = True
+
 # SERVICE_VARIANT specifies name of the variant used, which decides what JSON
 # configuration files are read during startup.
 SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', None)

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -58,7 +58,7 @@ django-ses==0.8.4
 django-simple-history
 django-splash
 django-statici18n==1.4.0
-django-storages==1.4.1
+django-storages==1.6.5
 django-user-tasks
 django-waffle==0.12.0
 django-webpack-loader               # Used to wire webpack bundles into the django asset pipeline

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -96,7 +96,7 @@ django-ses==0.8.4
 django-simple-history==2.1.1
 django-splash==0.2.2
 django-statici18n==1.4.0
-django-storages==1.4.1
+django-storages==1.6.5
 django-user-tasks==0.1.5
 django-waffle==0.12.0
 django-webpack-loader==0.6.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -116,7 +116,7 @@ django-ses==0.8.4
 django-simple-history==2.1.1
 django-splash==0.2.2
 django-statici18n==1.4.0
-django-storages==1.4.1
+django-storages==1.6.5
 django-user-tasks==0.1.5
 django-waffle==0.12.0
 django-webpack-loader==0.6.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -112,7 +112,7 @@ django-ses==0.8.4
 django-simple-history==2.1.1
 django-splash==0.2.2
 django-statici18n==1.4.0
-django-storages==1.4.1
+django-storages==1.6.5
 django-user-tasks==0.1.5
 django-waffle==0.12.0
 django-webpack-loader==0.6.0


### PR DESCRIPTION
upgrade `django-storages` to 1.6.5 for Tahoe staging. This version should be compatible with our version of Django and adds support for the `boto3` backend as well as a `S3_USE_SIGV4` setting that enables the older `boto` backend to use the v4 sigs to talk to newer AWS regions.