### PR TITLE
Multi-Tenant Emails: Change account email

### DIFF
--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_change_email.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_change_email.py
@@ -1,0 +1,122 @@
+"""
+Test cases to cover Accounts change email related to APPSEMBLER_MULTI_TENANT_EMAILS.
+"""
+
+from __future__ import unicode_literals
+
+from unittest import skipUnless
+import json
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from student.models import PendingEmailChange
+
+from .test_utils import with_organization_context, create_org_user
+
+
+@skip_unless_lms
+@skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This tests multi-tenancy')
+class TestAccountsAPI(APITestCase):
+    """
+    Unit tests for the Accounts views.
+
+    This is similar to user_api.accounts..TestAccountsAPI but focuses on the
+    limited to `APPSEMBLER_MULTI_TENANT_EMAILS` feature.
+    """
+
+    RED = 'red1'
+    BLUE = 'blue2'
+
+    AHMED_EMAIL = 'ahmedj@example.org'
+    JOHN_EMAIL = 'johnb@example.org'
+    PASSWORD = 'test_password'
+
+    def send_patch_email(self, user, new_email):
+        """
+        Login and send PATCH request to change the email then logout.
+        """
+        self.client.login(username=user.username, password=self.PASSWORD)
+        url = reverse('accounts_api', kwargs={'username': user.username})
+        patch_body = json.dumps({'email': new_email, 'goals': 'change my email'})
+        response = self.client.patch(url, patch_body, content_type='application/merge-patch+json')
+        self.client.logout()
+        return response
+
+    def assert_change_email(self, user, new_email):
+        """
+        Assert a successful but PENDING email change.
+        """
+        original_email = user.email
+        response = self.send_patch_email(user, new_email)
+        allow_change_email = 'Email change should be allowed: {}'.format(response.content)
+        assert response.status_code == status.HTTP_200_OK, allow_change_email
+
+        pending_changes = PendingEmailChange.objects.filter(user=user)
+        assert pending_changes.count() == 1, allow_change_email
+
+        user.refresh_from_db()
+        assert user.email == original_email, 'Should not change the email yet'
+
+    def assert_confirm_change(self, user, new_email):
+        # Now call the method that will be invoked with the user clicks the activation key in the received email.
+        # First we must get the activation key that was sent.
+        pending_change = PendingEmailChange.objects.get(user=user)
+        activation_key = pending_change.activation_key
+        confirm_change_url = reverse(
+            'confirm_email_change', kwargs={'key': activation_key}
+        )
+        confirm_response = self.client.get(confirm_change_url)
+        assert confirm_response.status_code == status.HTTP_200_OK, confirm_response.content
+        user.refresh_from_db()
+        assert user.email == new_email, 'Should change the email successfully'
+
+    def test_change_email_success(self):
+        """
+        Email change request is allowed regardless of APPSEMBLER_MULTI_TENANT_EMAILS.
+        """
+        with with_organization_context(site_color=self.RED) as org:
+            red_ahmed = create_org_user(org, email=self.AHMED_EMAIL, password=self.PASSWORD)
+            new_email = 'another_email@example.com'
+            self.assert_change_email(red_ahmed, new_email)
+            self.assert_confirm_change(red_ahmed, new_email)
+
+    def test_change_email_disallow_duplicate(self):
+        """
+        Ensure email reuse is not allowed within the organization regardless of APPSEMBLER_MULTI_TENANT_EMAILS.
+        """
+        with with_organization_context(site_color=self.RED) as org:
+            red_ahmed = create_org_user(org, email=self.AHMED_EMAIL, password=self.PASSWORD)
+            red_john = create_org_user(org, email=self.JOHN_EMAIL, password=self.PASSWORD)
+            response = self.send_patch_email(red_ahmed, red_john.email)
+            disallow_reuse_msg = 'Email reuse within the same organization should be disallowed'
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, disallow_reuse_msg
+            pending_changes = PendingEmailChange.objects.filter(user=red_ahmed)
+            assert not pending_changes.count(), disallow_reuse_msg
+
+    def test_change_email_success_multi_tenant(self):
+        """
+        Email change allows emails in other organizations when APPSEMBLER_MULTI_TENANT_EMAILS is enabled.
+
+        Story:
+         - John registers for the Red Academy via his corporate email address.
+         - John registers for the Blue University via his Gmail email address.
+         - John decides to use his corporate email address on Blue University as well.
+        """
+        john_email = 'johnb@gmail.com'
+        john_corp = 'johnb@corp.biz'
+
+        with with_organization_context(site_color=self.RED) as org:
+            # John registers for the Red Academy via his corporate email address.
+            red_john = create_org_user(org, email=john_corp, password=self.PASSWORD)
+
+        with with_organization_context(site_color=self.BLUE) as org:
+            # John registers for the Blue University via his Gmail email address.
+            blue_john = create_org_user(org, email=john_email, password=self.PASSWORD)
+            # John decides to use his corporate email address on Blue University as well.
+            self.assert_change_email(blue_john, red_john.email)  # Use corporate email in another organization
+            self.assert_confirm_change(blue_john, red_john.email)  # Reuse Ahmed's email in another organization

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_login_view.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_login_view.py
@@ -12,10 +12,8 @@ from django.urls import reverse
 
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from organizations.models import UserOrganizationMapping
-from student.tests.factories import UserFactory
 
-from .test_utils import with_organization_context
+from .test_utils import with_organization_context, create_org_user
 
 
 @skip_unless_lms
@@ -66,9 +64,7 @@ class MultiTenantLoginTest(CacheIsolationTestCase):
         """
         Create one user and save it to the database.
         """
-        user = UserFactory.create(first_name='noderabbit', email=email, password=password)
-        UserOrganizationMapping.objects.create(user=user, organization=org)
-        return user
+        return create_org_user(org, first_name='noderabbit', email=email, password=password)
 
     def test_login_success(self):
         """

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_utils.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_utils.py
@@ -6,6 +6,8 @@ import contextlib
 from organizations.models import Organization, UserOrganizationMapping
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
 
+from student.tests.factories import UserFactory
+
 
 @contextlib.contextmanager
 def with_organization_context(site_color, configs=None):
@@ -35,3 +37,12 @@ def with_organization_context(site_color, configs=None):
             )
             org.sites.add(site)
         yield org
+
+
+def create_org_user(organization, **kwargs):
+    """
+    Create one user and save it to the database.
+    """
+    user = UserFactory.create(**kwargs)
+    UserOrganizationMapping.objects.create(user=user, organization=organization)
+    return user


### PR DESCRIPTION
The [lms part](https://appsembler.atlassian.net/browse/RED-449) of the [Multi-Tenant Emails](https://appsembler.atlassian.net/browse/RED-124) epic.

This PR adds support for the change email in the account settings page (`http://blue.localhost:18000/account/settings`). Other parts of the [technical proposal](https://github.com/appsembler/tech-design-proposals/blob/master/proposals/0003-tahoe-multi-tenant.md) will be implemented in future PRs.

Tests can be run locally `$ tox -e py27-mte` on your computer. It doesn't need devstack!

### How to Manually Test It
The tests has a couple of checkpoints which are marked with :heavy_check_mark:, make sure to check everyone of them.
 
 - Ensure the correct branch is checked out
 - Edit the `lms.env.json` and set `FEATURES.APPSEMBLER_MULTI_TENANT_EMAILS` to `true`
 - Run the migrations from within your lms devstack shell: `# ./manage.py lms migrate multi_tenant_emails`, you should see `0001_initial` migration (:heavy_check_mark: checkpoint no. 1)
 - `$ make lms-restart`
 - Run `# ./manage.py lms create_devstack_site red` in your devstack lms shell.
 - Run `# ./manage.py lms create_devstack_site blue` in your devstack lms shell.
 - Go to http://blue.localhost:18000/ and register a user with the email `omar@example.com`
 - Try registering again, it should fail for the `blue` site (:heavy_check_mark: checkpoint no. 2)
 - Go to http://red.localhost:18000/ and register a user with the email `omar@example.com` it should succeed (:heavy_check_mark: checkpoint no. 3)
 - Try registering again, it should fail for the `red` site (:heavy_check_mark: checkpoint no. 4)

Then

 - Use the same email for different organizations it should be allowed (:heavy_check_mark: checkpoint no. 5)
 - Use the same email for the same organization it should be disallowed (:heavy_check_mark: checkpoint no. 6)

### TODO

 - [x] Omar to go through the manual testing steps above on devstack
 - [x] Another engineer (Maxi or John) to go through the same steps on their own devstack
 - [x] Omar to rebase this branch and clean the git history once #586 and #587 are merged
