### PR TITLE
Export site on LMS

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/management/commands/export_site.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/export_site.py
@@ -1,0 +1,309 @@
+from datetime import tzinfo, timedelta, datetime
+
+import json
+import os
+import pkg_resources
+import socket
+
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import Site
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management.base import BaseCommand, CommandError
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db.models import ForeignKey
+from django.db.models.fields.files import ImageFieldFile
+
+from django_countries.fields import Country
+from organizations.models import Organization
+
+
+class ExtendedEncoder(DjangoJSONEncoder):
+    def default(self, o, *args, **kwargs):
+        if isinstance(o, ImageFieldFile):
+            return str(o)
+        if isinstance(o, Country):
+            return o.code
+
+        return super(ExtendedEncoder, self).default(o, *args, **kwargs)
+
+
+class Command(BaseCommand):
+    """
+    Export a Tahoe website to be imported later.
+    """
+    # Increase this version by 1 after every backward-incompatible
+    # change in the exported data format
+    VERSION = 1
+
+    def __init__(self, *args, **kwargs):
+        self.debug = False
+        self.version = self.VERSION
+        self.default_path = os.getcwd()
+
+        super(Command, self).__init__(*args, **kwargs)
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'domain',
+            help='The domain of the organization to be deleted.',
+            type=str,
+        )
+        parser.add_argument(
+            '-o', '--output',
+            help='The location you want to direct your output to.',
+            default=self.default_path,
+            type=str,
+        )
+        parser.add_argument(
+            '-d', '--debug',
+            action='store_true',
+            default=settings.DEBUG,
+            help='Execute in debug mode (Will not commit or save changes).'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Verifies the input and packs the site objects.
+        """
+        self.debug = options['debug']
+        domain = options['domain']
+
+        self.stdout.write('Inspecting project for potential problems...')
+        self.check(display_num_errors=True)
+
+        self.stdout.write(self.style.MIGRATE_HEADING('Exporting "%s" in progress...' % domain))
+        site = self.get_site(domain)
+
+        orgs = [org for org in Organization.objects.filter(sites__id=site.id)]
+
+        # Processes the necessary data all exported objects share.
+        # This data will be helpful if you are debugging or returning to an earlier state
+        # later if any changes occur when packages gets updated, or our code changes.
+        # Also some instance tracking information has been added.
+        hostname = socket.gethostname()
+        ip_address = socket.gethostbyname(hostname)
+        export_data = {
+            'version': self.version,
+            'date': datetime.now(),
+            'host_name': hostname,
+            'ip_address': ip_address,
+            'libraries': self.get_pip_packages(),
+            'site_domain': site.domain,
+            'objects': self.generate_objects(site, *orgs),
+        }
+
+        output = json.dumps(
+            export_data,
+            sort_keys=True,
+            indent=1,
+            cls=ExtendedEncoder
+        )
+
+        if self.debug:
+            self.stdout.write('\nCommand output >>>')
+            self.stdout.write(self.style.SQL_KEYWORD(output))
+
+        path = self.generate_file_path(site, options['output'])
+        self.write_to_file(path, output)
+
+        self.stdout.write(self.style.SUCCESS('\nSuccessfully exported "%s" site' % site.domain))
+
+    def get_site(self, site):
+        """
+        Locates the site to be exported and return its instance.
+
+        :param site: The site of the site to be returned.
+        :return: Returns the site object.
+        """
+        try:
+            return Site.objects.get(domain=site)
+        except Site.DoesNotExist:
+            raise CommandError('Cannot find a site for the provided domain "%s"!' % site)
+
+    def generate_objects(self, *args):
+        """
+        A Breadth First Search technique to extract the objects and processing its
+        childern.
+        What we are looking to achieve here is simply: Process the site; and
+        any related object to it. This simply will give you all the data a site
+        uses in order to operate properly when imported.
+
+        We start with the site object, all discovered relations will be added
+        to the queue to take part in the processing later. Same goes for any discovered
+        relation.
+
+        To avoid infinite loops and processing the same element more than one time, we check
+        the discovered space (processing and processed objects) before adding new elements.
+
+        :return: Simply all the discovered objects' data.
+        """
+        objects = []
+        processing_queue = list(args)
+        processed_objects = set()
+
+        while processing_queue:
+            instance = processing_queue.pop(0)
+            item, pending_items = self.process_instance(instance)
+
+            if item:
+                objects.append(item)
+
+            for pending_item in pending_items:
+                if pending_item not in processed_objects and pending_item not in processing_queue:
+                    processing_queue.append(pending_item)
+
+            processed_objects.add(instance)
+
+        return objects
+
+    def process_instance(self, instance):
+        """
+        Inspired from: django.forms.models.model_to_dict
+        Return a dict containing the data in ``instance`` suitable for passing as
+        a Model's ``create`` keyword argument with all its discovered relations.
+        """
+        if not instance:
+            return instance, []
+
+        to_process = set()
+        content_type = ContentType.objects.get_for_model(instance)
+        opts = instance._meta  # pylint: disable=W0212
+
+        data = {
+            'model': '%s.%s' % (content_type.app_label, content_type.model),
+            'fields': {},
+        }
+
+        if self.debug:
+            self.stdout.write(self.style.MIGRATE_LABEL('Processing a %s object...' % data['model']))
+
+        # We are going to iterate over the fields one by one, and depending
+        # on the type, we determine how to process them.
+        for field in opts.get_fields():
+            if isinstance(field, ForeignKey):
+                value, item = self._process_foreign_key(instance, field)
+                data['fields'][field.name] = value
+                to_process.add(item)
+
+            elif field.one_to_many:
+                items = self._process_one_to_many_relation(instance, field)
+                to_process.update(items)
+
+            elif field.one_to_one:
+                items = self._process_one_to_one_relation(instance, field)
+                to_process.update(items)
+
+            elif field in opts.many_to_many:
+                value, items = self._process_many_to_many_relation(instance, field)
+                data['fields'][field.name] = value
+                to_process.update(items)
+
+            elif field in opts.concrete_fields or field in opts.private_fields:
+                # Django stores the primary key under `id`
+                if field.name == 'id':
+                    data['pk'] = field.value_from_object(instance)
+                else:
+                    data['fields'][field.name] = field.value_from_object(instance)
+
+        if self.debug:
+            self.stdout.write('Finished processing %s object successfully!' % data['model'])
+            self.stdout.write('%d new items to process' % len(to_process))
+        else:
+            self.stdout.write('.', ending='')
+
+        return data, to_process
+
+    def _process_foreign_key(self, instance, field):
+        """
+        What we are looking to achieve from here is the to get the ID of the object
+        this instance is pointing at, and to return that instance for later processing.
+
+        Note: This will process both; ForeignKeys and OneToOneKey. As in Django a
+        OneToOneKey is sub class of ForeignKey.
+        """
+        # Gets the ID of the instance pointed at
+        value = field.value_from_object(instance)
+        return value, getattr(instance, field.name)
+
+    def _process_one_to_many_relation(self, instance, field):
+        """
+        In OneToManyRelations, it is this model that other objects are pointing at.
+        We are collecting these models to make sure that this we are not missing any
+        data used in some apps, and to protect the organization integrity.
+
+        Unlike ForeignKey, we just need too return the instances pointing at this
+        object so we can process them later.
+        """
+        manager = getattr(instance, field.name, [])
+        to_process = [obj for obj in manager.all()] if manager else []
+
+        return to_process
+
+    def _process_one_to_one_relation(self, instance, field):
+        """
+        This is a little bit similar to the OneToManyRel, except that we attribute
+        returns one instance when called instead of a Model Manager.
+        """
+        try:
+            obj = getattr(instance, field.name)
+        except ObjectDoesNotExist:
+            # Nothing to do, we didn't find any object related to this
+            # in the other model.
+            obj = None
+
+        return [obj, ]
+
+    def _process_many_to_many_relation(self, instance, field):
+        """
+        Exctrtacts all objects this instance is pointing at for later processing.
+        Also returns a list of these objects IDs to be used as a value under the
+        field name.
+        """
+        data = []
+        to_process = []
+
+        for relation in field.value_from_object(instance):
+            data.append(relation.id)
+            to_process.append(relation)
+
+        return data, to_process
+
+    def generate_file_path(self, site, output):
+        """
+        Determines and returns the output file name.
+        If the user specified a full path, then just return it. If a partial path
+        has been specified, we add the file name to it and return. Other wise, we
+        combine our base path with the file name and return them.
+        """
+        base = output or self.default_path
+
+        if base.endswith('.json'):
+            return base
+
+        now = datetime.now()
+        timestamp = (now - datetime(1970, 1, 1)).total_seconds()
+
+        file_name = '{}_{}.json'.format(site.name, timestamp)
+        path = os.path.join(base, file_name)
+        return path
+
+    def get_pip_packages(self):
+        """
+        Returns a dictionary of pip packages names and their versions. Similar
+        to `$ pip freeze`
+        """
+        return {
+            package.project_name: package.version
+            for package in pkg_resources.working_set
+        }
+
+    def write_to_file(self, path, content):
+        """
+        Writes content in the specified path.
+        """
+
+        with open(path, 'w') as file:
+            file.write(content)
+
+        self.stdout.write(self.style.SQL_KEYWORD('\nExported objects saved in %s' % path))

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -1,15 +1,19 @@
 import hashlib
-from mock import patch
+import pkg_resources
+from mock import patch, mock_open
+from StringIO import StringIO
 
-from django.test import override_settings, TestCase
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-from django.core.management import call_command
-
 from openedx.core.djangoapps.appsembler.sites.management.commands.create_devstack_site import Command
+from openedx.core.djangoapps.appsembler.sites.management.commands.export_site import Command as ExportSiteCommand
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.theming.models import SiteTheme
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import override_settings, TestCase
+
 from organizations.models import Organization
 from provider.constants import CONFIDENTIAL
 from provider.oauth2.models import AccessToken, RefreshToken, Client
@@ -114,3 +118,151 @@ class RemoveSiteCommandTestCase(TestCase):
         assert SiteConfiguration.objects.get(site=site)
 
         assert SiteTheme.objects.filter(site=site).count() == site.themes.count()
+
+
+class TestExportSiteCommand(TestCase):
+    """
+    Test ./manage.py lms export_site somesite
+    """
+
+    def setUp(self):
+        self.site_name = 'site'
+        self.site_domain = '{}.localhost:18000'.format(self.site_name)
+        self.site = Site.objects.create(domain=self.site_domain, name=self.site_name)
+
+        self.command = ExportSiteCommand()
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.export_site.Command.get_pip_packages', return_value={})
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.export_site.Command.write_to_file', return_value='called')
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.export_site.Command.check')
+    def test_handle(self, mock_check, mock_write_to_file, mock_get_pip_packages):
+        out = StringIO()
+        call_command('export_site', self.site_domain, stdout=out)
+
+        assert mock_check.called
+        assert mock_get_pip_packages.called
+        assert mock_write_to_file.called
+
+        assert 'Exporting "%s" in progress' % self.site_domain in out.getvalue()
+        assert 'Successfully exported' in out.getvalue()
+        assert 'Command output >>>' not in out.getvalue()
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.export_site.Command.get_pip_packages', return_value={})
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.export_site.Command.write_to_file', return_value='called')
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.export_site.Command.check')
+    def test_handle_debug(self, mock_check, mock_write_to_file, mock_get_pip_packages):
+        out = StringIO()
+        call_command('export_site', self.site_domain, debug=True, stdout=out)
+
+        assert mock_check.called
+        assert mock_get_pip_packages.called
+        assert mock_write_to_file.called
+
+        assert 'Exporting "%s" in progress' % self.site_domain in out.getvalue()
+        assert 'Command output >>>' in out.getvalue()
+        assert 'Successfully exported' in out.getvalue()
+
+    def test_handle_system_check_fails(self):
+        """
+        According to Django, serious problems are raised as a CommandError wheb calling
+        this `check` function. Proccessing should stop in case we got a serious problem.
+
+        https://docs.djangoproject.com/en/1.11/howto/custom-management-commands/#django.core.management.BaseCommand.check
+        """
+
+        with patch('openedx.core.djangoapps.appsembler.sites.management.commands.export_site.Command.check', side_effect=CommandError()):
+            with self.assertRaises(CommandError):
+                call_command('export_site', self.site_domain, debug=True)
+            with self.assertRaises(CommandError):
+                call_command('export_site', self.site_domain)
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.export_site.Command.process_instance')
+    def test_generate_objects_bfs(self, mock_process_instance):
+        """
+        To be able to test BFS we need a graph structure, this mimics database
+        relations to some extent.
+        """
+        mock_process_instance.side_effect = self.fake_process_instance
+        objects = self.command.generate_objects('microsite')
+
+        # Each assert is a level where its elements can be exchangeble.
+        assert objects[0] == 'microsite'
+        assert objects[1] == 'organization_1'
+        assert set(objects[2:5]) == {'user_1', 'user_2', 'tier'}
+        assert set(objects[5:8]) == {'user_terms_conditions_1', 'auth_token_1', 'user_terms_conditions_2'}
+        assert objects[8] == 'auth_token_2'
+        assert set(objects[9:]) == {'terms_1', 'terms_2'}
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.export_site.Command.process_instance')
+    def test_generate_objects_integrity(self, mock_process_instance):
+        """
+        makes sure that:
+            - All required objects are processed.
+            - Unrelated objects are not included.
+            - No object appears more than once.
+        """
+        mock_process_instance.side_effect = self.fake_process_instance
+        objects = self.command.generate_objects('microsite')
+
+        # Test duplicates
+        assert len(objects) == len(set(objects))
+
+        # Test exact items
+        assert set(objects) == {
+            'microsite',
+            'organization_1',
+            'user_1',
+            'user_2',
+            'tier',
+            'user_terms_conditions_1',
+            'auth_token_1',
+            'user_terms_conditions_2',
+            'auth_token_2',
+            'terms_1',
+            'terms_2'
+        }
+
+    def test_get_pip_packages(self):
+        packages = self.command.get_pip_packages()
+        assert isinstance(packages, dict)
+
+        for package in pkg_resources.working_set:
+            assert packages.pop(package.project_name) == package.version
+
+    @patch('django.core.files.File.write')
+    def test_write_to_file(self, mock_write):
+        path = '/dummy/path.json'
+        content = '{"tetst": "contetnt"}'
+
+        with patch("__builtin__.open", mock_open()) as mock_file:
+            self.command.write_to_file(path, content)
+
+        mock_file.assert_called_once_with(path, 'w')
+        assert mock_write.called_with(content)
+
+    @staticmethod
+    def fake_process_instance(instance):
+        """
+        Returns all this nodes relations; the ones that it points at, and the
+        ones they point at it.
+        """
+        graph = {
+            'microsite': ['organization_1', ],
+            'organization_1': ['user_1', 'user_2'],
+            'tier': ['organization_1', ],
+            'user_1': [],
+            'user_2': [],
+            'auth_token_1': ['user_1', ],
+            'auth_token_2': ['user_2', ],
+            'user_terms_conditions_1': ['user_1', 'terms_1', ],
+            'user_terms_conditions_2': ['user_1', 'terms_2', ],
+            'should_not_appear_1': ['object_not_used_1', 'object_not_used_2', ],
+            'should_not_appear_2': ['object_not_used_3', ]
+        }
+
+        objects = graph.get(instance, [])
+        for key, value in graph.items():
+            if instance in value:
+                objects.append(key)
+
+        return instance, objects


### PR DESCRIPTION
The logic has not changed in here than it is in [amc#300](https://github.com/appsembler/amc/pull/300). However, we needed to add two extra things  to be able to export an edX organization:

- `ExtendedEncoder` that allows us `ImageFieldFile` and `Country` objects in a JSON file. (Line 21)
- Some objects are not directly related, we needed to extend the initial view to include these objects in the first run. (Line 78)