### PR TITLE
(WIP) Pass request.user to LTI XBlock in Studio

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -187,6 +187,17 @@ def _preview_module_system(request, descriptor, field_data):
         # stick the license wrapper in front
         wrappers.insert(0, wrap_with_license)
 
+    def get_real_user(*_args):
+        """
+        Get the request.user object if logged logged in.
+
+        Appsembler: This is used for the LTI processors in Studio. It mimics `user_by_anonymous_id` on the lms.
+
+        :param _args: Ignored parameters.
+        :return: User
+        """
+        return request.user if request.user.is_authenticated else None
+
     return PreviewModuleSystem(
         static_url=settings.STATIC_URL,
         # TODO (cpennington): Do we want to track how instructors are using the preview problems?
@@ -207,6 +218,7 @@ def _preview_module_system(request, descriptor, field_data):
         wrappers=wrappers,
         wrappers_asides=wrappers_asides,
         error_descriptor_class=ErrorDescriptor,
+        get_real_user=get_real_user,
         get_user_role=lambda: get_user_role(request.user, course_id),
         # Get the raw DescriptorSystem, not the CombinedSystem
         descriptor_runtime=descriptor._runtime,  # pylint: disable=protected-access

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -200,3 +200,18 @@ class StudioXBlockServiceBindingTest(ModuleStoreTestCase):
         )
         service = runtime.service(descriptor, expected_service)
         self.assertIsNotNone(service)
+
+    @XBlock.register_temp_plugin(PureXBlock, identifier='pure')
+    def test_get_real_user(self):
+        """
+        Tests the `runtime.get_real_user` function exists on the Studio runtime.
+
+        Appsembler: This is useful for LTI XBlock processor parameters.
+        """
+        descriptor = ItemFactory(category="pure", parent=self.course)
+        runtime = _preview_module_system(
+            self.request,
+            descriptor,
+            self.field_data,
+        )
+        assert runtime.get_real_user(), 'Ensure get_real_user exists on CMS'


### PR DESCRIPTION
### TODO

 - [ ] I think I should fix it inside the `tahoe-lti` when possible.
-------------
So it matches the LMS behaviour.

Jira: [**RED-854:** Add support for LTI processors in Studio](https://appsembler.atlassian.net/browse/RED-854)

This way the email is sent via the LTI XBlock on Studio previews:

<kbd>![image](https://user-images.githubusercontent.com/645156/78692291-51f30d00-7902-11ea-96ba-9d57f09a6a9b.png)</kbd>

### Background

We made a `tahoe-lti` package to add custom params to the LTI providers (e.g. Scorm Cloud). This package [makes use of `get_real_user`](https://github.com/appsembler/tahoe-lti/blob/028ed0ca982d5f0d90464b0536fa16dc839e8bf4/tahoe_lti/processors.py#L6-L23) which is available exclusively on LMS. This pull request adds to Studio so it functions properly.