### PR TITLE
Maxi/redirect when trial expired

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -7,6 +7,7 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib.admin import autodiscover as django_autodiscover
 from django.utils.translation import ugettext_lazy as _
+from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
 from rest_framework_swagger.views import get_swagger_view
 
@@ -1099,4 +1100,12 @@ urlpatterns += (
     url(r'^tahoe/api/',
         include('openedx.core.djangoapps.appsembler.api.urls',
                 namespace='tahoe-api')),
+)
+
+# Tahoe trial expired redirect
+urlpatterns += (
+    url(r'^site-unavailable/$',
+        TemplateView.as_view(
+            template_name='design-templates/pages/messages/site-expired.html'
+        )),
 )


### PR DESCRIPTION
This is a companion PR of: https://github.com/appsembler/edx-configs/pull/845
The edx configs change will trigger a redirect on expired or non payed sites in the platform, this view and URL adds the new page.

The companion PRs create the redirect in the tiers app and the new template:
* https://github.com/appsembler/edx-configs/pull/845
* https://github.com/appsembler/edx-theme-customers/pull/115

RED-953


### Current status

The priority here was lowered in order to work on other parts of the trial UX. So I'm describing the status of the issue here.

The goal: When a trial site is expired, we want to redirected users to a site unavailable page in the LMS, the redirect should work on LMS and Studio. If the trial is expired, all users are redirected to the new LMS page.

**What is Done:**

-   Matej added the new page in the LMS: https://github.com/appsembler/edx-theme-customers/pull/115

-   Maxi added the new URL to the LMS, under code review: https://github.com/appsembler/edx-platform/pull/576

**What it's done but now working:**

-   Maxi added a new config for Tiers app, to redirect to the LMS page, but is not working on devstack nor staging. https://github.com/appsembler/edx-configs/pull/845 This should work, since the tiers app has a redirection on trial expired that should work, configuring the proper variables.

**Problems identified:**

-   We want to make the redirect work on Studio, but the tiers app in studio doesn't know in which site are we, so the the relative redirect won't work, because it will try to redirect to `https://tahoe.appsembler.com/site-unavailaible/` and we need to redirect to `https://site.tahoe.appsembler.com/site-unavailaible/`.

In order to move forward please Omar Al-Ithawi meet Matej Grozdanović if it's needed to identify a solution for this in the tiers app, in order to identify the site, and make a proper redirect.