### PR TITLE
Segment eventtracking processor to copy data properties to top level

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1232,6 +1232,9 @@ EVENT_TRACKING_BACKENDS = {
                     }
                 },
                 {
+                    'ENGINE': 'openedx.core.djangoapps.appsembler.eventtracking.segment.SegmentTopLevelPropertiesProcessor'
+                },
+                {
                     'ENGINE': 'track.shim.GoogleAnalyticsProcessor'
                 }
             ]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -779,6 +779,9 @@ EVENT_TRACKING_BACKENDS = {
                     }
                 },
                 {
+                    'ENGINE': 'openedx.core.djangoapps.appsembler.eventtracking.segment.SegmentTopLevelPropertiesProcessor'
+                },
+                {
                     'ENGINE': 'track.shim.GoogleAnalyticsProcessor'
                 }
             ]

--- a/openedx/core/djangoapps/appsembler/eventtracking/__init__.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/__init__.py
@@ -1,0 +1,3 @@
+"""
+Custom eventtracking behavior: backends, processors, etc.
+"""

--- a/openedx/core/djangoapps/appsembler/eventtracking/segment.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/segment.py
@@ -1,0 +1,83 @@
+"""
+Custom event processors and other functionality for the Segment backend.
+"""
+
+from django.conf import settings
+from openedx.core.djangoapps.site_configuration import helpers
+
+
+class SegmentTopLevelPropertiesProcessor(object):
+    """
+
+    Most Segment.io Destination APIs require properties to be at the top level
+    of the event. Copy all properties contained within the event's 'data' key
+    to the top level of the event dict.
+
+    We copy properties instead of reassign to not break previous integrations.
+
+    For example: by default, tracker.emit() will produce an event
+    with most interesting properties in the `data` key, like:
+
+    analytics.track('13', 'edx.bi.completion.user.chapter.started', {
+    'context': { ... },
+    'data': {
+        'block_id': 'block-v1:foo+101+forever+type@chapter+block@3707382f0c284b6aadbd7c50d767ca8f',
+        'block_name': 'Section 1',
+        'completion_percent': 33.3333333333333,
+        'course_id': 'course-v1:foo+101+forever',
+        'course_name': 'CompletionTest',
+        'label': 'chapter Section 1 started'
+    },
+    'name': 'edx.bi.completion.user.chapter.started',
+    ...
+    })
+
+    Many/most Segment Destinations will not be able to access properties inside 'data'.
+    Copy these to the top level of the event before emitting.
+    For example, the previous becomes:
+    analytics.track('13', 'edx.bi.completion.user.chapter.started', {
+    'context': { ... },
+    'block_id': 'block-v1:foo+101+forever+type@chapter+block@3707382f0c284b6aadbd7c50d767ca8f',
+    'block_name': 'Section 1',
+    'completion_percent': 33.3333333333333,
+    'course_id': 'course-v1:foo+101+forever',
+    'course_name': 'CompletionTest',
+    'label': 'chapter Section 1 started',
+    'data': {
+        'block_id': 'block-v1:foo+101+forever+type@chapter+block@3707382f0c284b6aadbd7c50d767ca8f',
+        'block_name': 'Section 1',
+        'completion_percent': 33.3333333333333,
+        'course_id': 'course-v1:foo+101+forever',
+        'course_name': 'CompletionTest',
+        'label': 'chapter Section 1 started'
+    },
+    'name': 'edx.bi.completion.user.chapter.started',
+    ...
+    })
+
+
+    Always returns the event for continued processing.
+    """
+
+    def __call__(self, event):
+        if not helpers.get_value(
+            'COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL',
+            settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL
+        ):
+            # processor disabled, but keep processing
+            return event
+        try:
+            for key, val in event['data'].items():
+                if key in event:
+                    try:
+                        event[key].update(event['data'][key])  # dict
+                    except AttributeError:
+                        try:
+                            event[key].extend(event['data'][key])  # list
+                        except AttributeError:
+                            event[key] = val
+                else:
+                    event[key] = val
+        except KeyError:  # no 'data'
+            pass
+        return event

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -37,3 +37,5 @@ def plugin_settings(settings):
 
     settings.CUSTOM_DOMAINS_REDIRECT_CACHE_TIMEOUT = None  # The length of time we cache Redirect model data
     settings.CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX = 'custom_domains_redirects'
+
+    settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL = True

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -38,4 +38,4 @@ def plugin_settings(settings):
     settings.CUSTOM_DOMAINS_REDIRECT_CACHE_TIMEOUT = None  # The length of time we cache Redirect model data
     settings.CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX = 'custom_domains_redirects'
 
-    settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL = True
+    settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL = False


### PR DESCRIPTION
...used when destined for Segment and enabled via settings/SiteConfiguration.

replacing https://github.com/appsembler/event-tracking/pull/1 though I will try to upstream work directly in that repo.