### PR TITLE
Mutli-Tenant Emails: Add optional database migrations

### DIFF
--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/__init__.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/__init__.py
@@ -1,0 +1,5 @@
+"""
+This migration enabled Multi-Tenant Emails on Tahoe.
+
+This app exists solely to rollback what the `common/djangoapps/database_fixups` does.
+"""

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/migrations/0001_initial.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations, models
+
+
+def remove_user_email_uniqueness_constraint(apps, schema_editor):
+    """
+    Enable multi-tenant emails.
+
+    To revert this migration, run the following code (untested):
+        SQL> alter table auth_user drop index email, add unique index `email` (`email`);
+        $ ./manage.py lms migrate multi_tenant_emails zero --fake
+
+    Then disable this application by removing it from INSTALLED_APPS (or ADDL_INSTALLED_APPS).
+    """
+    # Do we already have an email uniqueness constraint?
+    cursor = schema_editor.connection.cursor()
+    constraints = schema_editor.connection.introspection.get_constraints(cursor, "auth_user")
+    email_constraint = constraints.get("email", {})
+    if email_constraint.get("columns") == ["email"] and email_constraint.get("unique") == True:
+        # There is a UNIQUE constraint, but we need multi-tenant emails instead.
+        # Let's make it a regular index to retain the performance of it.
+        schema_editor.execute("alter table auth_user drop index email, add index `email` (`email`)")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('database_fixups', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_user_email_uniqueness_constraint, atomic=False)
+    ]

--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_common.py
@@ -71,6 +71,11 @@ def plugin_settings(settings):
             'tiers',
         )
 
+    if settings.FEATURES.get('APPSEMBLER_MULTI_TENANT_EMAILS', False):
+        settings.INSTALLED_APPS += (
+            'openedx.core.djangoapps.appsembler.multi_tenant_emails',
+        )
+
     settings.TAHOE_DEFAULT_COURSE_NAME = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_NAME', '')
     settings.TAHOE_DEFAULT_COURSE_GITHUB_ORG = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_GITHUB_ORG', '')
     settings.TAHOE_DEFAULT_COURSE_GITHUB_NAME = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_GITHUB_NAME', '')


### PR DESCRIPTION
### Overview
Undo the `common/djangoapps/database_fixups` database unique email constraint in favor of our own Python-enforced email uniqueness within the organization. The Python checks will be added soon in other PRs.

This is the first piece that's intended to make it in production for the Multi-Tenant Emails epic.

 - **Technical Design Proposal by Maxi and Matej:** https://github.com/appsembler/tech-design-proposals/pull/8 -- :book: required read to review any Mutli-Tenant Emails PR :book: 
 - **Original spike pull request by Maxi:** https://github.com/appsembler/edx-platform/pull/430
 - **Epic on Jira:** https://appsembler.atlassian.net/browse/RED-124

### Known Issues
It is possible with certain race-conditions that we end up with the same email having two account in the same organization (hence Tahoe site). This is an acceptable risk that we plan to monitor and only provide solutions when we think it's worth it. See [RED-1006](https://appsembler.atlassian.net/browse/RED-1006) for progress on that.

### Implementation Details

Enable `APPSEMBLER_MULTI_TENANT_EMAILS` to run the `multi_tenant_emails` migrations.  This will save us the hassle of adding the app to `ADDL_INSTALLED_APPS`. The same pattern is being used by the edX Platform a lot but I'm not sure that we want to copy it:

https://github.com/appsembler/edx-platform/blob/a9e3b3fb58d6af40f5484c1dbc27c16ac2dea267/lms/envs/aws.py#L877-L879

This migration is optional so we can merge safely into production until we're sure about all the other changes and test them on Staging for enough time.

The rest non-database changes will be added behind a feature flag (`APPSEMBLER_MULTI_TENANT_EMAILS`) to follow the same pattern just in case we decided to hold off launching the feature for a while.

:warning: Once the application is enabled the migrations will run, to undo the migration follow the instructions in the `multi_tenant_emails/migrations/0001_initial.py` file.

### Rejected Alternatives

It's not fully decided yet, but I initially rejected the alternative below:

#### Alternative A: Require explicit entry in `ADDL_APPS`

```yaml
ADDL_INSTALLED_APPS:
 - openedx.core.djangoapps.appsembler.database_unfixups
```
