### PR TITLE
Multi-Tenant Emails: Login

### DIFF
--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -571,6 +571,11 @@ COURSE_CATALOG_API_URL = 'https://catalog.example.com/api/v1'
 COMPREHENSIVE_THEME_DIRS = [REPO_ROOT / "common/test/appsembler", REPO_ROOT / "themes", REPO_ROOT / "common/test"]
 COMPREHENSIVE_THEME_LOCALE_PATHS = [REPO_ROOT / "themes/conf/locale", ]
 
+# Appsembler: We have a single theme for all customers. We might want to undo this if it turns out that it fails
+#             More tests than it fixes. If we undo this, we need to
+#             add `@override_settings(DEFAULT_SITE_THEME='edx-theme-codebase') to individual failed tests.
+DEFAULT_SITE_THEME = 'edx-theme-codebase'
+
 LMS_BASE = "localhost:8000"
 LMS_ROOT_URL = "http://localhost:8000"
 

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_login_view.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_login_view.py
@@ -1,0 +1,127 @@
+"""
+Tests for multi-tentant login view.
+"""
+
+from unittest import skipUnless
+
+from django.conf import settings
+from django.core.cache import cache
+from django.test.client import Client
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from organizations.models import UserOrganizationMapping
+from student.tests.factories import UserFactory
+
+from .test_utils import with_organization_context
+
+
+@skip_unless_lms
+@override_settings(
+    AUTHENTICATION_BACKENDS=(
+        # Match the Appsembler configuration in appsembler.settings..aws_common
+        'organizations.backends.DefaultSiteBackend',
+        'organizations.backends.SiteMemberBackend',
+        'organizations.backends.OrganizationMemberBackend',
+    )
+)
+@skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This only tests multi-tenancy')
+class MultiTenantLoginTest(CacheIsolationTestCase):
+    """
+    Test student.views.login_user() view.
+
+    This is similar to student.tests.test_login.LoginTest focuses on our multi-tenant tests including but not
+    limited to `APPSEMBLER_MULTI_TENANT_EMAILS` i.e. these tests test
+    the `organizations.backends.OrganizationMemberBackend` backend we rely on for Tahoe security.
+    """
+
+    ENABLED_CACHES = ['default']
+    EMAIL = 'test@edx.org'
+    PASSWORD = 'test_password'
+
+    RED = 'red1'
+    BLUE = 'blue2'
+
+    def setUp(self):
+        super(MultiTenantLoginTest, self).setUp()
+        # Create the test client
+        self.client = Client()
+        cache.clear()
+        # Store the login url
+        self.url = reverse('login')
+
+    def test_auth_backends(self):
+        """
+        Ensure the correct authentication backends are enabled for this test case.
+        """
+        assert settings.AUTHENTICATION_BACKENDS == (
+            'organizations.backends.DefaultSiteBackend',
+            'organizations.backends.SiteMemberBackend',
+            'organizations.backends.OrganizationMemberBackend',
+        )
+
+    def create_user(self, org, email=EMAIL, password=PASSWORD):
+        """
+        Create one user and save it to the database.
+        """
+        user = UserFactory.create(first_name='noderabbit', email=email, password=password)
+        UserOrganizationMapping.objects.create(user=user, organization=org)
+        return user
+
+    def test_login_success(self):
+        """
+        Happy scenario for Tahoe sites regardless of APPSEMBLER_MULTI_TENANT_EMAILS.
+        """
+        with with_organization_context(self.RED) as org:
+            self.create_user(org)
+            response = self.client.post(self.url, {'email': self.EMAIL, 'password': self.PASSWORD})
+            assert response.json()['success'], response.content
+
+    def test_login_site_separation(self):
+        """
+        Ensure site separation via our OrganizationMemberBackend regardless of APPSEMBLER_MULTI_TENANT_EMAILS.
+        """
+        with with_organization_context(self.RED) as org:
+            self.create_user(org)
+
+        with with_organization_context(self.BLUE):
+            response = self.client.post(self.url, {'email': self.EMAIL, 'password': self.PASSWORD})
+            assert not response.json()['success'], response.content
+            assert response.json()['value'], 'Email or password is incorrect'
+
+    def test_login_reuse_email_two_sites(self):
+        """
+        Testing two emails with the `APPSEMBLER_MULTI_TENANT_EMAILS` enabled.
+        """
+        with with_organization_context(self.RED) as org:
+            self.create_user(org)
+            response = self.client.post(self.url, {'email': self.EMAIL, 'password': self.PASSWORD})
+            assert response.json()['success'], response.content
+
+        with with_organization_context(self.BLUE) as org:
+            self.create_user(org)
+            response = self.client.post(self.url, {'email': self.EMAIL, 'password': self.PASSWORD})
+            assert response.json()['success'], response.content
+
+    def test_login_fail_no_user_exists(self):
+        """
+        Sanity check for user not found regardless of APPSEMBLER_MULTI_TENANT_EMAILS.
+        """
+        with with_organization_context(self.RED) as org:
+            self.create_user(org)
+            nonexistent_email = u'not_a_user@edx.org'
+            response = self.client.post(self.url, {'email': nonexistent_email, 'password': self.PASSWORD})
+            assert not response.json()['success'], response.content
+            assert response.json()['value'], 'Email or password is incorrect'
+
+    def test_login_fail_wrong_password(self):
+        """
+        Sanity check for incorrect password regardless of APPSEMBLER_MULTI_TENANT_EMAILS.
+        """
+        with with_organization_context(self.RED) as org:
+            self.create_user(org)
+            response = self.client.post(self.url, {'email': self.EMAIL, 'password': 'wrong_password'})
+            assert not response.json()['success'], response.content
+            assert response.json()['value'], 'Email or password is incorrect'

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_utils.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_utils.py
@@ -1,0 +1,37 @@
+"""
+Tests utils for multi-tenant emails.
+"""
+
+import contextlib
+from organizations.models import Organization, UserOrganizationMapping
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
+
+
+@contextlib.contextmanager
+def with_organization_context(site_color, configs=None):
+    """
+    Tests helper to create organization with proper site configuration.
+
+    This to be used like `with_site_configuration_context`.
+    course_org_filter will be prefilled if not provided in configs.
+
+    :param site_color: any name to be used for both site domain and organization name.
+    :param configs: dictionary of configs.
+
+    :yield: organization object.
+    """
+
+    configs = configs or {}
+    if 'course_org_filter' not in configs:
+        configs['course_org_filter'] = site_color
+
+    with with_site_configuration_context(domain=site_color, configuration=configs) as site:
+        try:
+            org = Organization.objects.get(name=site_color)
+        except Organization.DoesNotExist:
+            org = Organization.objects.create(
+                name=site_color,
+                short_name=site_color,
+            )
+            org.sites.add(site)
+        yield org

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -69,7 +69,7 @@ class SiteConfiguration(models.Model):
         # When creating a new object, save default microsite values. Not implemented as a default method on the field
         # because it depends on other fields that should be already filled.
         if not self.id:
-            self.values = self._get_initial_microsite_values()
+            self.values = self.get_initial_microsite_values()
 
         # fix for a bug with some pages requiring uppercase platform_name variable
         self.values['PLATFORM_NAME'] = self.values.get('platform_name', '')
@@ -228,7 +228,7 @@ class SiteConfiguration(models.Model):
             return [(path, self.values.get('customer_sass_input', ''))]
         return None
 
-    def _get_initial_microsite_values(self):
+    def get_initial_microsite_values(self):
         domain_without_port_number = self.site.domain.split(':')[0]
         return {
             'platform_name': self.site.name,

--- a/openedx/core/djangoapps/site_configuration/tests/test_util.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_util.py
@@ -12,6 +12,22 @@ from django.contrib.sites.models import Site
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
 
+def apply_appsembler_theme_configs(site_configuration, values):
+    """
+    Save the SiteConfiguration for testing in compatibility with the theme.
+
+    Using get_initial_microsite_values() to ensure the theme configs are used
+    correctly.
+
+    This helper is related to our hack in the `SiteConfiguration.save()` method.
+    """
+    appsembler_configs = site_configuration.get_initial_microsite_values()
+    appsembler_configs.update(values or {})
+    site_configuration.values = appsembler_configs
+    site_configuration.save()
+    return site_configuration
+
+
 def with_site_configuration(domain="test.localhost", configuration=None):
     """
     A decorator to run a test with a configuration enabled.
@@ -28,11 +44,9 @@ def with_site_configuration(domain="test.localhost", configuration=None):
             site, __ = Site.objects.get_or_create(domain=domain, name=domain)
             site_configuration, created = SiteConfiguration.objects.get_or_create(
                 site=site,
-                defaults={"enabled": True, "values": configuration},
+                defaults={"enabled": True},
             )
-            if not created:
-                site_configuration.values = configuration
-                site_configuration.save()
+            apply_appsembler_theme_configs(site_configuration, configuration)
 
             with patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
                        return_value=site_configuration):
@@ -53,13 +67,11 @@ def with_site_configuration_context(domain="test.localhost", configuration=None)
         configuration (dict): configuration to use for the test site.
     """
     site, __ = Site.objects.get_or_create(domain=domain, name=domain)
-    site_configuration, created = SiteConfiguration.objects.get_or_create(
+    site_configuration, _created = SiteConfiguration.objects.get_or_create(
         site=site,
-        defaults={"enabled": True, "values": configuration},
+        defaults={"enabled": True},
     )
-    if not created:
-        site_configuration.values = configuration
-        site_configuration.save()
+    apply_appsembler_theme_configs(site_configuration, configuration)
 
     with patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
                return_value=site_configuration):

--- a/openedx/core/djangoapps/site_configuration/tests/test_util.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_util.py
@@ -65,4 +65,4 @@ def with_site_configuration_context(domain="test.localhost", configuration=None)
                return_value=site_configuration):
         with patch('openedx.core.djangoapps.theming.helpers.get_current_site', return_value=site):
             with patch('django.contrib.sites.models.SiteManager.get_current', return_value=site):
-                yield
+                yield site


### PR DESCRIPTION
The [lms part](https://appsembler.atlassian.net/browse/RED-449) of the [Multi-Tenant Emails](https://appsembler.atlassian.net/browse/RED-124) epic.

This PR adds support for the login only. Other parts of the [technical proposal](https://github.com/appsembler/tech-design-proposals/blob/master/proposals/0003-tahoe-multi-tenant.md) will be implemented in future PRs.

Tests can be run locally `$ tox -e py27-mte` on your computer. It doesn't need devstack!

### How to Manually Test It
The manual testing for the login requires #586 to be merged first.

The tests has a couple of checkpoints which are marked with :heavy_check_mark:, make sure to check everyone of them.

 - Edit the `lms.env.json` and set `FEATURES.APPSEMBLER_MULTI_TENANT_EMAILS` to `true`
 - Run the migrations from within your lms devstack shell: `# ./manage.py lms migrate multi_tenant_emails`, you should see `0001_initial` migration (:heavy_check_mark: checkpoint no. 1)
 - `$ make lms-restart`
 - Run `# ./manage.py lms create_devstack_site red` in your devstack lms shell.
 - Run `# ./manage.py lms create_devstack_site blue` in your devstack lms shell.
 - Go to http://blue.localhost:18000/ and register a user with the email `omar@example.com`
 - Try registering again, it should fail for the `blue` site (:heavy_check_mark: checkpoint no. 2)
 - Go to http://red.localhost:18000/ and register a user with the email `omar@example.com` it should succeed (:heavy_check_mark: checkpoint no. 3)
 - Try registering again, it should fail for the `red` site (:heavy_check_mark: checkpoint no. 4)
 - Log out and login again into `blue` site (:heavy_check_mark: checkpoint no. 5)
 - Log out and login again into `red` site (:heavy_check_mark: checkpoint no. 6)

### TODO

 - [x] Omar to go through the manual testing steps above on devstack
 - [x] Another engineer (Maxi or John) to go through the same steps on their own devstack
