### PR TITLE
Multi-Tenant Emails: Registration form

### DIFF
--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_registration_view.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_registration_view.py
@@ -1,0 +1,69 @@
+import json
+from unittest import skipUnless
+
+from django.conf import settings
+from django.test.utils import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+from .test_utils import with_organization_context
+
+
+@skip_unless_lms
+@override_settings(DEFAULT_SITE_THEME='edx-theme-codebase')
+@skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This only tests multi-tenancy')
+class MultiTenantRegistrationViewTest(APITestCase):
+    """
+    Tests to ensure the registration end-point allow multi-tenant emails.
+    """
+
+    EMAIL = 'ali@example.com'
+    PASSWORD = 'zzz'
+
+    def setUp(self):
+        super(MultiTenantRegistrationViewTest, self).setUp()
+        self.url = reverse('user_api_registration')
+
+    def register_user(self, color):
+        # Register the first user
+        response = self.client.post(self.url, {
+            'email': self.EMAIL,
+            'name': 'Ali',
+            'username': 'ali_{}'.format(color),
+            'password': self.PASSWORD,
+            'honor_code': 'true',
+        })
+        assert response.status_code == status.HTTP_200_OK, '{}: {}'.format(color, response.content)
+
+        # Try to create a second user with the same email address
+        response = self.client.post(self.url, {
+            'email': self.EMAIL,
+            'name': 'Ali Trying Again',
+            'username': 'ali_again_{}'.format(color),
+            'password': self.PASSWORD,
+            'honor_code': 'true',
+        })
+        assert response.status_code == status.HTTP_409_CONFLICT, '{}: {}'.format(color, response.content)
+        response_json = json.loads(response.content)
+        assert response_json == {
+            'email': [{
+                'user_message': (
+                    'It looks like {} belongs to an existing account. '
+                    'Try again with a different email address.'
+                ).format(
+                    self.EMAIL
+                )
+            }]
+        }, color
+
+    def test_register_duplicate_email(self):
+        color1 = 'red1'
+        with with_organization_context(site_color=color1):
+            self.register_user(color1)
+
+        color2 = 'blue2'
+        with with_organization_context(site_color=color2):
+            self.register_user(color2)


### PR DESCRIPTION
The [lms part](https://appsembler.atlassian.net/browse/RED-449) of the [Multi-Tenant Emails](https://appsembler.atlassian.net/browse/RED-124) epic.

This PR adds support for the registration form only. Other parts of the [technical proposal](https://github.com/appsembler/tech-design-proposals/blob/master/proposals/0003-tahoe-multi-tenant.md) will be implemented in future PRs.

Tests can be run locally `$ tox -e py27-mte` on your computer. It doesn't need devstack!

### How to Manually Test It
The tests has a couple of checkpoints which are marked with :heavy_check_mark:, make sure to check everyone of them.

 - Edit the `lms.env.json` and set `FEATURES.APPSEMBLER_MULTI_TENANT_EMAILS` to `true`
 - Run the migrations from within your lms devstack shell: `# ./manage.py lms migrate multi_tenant_emails`, you should see `0001_initial` migration (:heavy_check_mark: checkpoint no. 1)
 - `$ make lms-restart`
 - Run `# ./manage.py lms create_devstack_site red` in your devstack lms shell.
 - Run `# ./manage.py lms create_devstack_site blue` in your devstack lms shell.
 - Go to http://blue.localhost:18000/ and register a user with the email `omar@example.com`
 - Try registering again, it should fail for the `blue` site (:heavy_check_mark: checkpoint no. 2)
 - Go to http://red.localhost:18000/ and register a user with the email `omar@example.com` it should succeed (:heavy_check_mark: checkpoint no. 3)
 - Try registering again, it should fail for the `red` site (:heavy_check_mark: checkpoint no. 4)


### TODO

 - [x] Omar to go through the manual testing steps above on devstack
 - [x] Another engineer (Maxi or John) to go through the same steps on their own devstack
