### PR TITLE
Support Site-based Segment Client routing from events without request obj in thread

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -1,6 +1,7 @@
 """Map new event context values to old top-level field values. Ensures events can be parsed by legacy parsers."""
 
 import json
+import logging
 import uuid
 import copy
 
@@ -8,6 +9,7 @@ import analytics
 from analytics.client import Client
 
 from openedx.core.djangoapps.site_configuration import helpers
+from openedx.core.djangoapps.appsembler.eventtracking import exceptions, utils
 
 from .transformers import EventTransformerRegistry
 
@@ -20,6 +22,8 @@ CONTEXT_FIELDS_TO_INCLUDE = [
     'referer',
     'accept_language'
 ]
+
+logger = logging.getLogger(__name__)
 
 
 class LegacyFieldMappingProcessor(object):
@@ -131,6 +135,33 @@ class DefaultMultipleSegmentClient(object):
                 params[param] = getattr(analytics, param)
         return Client(write_key, **params)
 
+    def _get_site_segment_key(self, *args):
+        """
+        Find the Site-specific Segment writekey by possible strategies.
+        """
+
+        # Preferentially, by site from request middleware if request available in thread
+        site_segment_key = helpers.get_value('SEGMENT_KEY')
+        if not site_segment_key:
+            try:
+                # this code should only ever run on TRACK events which
+                # will pass args like (user_id, event name, event dict)
+                event_props = args[2]
+                siteconfig = utils.get_site_config_for_event(event_props)
+                if siteconfig:
+                    site_segment_key = siteconfig.get_value('SEGMENT_KEY', None)
+            except (IndexError, exceptions.EventProcessingError) as e:
+                try:
+                    event_name = args[1]
+                except IndexError:
+                    event_name = '(unknown event name)'
+                logger.warn(
+                    "Error retrieving Site SEGMENT_KEY. Cannot send event {} to "
+                    "Site's Segment account. Sending only to main Segment client. "
+                    "Error was {}".format(event_name, e.msg)
+                )
+            return site_segment_key
+
     def __getattr__(self, name, *args, **kwargs):
 
         def proxy(*args, **kwargs):
@@ -138,15 +169,7 @@ class DefaultMultipleSegmentClient(object):
 
             site_client = None
 
-            from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
-            site_segment_key = helpers.get_value('SEGMENT_KEY')
-            try:
-                if not site_segment_key and 'org' in args[2]:
-                    org_name = args[2]['org']
-                    site_segment_key = SiteConfiguration.get_value_for_org(org_name, 'SEGMENT_KEY')
-            except (IndexError, TypeError):
-                pass
-
+            site_segment_key = self._get_site_segment_key(*args)
             if site_segment_key:
                 site_client = self._create_client(site_segment_key)
 

--- a/openedx/core/djangoapps/appsembler/eventtracking/exceptions.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/exceptions.py
@@ -1,0 +1,9 @@
+"""
+Custom exceptions for this package.
+"""
+
+class EventProcessingError(Exception):
+    """
+    Encapsulating error class for exceptions raised 
+    trying to process and event for eventtracking.
+    """

--- a/openedx/core/djangoapps/appsembler/eventtracking/exceptions.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/exceptions.py
@@ -2,8 +2,9 @@
 Custom exceptions for this package.
 """
 
+
 class EventProcessingError(Exception):
     """
-    Encapsulating error class for exceptions raised 
+    Encapsulating error class for exceptions raised
     trying to process and event for eventtracking.
     """

--- a/openedx/core/djangoapps/appsembler/eventtracking/segment.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/segment.py
@@ -28,7 +28,7 @@ class SegmentTopLevelPropertiesProcessor(object):
         'block_name': 'Section 1',
         'completion_percent': 33.3333333333333,
         'course_id': 'course-v1:foo+101+forever',
-        'course_name': 'CompletionTest',foo
+        'course_name': 'CompletionTest',
         'label': 'chapter Section 1 started'
     },
     'name': 'edx.bi.completion.user.chapter.started',

--- a/openedx/core/djangoapps/appsembler/eventtracking/segment.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/segment.py
@@ -28,7 +28,7 @@ class SegmentTopLevelPropertiesProcessor(object):
         'block_name': 'Section 1',
         'completion_percent': 33.3333333333333,
         'course_id': 'course-v1:foo+101+forever',
-        'course_name': 'CompletionTest',foo
+        'course_name': 'CompletionTest',
         'label': 'chapter Section 1 started'
     },
     'name': 'edx.bi.completion.user.chapter.started',
@@ -73,7 +73,7 @@ class SegmentTopLevelPropertiesProcessor(object):
                 settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL
             ):
                 return event
-        except exceptions.EventProcessingError:
+        except (AttributeError, exceptions.EventProcessingError):
             return event
 
         try:

--- a/openedx/core/djangoapps/appsembler/eventtracking/segment.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/segment.py
@@ -28,7 +28,7 @@ class SegmentTopLevelPropertiesProcessor(object):
         'block_name': 'Section 1',
         'completion_percent': 33.3333333333333,
         'course_id': 'course-v1:foo+101+forever',
-        'course_name': 'CompletionTest',
+        'course_name': 'CompletionTest',foo
         'label': 'chapter Section 1 started'
     },
     'name': 'edx.bi.completion.user.chapter.started',
@@ -73,7 +73,7 @@ class SegmentTopLevelPropertiesProcessor(object):
                 settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL
             ):
                 return event
-        except (AttributeError, exceptions.EventProcessingError):
+        except exceptions.EventProcessingError:
             return event
 
         try:

--- a/openedx/core/djangoapps/appsembler/eventtracking/segment.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/segment.py
@@ -73,7 +73,7 @@ class SegmentTopLevelPropertiesProcessor(object):
                 settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL
             ):
                 return event
-        except exceptions.EventProcessingError:
+        except (AttributeError, exceptions.EventProcessingError):
             return event
 
         try:

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -1,0 +1,41 @@
+"""
+Utility functions for event tracking processing.
+"""
+
+from django.core.exceptions import MultipleObjectsReturned
+
+from . import exceptions
+
+
+def get_site_config_for_event(event_props):
+    """
+    Try multiple strategies to find a SiteConfiguration object to use
+    for evaluating and processing an event.
+
+    This will only be called if the SiteConfiguration cannot be retrieved
+    via the request on the thread.
+
+    Return a SiteConfiguration object if found; otherwise, None.
+    """
+    from openedx.core.djangoapps.appsembler.sites import utils
+    from openedx.core.djangoapps.site_configuration import helpers
+    from organizations import models
+
+    # try first via request obj in thread
+    site_configuration = helpers.get_current_site_configuration()
+    if not site_configuration:
+        try:
+            if 'org' in event_props:
+                org_name = event_props['org']
+                org = models.Organization.objects.get(short_name=org_name)
+            # try by OrganizationCourse relationship if event has a course_id property
+            elif 'course_id' in event_props:
+                course_id = event_props['course_id']
+                # allow to fail if more than one Organization to avoid sharing data
+                orgcourse = models.OrganizationCourse.objects.get(course_id=args)
+                org = orgcourse.organization
+            site = utils.get_site_by_organization(org)
+            site_configuration = site.configuration
+        except (AttributeError, TypeError, MultipleObjectsReturned) as e:
+            raise exceptions.EventProcessingError(e)
+    return site_configuration

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -12,9 +12,6 @@ def get_site_config_for_event(event_props):
     Try multiple strategies to find a SiteConfiguration object to use
     for evaluating and processing an event.
 
-    This will only be called if the SiteConfiguration cannot be retrieved
-    via the request on the thread.
-
     Return a SiteConfiguration object if found; otherwise, None.
     """
     from openedx.core.djangoapps.appsembler.sites import utils


### PR DESCRIPTION
Rework track.shim.DefaultMultipleSegmentClient to try getting Site Segment Key via org passed in event.

Not all events are triggered within the thread that has the request,
so site_configuration.helpers.get_value won't always be able to find the
Site's Segment Key.  First check via helpers.get_value and if not available
get by SiteConfiguration.get_value_for_org using org key passed in event.
This approach requires constructing the Site client in each proxy'd
method, not in the getattr override. Should be just the same result.