### PR TITLE
Fixed bug in import_course_on_site_creation call

### DIFF
--- a/cms/djangoapps/appsembler/tests/test_appsembler_sites_tasks.py
+++ b/cms/djangoapps/appsembler/tests/test_appsembler_sites_tasks.py
@@ -8,7 +8,7 @@ from organizations.models import UserOrganizationMapping
 from organizations.tests.factories import OrganizationFactory
 
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.appsembler.sites.tasks import import_course_on_site_creation
+from openedx.core.djangoapps.appsembler.sites.tasks import import_course_on_site_creation_apply_async
 from student.roles import CourseAccessRole
 from student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
@@ -86,8 +86,8 @@ class ImportCourseOnSiteCreationTestCase(ModuleStoreTestCase):
         """
         Ensure the task run properly.
         """
-        result = import_course_on_site_creation(self.organization)
-        assert not result, 'Task should succeed instead of returning an exception'
+        result = import_course_on_site_creation_apply_async(self.organization)
+        assert not result.failed(), 'Task should succeed instead of returning: "{}"'.format(result.result)
 
         courses = self.m_store.get_courses()
         assert len(courses) == 1, 'Should import just one course'

--- a/openedx/core/djangoapps/appsembler/sites/serializers.py
+++ b/openedx/core/djangoapps/appsembler/sites/serializers.py
@@ -1,12 +1,14 @@
 from django.conf import settings
 from django.contrib.sites.models import Site
-from opaque_keys.edx.locator import CourseLocator
 from rest_framework import serializers
 from organizations import api as organizations_api
 from organizations.models import Organization
 
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
-from openedx.core.djangoapps.appsembler.sites.tasks import import_course_on_site_creation
+from openedx.core.djangoapps.appsembler.sites.tasks import (
+    import_course_on_site_creation,
+    import_course_on_site_creation_apply_async,
+)
 from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
 from openedx.core.djangoapps.appsembler.sites.utils import sass_to_dict, dict_to_sass, bootstrap_site
 
@@ -136,10 +138,7 @@ class RegistrationSerializer(serializers.Serializer):
 
         # clone course
         if settings.FEATURES.get("APPSEMBLER_IMPORT_DEFAULT_COURSE_ON_SITE_CREATION", False):
-            import_course_on_site_creation.apply_async(
-                organization,
-                queue="edx.core.cms.high"
-            )
+            import_course_on_site_creation_apply_async(organization)
         return {
             'site': site,
             'organization': organization,


### PR DESCRIPTION
Now using serializable kwargs so tasks can run for real :sweat_smile:.

We don't have a test for the actual call yet in the `Registration` class so I've refactored the call into a helper function so we keep the minimize the uncovered code. Not clean, but effective in my opinion.

https://github.com/appsembler/edx-platform/blob/48506597a3053a865484a05582a017443b8c0c13/openedx/core/djangoapps/appsembler/sites/serializers.py#L139-141