### PR TITLE
explicitly allow course admins(instructor) to re run courses

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -289,8 +289,9 @@ def course_rerun_handler(request, course_key_string):
     # Appsembler: Also course staff can do reruns
     course_key = CourseKey.from_string(course_key_string)
     if not CourseStaffRole(course_key).has_user(request.user):
-        if not GlobalStaff().has_user(request.user):
-            raise PermissionDenied()
+        if not CourseInstructorRole(course_key).has_user(request.user):
+            if not GlobalStaff().has_user(request.user):
+                raise PermissionDenied()
     with modulestore().bulk_operations(course_key):
         course_module = get_course_and_check_access(course_key, request.user, depth=3)
         if request.method == 'GET':


### PR DESCRIPTION
This was a tough one to reproduce. 

Two customers reported in the same week to been unable to re run course, despite the fact they were Course Admins(Instructors).

How to reproduce the issue in Studio:
1. Create or open an existing course.
2. Go to Settings -> Course Team and invite a new user.
3. Open an incognito window, log in as the invited user.
4. Look for the course and click on "Re Run Course", the re run form will be displayed.
5. Using the first user, go to Settings -> Course Team again and bump the second user permission to Admin(Instructor).
6. Using the second user, try to re run the course again, you will get a 403 Forbidden page.

Explanation

Originally the platform only allow re runs to GlobalStaff users (is_staff=true), we adapted that to work on Tahoe, when the staff permission are granted per course only.
Here is the PR @OmarIthawi wrote to fix it: https://github.com/appsembler/edx-platform/pull/396

When a user creates a course `CourseInstructorRole` and `CourseStaffRole` over the course. When you invite a user to the course team, is granted with CourseStaffRole, and it's allow to re run the course, but when you promote the user to `CourseInstructorRole` (Admin) the original `CourseStaffRole` is removed, and the user is now allowed to re run the course anymore.

So, the bug was hard to track, since only happens with invited users, and no the creator of the course.

There is a separate discussion here about what edX does with the permission assigning and removing the regular staff, but I think for the sake of our users is better to be defensive in this check.