### PR TITLE
Enabling Github Oauth2 backend for social login

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -679,6 +679,7 @@ if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
         'social_core.backends.linkedin.LinkedinOAuth2',
         'social_core.backends.facebook.FacebookOAuth2',
         'social_core.backends.azuread.AzureADOAuth2',
+        'social_core.backends.github.GithubOAuth2',
         'third_party_auth.saml.SAMLAuthBackend',
         'third_party_auth.lti.LTIAuthBackend',
     ])


### PR DESCRIPTION
Chef needs Github Social login to be enabled on their site and it seems the Github backend is not enabled in our env file. I added the Github Oauth2 to our `ENABLE_THIRD_PARTY_AUTH` list