### PR TITLE
Revert "Revert "Support Site-based Segment Client routing from events without request obj in thread""

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/exceptions.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/exceptions.py
@@ -1,0 +1,10 @@
+"""
+Custom exceptions for this package.
+"""
+
+
+class EventProcessingError(Exception):
+    """
+    Encapsulating error class for exceptions raised
+    trying to process and event for eventtracking.
+    """

--- a/openedx/core/djangoapps/appsembler/eventtracking/segment.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/segment.py
@@ -3,7 +3,10 @@ Custom event processors and other functionality for the Segment backend.
 """
 
 from django.conf import settings
+
 from openedx.core.djangoapps.site_configuration import helpers
+
+from . import exceptions, utils
 
 
 class SegmentTopLevelPropertiesProcessor(object):
@@ -60,12 +63,19 @@ class SegmentTopLevelPropertiesProcessor(object):
     """
 
     def __call__(self, event):
-        if not helpers.get_value(
-            'COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL',
-            settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL
-        ):
-            # processor disabled, but keep processing
+        """
+        Process only if processor is enabled for Site.
+        """
+        try:
+            siteconfig = utils.get_site_config_for_event(event['data'])
+            if not siteconfig.get_value(
+                'COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL',
+                settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL
+            ):
+                return event
+        except (AttributeError, exceptions.EventProcessingError):
             return event
+
         try:
             for key, val in event['data'].items():
                 if key in event:

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -1,0 +1,38 @@
+"""
+Utility functions for event tracking processing.
+"""
+
+from django.core.exceptions import MultipleObjectsReturned
+
+from . import exceptions
+
+
+def get_site_config_for_event(event_props):
+    """
+    Try multiple strategies to find a SiteConfiguration object to use
+    for evaluating and processing an event.
+
+    Return a SiteConfiguration object if found; otherwise, None.
+    """
+    from openedx.core.djangoapps.appsembler.sites import utils
+    from openedx.core.djangoapps.site_configuration import helpers
+    from organizations import models
+
+    # try first via request obj in thread
+    site_configuration = helpers.get_current_site_configuration()
+    if not site_configuration:
+        try:
+            if 'org' in event_props:
+                org_name = event_props['org']
+                org = models.Organization.objects.get(short_name=org_name)
+            # try by OrganizationCourse relationship if event has a course_id property
+            elif 'course_id' in event_props:
+                course_id = event_props['course_id']
+                # allow to fail if more than one Organization to avoid sharing data
+                orgcourse = models.OrganizationCourse.objects.get(course_id=args)
+                org = orgcourse.organization
+            site = utils.get_site_by_organization(org)
+            site_configuration = site.configuration
+        except (AttributeError, TypeError, MultipleObjectsReturned) as e:
+            raise exceptions.EventProcessingError(e)
+    return site_configuration


### PR DESCRIPTION
Reverts appsembler/edx-platform#593

As @thraxil Suggested, we should implement some tests for this.