### PR TITLE
upgrade raven to 6.10.0

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -1,7 +1,7 @@
 django-extensions==1.5.9
 libsass==0.11.1
 python-intercom==0.2.13
-raven==5.21.0
+raven==6.10.0
 requests==2.9.1
 django-anymail==5.0
 django-tiers==0.1.0


### PR DESCRIPTION
eliminate a sentry warning.