### PR TITLE
Bump Django to 1.11.29

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -33,7 +33,7 @@ botocore==1.8.17                    # via boto3, s3transfer
 celery==3.1.25                      # Asynchronous task execution library
 ddt==0.8.0                          # via xblock-drag-and-drop-v2 (which probably shouldn't require it)
 defusedxml==0.4.1                   # XML bomb protection for common XML parsers
-Django==1.11.23                     # Web application framework
+Django==1.11.29                     # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
 django-config-models==0.1.8         # Configuration models for Django allowing config management with auditing
 django-cors-headers==2.1.0          # Used to allow to configure CORS headers for cross-domain requests

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -100,7 +100,7 @@ django-storages==1.6.5
 django-user-tasks==0.1.5
 django-waffle==0.12.0
 django-webpack-loader==0.6.0
-django==1.11.15
+django==1.11.29
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0  # via edx-enterprise
 dm.xmlsec.binding==1.3.3  # via python-saml

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -120,7 +120,7 @@ django-storages==1.6.5
 django-user-tasks==0.1.5
 django-waffle==0.12.0
 django-webpack-loader==0.6.0
-django==1.11.15
+django==1.11.29
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0
 dm.xmlsec.binding==1.3.3


### PR DESCRIPTION
in edx-platform, Django is set to different versions.

In edx/base.in, it was previously 1.11.23, but in edx/base.txt and
edx/development.txt it was 1.11.15

Inspecting production: Production is using 1.11.15

* https://docs.djangoproject.com/en/3.0/releases/1.11.29/

Follow the links from the above to see the changes for 1.11.16 to
1.11.28