### PR TITLE
Multi-Tenant Emails: Fixes for Retirement (Account Deletion)

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -69,6 +69,7 @@ DISABLE_UNENROLL_CERT_STATES = [
     'generating',
     'downloadable',
 ]
+EMAIL_EXISTS_MSG_FMT = _("An account with the Email '{email}' already exists.")
 USERNAME_EXISTS_MSG_FMT = _("An account with the Public Username '{username}' already exists.")
 
 

--- a/common/djangoapps/student/signals/receivers.py
+++ b/common/djangoapps/student/signals/receivers.py
@@ -6,10 +6,12 @@ from __future__ import absolute_import
 from django.conf import settings
 from django.utils import timezone
 
+from openedx.core.djangoapps.appsembler.sites.utils import get_current_organization
 from openedx.core.djangoapps.user_api.config.waffle import PREVENT_AUTH_USER_WRITES, waffle
 from student.helpers import (
     AccountValidationError,
-    USERNAME_EXISTS_MSG_FMT
+    USERNAME_EXISTS_MSG_FMT,
+    EMAIL_EXISTS_MSG_FMT,
 )
 from student.models import (
     is_email_retired,
@@ -51,8 +53,39 @@ def on_user_updated(sender, instance, **kwargs):  # pylint: disable=unused-argum
             )
 
         # Check for a retired email.
-        if is_email_retired(instance.email):
-            raise AccountValidationError(
-                EMAIL_EXISTS_MSG_FMT.format(username=instance.email),
-                field="email"
-            )
+        if not settings.FEATURES.get('APPSEMBLER_MULTI_TENANT_EMAILS', False):
+            # Note: Doing a loose check for retirement within organization in case
+            #       of non-request contexts such as management commands or Django shell which is not a
+            #       common use-case at all, except that it shows up in tests when we don't do full mocking.
+            #
+            #       This is a best-effort trade-off to allow compatibility with upstream while enabling
+            #       the unique constraints on all learner-initiated contexts.
+            #
+            #        There are limitations to this such as limited or non-existent checks for superuser
+            #        operations via the admin panel.
+            #
+            #        For more information about the AccountValidationError below please checkout the
+            #        upstream conversations at:
+            #               - https://github.com/edx/edx-platform/pull/18136
+            #               - https://openedx.atlassian.net/browse/PLAT-2117
+            organization = get_current_organization(failure_return_none=True)
+            if is_email_retired(
+                    email=instance.email,
+                    # Avoid a chicken-and-egg problem in which that we don't have an active request to get the
+                    # organization from.
+                    #
+                    # This specifically solves the issue with `student.signals..on_user_updated` for new users
+                    # calls `is_email_retired` in non-request contexts.
+                    #
+                    # Chicken-and-egg:
+                    #   It's impossible to get the organization for a user that we didn't save yet
+                    #   to the database because we don't have `UserOrganizationMapping` yet.
+                    #   We cannot have `UserOrganizationMapping` until we save the user,
+                    #   therefore it's not possible to get the organization from the user.
+                    check_within_organization=bool(organization),
+                    organization=organization,
+            ):
+                raise AccountValidationError(
+                    EMAIL_EXISTS_MSG_FMT.format(username=instance.email),
+                    field="email"
+                )

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_deletion.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_deletion.py
@@ -1,0 +1,146 @@
+"""
+Tests for the Account Deletion (Retirement) view.
+"""
+
+from mock import patch
+import pytest
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from openedx.core.djangoapps.user_api.models import UserRetirementStatus
+from openedx.core.djangoapps.user_api.accounts.views import DeactivateLogoutView
+
+from .test_utils import with_organization_context, lms_multi_tenant_test
+
+from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (
+    # Importing this module to allow using `usefixtures("setup_retirement_states")`
+    setup_retirement_states,  # pylint: disable=unused-import
+)
+
+
+@lms_multi_tenant_test
+@patch.dict('django.conf.settings.FEATURES', {'SKIP_EMAIL_VALIDATION': True})
+@pytest.mark.usefixtures("setup_retirement_states")
+class MultiTenantDeactivateLogoutViewTest(APITestCase):
+    """
+    Tests to ensure the DeactivateLogoutView works well with multi-tenant emails.
+    """
+
+    RED = 'red1'
+    BLUE = 'blue2'
+    EMAIL = 'ali@example.com'
+    PASSWORD = 'zzz'
+
+    def setUp(self):
+        super(MultiTenantDeactivateLogoutViewTest, self).setUp()
+        self.registration_url = reverse('user_api_registration')
+        self.deactivate_url = reverse('deactivate_logout')
+
+    def register_user(self, color, username=None):
+        """
+        Register a user.
+        """
+        response = self.client.post(self.registration_url, {
+            'email': self.EMAIL,
+            'name': 'Ali',
+            'username': username or 'ali_{}'.format(color),
+            'password': self.PASSWORD,
+            'honor_code': 'true',
+        })
+        return response
+
+    def deactivate_user(self, color, username=None):
+        """
+        Post a deactivate_logout request (a.k.a GDPR forget me).
+        """
+        client = self.client_class()
+        username = username or 'ali_{}'.format(color)
+        assert client.login(username=username, password=self.PASSWORD)
+        response = client.post(self.deactivate_url, {
+            'password': self.PASSWORD,
+        })
+        return response
+
+    def assert_re_register_fails(self, color, email, username=None):
+        """
+        Assert that email re-use is disallowed.
+        """
+        username = username or 'ali2_{}'.format(color)
+        res = self.register_user(self.RED, username=username)
+        assert res.status_code == status.HTTP_409_CONFLICT, res.content
+
+        error_response = {
+            'email': [
+                {
+                    'user_message': ('It looks like {} belongs to an existing account. '
+                                     'Try again with a different email address.').format(email)
+                }
+            ]
+        }
+        assert res.json() == error_response, '{}: {}'.format(
+            'Should complain of retired email',
+            res.content,
+        )
+
+    def test_disallow_email_reuse_after_deactivate(self):
+        """
+        Happy case scenario regardless of the `APPSEMBLER_MULTI_TENANT_EMAILS` feature.
+        """
+        with with_organization_context(site_color=self.RED):
+            register_res = self.register_user(self.RED)
+            assert register_res.status_code == status.HTTP_200_OK, register_res.content
+            deactivate_res = self.deactivate_user(self.RED)
+            assert deactivate_res.status_code == status.HTTP_204_NO_CONTENT, deactivate_res.content
+            assert UserRetirementStatus.objects.exists()
+            self.assert_re_register_fails(self.RED, self.EMAIL)
+
+    def test_email_suffix_hacks(self):
+        """
+        Tests for the email suffix hack.
+
+        Ensure the email suffix is done properly and the original organization and email
+        are stored in the profile meta for retirement cancellation purposes.
+
+        This fixes email collision issues when the APPSEMBLER_MULTI_TENANT_EMAILS feature
+        is enabled.
+
+        See the related decision document: https://appsembler.atlassian.net/l/c/QBcq0Mhu
+        """
+        username = 'some_learner'
+
+        with with_organization_context(site_color=self.RED):
+            register_res = self.register_user(self.RED, username=username)
+            assert register_res.status_code == status.HTTP_200_OK, register_res.content
+            self.deactivate_user(self.RED, username=username)
+            retirement_status = UserRetirementStatus.objects.get(original_username=username)
+
+        learner = retirement_status.user
+        assert learner.email.endswith('retired.invalid')
+
+        retired_email = 'ali@example.com..red1'  # See: generate_retired_email_address
+        assert retirement_status.original_email == retired_email
+
+        profile_meta = learner.profile.get_meta()
+        assert profile_meta[DeactivateLogoutView.APPSEMBLER_RETIREMENT_EMAIL_META_KEY] == self.EMAIL
+
+    def test_allow_email_reuse_in_other_organization(self):
+        """
+        Ensure deactivated emails can be used in other organizations.
+
+        This case tests DeactivateLogoutView with `APPSEMBLER_MULTI_TENANT_EMAILS`.
+        """
+        with with_organization_context(site_color=self.RED):
+            red_register_res = self.register_user(self.RED)
+            assert red_register_res.status_code == status.HTTP_200_OK, red_register_res.content
+            red_deactivate_res = self.deactivate_user(self.RED)
+            assert red_deactivate_res.status_code == status.HTTP_204_NO_CONTENT, red_deactivate_res.content
+            assert UserRetirementStatus.objects.count() == 1
+
+        with with_organization_context(site_color=self.BLUE):
+            blue_register_res = self.register_user(self.BLUE)
+            assert blue_register_res.status_code == status.HTTP_200_OK, blue_register_res.content
+            blue_deactivate_res = self.deactivate_user(self.BLUE)
+            assert blue_deactivate_res.status_code == status.HTTP_204_NO_CONTENT, blue_deactivate_res.content
+            assert UserRetirementStatus.objects.count() == 2

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_utils.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_utils.py
@@ -3,7 +3,6 @@ Tests utils for multi-tenant emails.
 """
 
 import contextlib
-from mock import patch
 
 from django.conf import settings
 from unittest import skipUnless

--- a/tox.ini
+++ b/tox.ini
@@ -154,8 +154,7 @@ commands =
     # Upgrade sqlite to fix crashes during testing.
     bash scripts/upgrade_pysqlite.sh
     {env:TRAVIS_FIXES}
-    pytest \
-        openedx/core/djangoapps/appsembler/multi_tenant_emails
+    pytest {posargs:openedx/core/djangoapps/appsembler/multi_tenant_emails}
 
 
 [testenv:pytest]


### PR DESCRIPTION
Please read and understand the [related decision](https://appsembler.atlassian.net/wiki/spaces/RT/pages/577569484/Decision+How+to+make+is+email+retired+function+multi-tenant) before reviewing this pull request.

### Related

 - This PR is part of the larger [Multi-Tenant Emails proposal](https://github.com/appsembler/tech-design-proposals/blob/master/proposals/0003-tahoe-multi-tenant.md).
 - Jira task: [MTE Retirement: As a learner registered in both Blue University and Green Academy I want to request the deletion of my account in Blue University and keep all my Green Academy untouched.](https://appsembler.atlassian.net/browse/RED-1017)


### TODO

 - [x] Waiting for [Decision: How to make is_email_retired function multi-tenant?](https://appsembler.atlassian.net/wiki/spaces/RT/pages/577569484/Decision+How+to+make+is+email+retired+function+multi-tenant)
- [x] Omar to add one more test case for the hack we’re proposing in Option 2 for this PR.
- [x] Omar to add follow up Jira tasks for the issues regarding cancel_user_retirement_request and Tubular.
  - See the [Pay Multi-Tenant Emails Tech Debt](https://appsembler.atlassian.net/browse/RED-1142) Epic
- [x] Review the pull request by @ahmedaljazzar 
- [x] Review the pull request by Maxi or John
- [x] Check whether the suffix log (i.e. turning `someone@example.com` -> `someone@example.com..org-short-name` for `UserRetirementStatus` has potential issues.
 - [x] Ahmed's request: `Can we test calling deactivate_user from within self.BLUE too?`