### PR TITLE
removed obsolete parameter in boto3

### DIFF
--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -376,11 +376,7 @@ def export_status_handler(request, course_key_string):
         elif isinstance(artifact.file.storage, S3Boto3Storage):
             filename = os.path.basename(artifact.file.name).encode('utf-8')
             disposition = 'attachment; filename="{}"'.format(filename)
-            output_url = artifact.file.storage.url(artifact.file.name, response_headers={
-                'response-content-disposition': disposition,
-                'response-content-encoding': 'application/octet-stream',
-                'response-content-type': 'application/x-tgz'
-            })
+            output_url = artifact.file.storage.url(artifact.file.name)
         else:
             output_url = artifact.file.storage.url(artifact.file.name)
     elif task_status.state in (UserTaskStatus.FAILED, UserTaskStatus.CANCELED):

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -374,8 +374,6 @@ def export_status_handler(request, course_key_string):
         if isinstance(artifact.file.storage, FileSystemStorage):
             output_url = reverse_course_url('export_output_handler', course_key)
         elif isinstance(artifact.file.storage, S3Boto3Storage):
-            filename = os.path.basename(artifact.file.name).encode('utf-8')
-            disposition = 'attachment; filename="{}"'.format(filename)
             output_url = artifact.file.storage.url(artifact.file.name)
         else:
             output_url = artifact.file.storage.url(artifact.file.name)


### PR DESCRIPTION
The parameter response_headers is not available in the new storage backend:

boto: https://github.com/jschneier/django-storages/blob/1.6.5/storages/backends/s3boto.py#L470

boto3: https://github.com/jschneier/django-storages/blob/master/storages/backends/s3boto3.py#L670

I just tried the change in staging hardcoding it, and it works perfect.