### PR TITLE
SegmentTopLevelPropertiesProcessor handle non-dict data property

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/segment.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/segment.py
@@ -88,6 +88,6 @@ class SegmentTopLevelPropertiesProcessor(object):
                             event[key] = val
                 else:
                     event[key] = val
-        except KeyError:  # no 'data'
+        except (KeyError, AttributeError):  # no 'data' or no sub-properties
             pass
         return event


### PR DESCRIPTION
Some events do pass 'data' property but a single string.