### PR TITLE
Introducing Offboarding script

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/management/commands/offboard.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/offboard.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         self.stdout.write('Inspecting project for potential problems...')
         self.check(display_num_errors=True)
 
-        self.stdout.write(self.style.MIGRATE_HEADING('Exporting "%s" in progress...' % domain))
+        self.stdout.write(self.style.MIGRATE_HEADING('Offboarding "%s" in progress...' % domain))
         site = self.get_site(domain)
 
         export_data = {
@@ -92,11 +92,11 @@ class Command(BaseCommand):
         path = self.generate_file_path(site, options['output'])
         self.write_to_file(path, output)
 
-        self.stdout.write(self.style.SUCCESS('\nSuccessfully exported "%s" site' % site.domain))
+        self.stdout.write(self.style.SUCCESS('\nSuccessfully offboarded "%s" site' % site.domain))
 
     def get_site(self, domain):
         """
-        Locates the site to be exported and return its instance.
+        Locates the site to be offboarded and return its instance.
 
         :param domain: The domain of the ite to be returned.
         :return: Returns the site object.

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/offboard.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/offboard.py
@@ -1,0 +1,498 @@
+from datetime import datetime
+import json
+import os
+import pkg_resources
+import socket
+
+from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import Site
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management.base import BaseCommand, CommandError
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db.models import ForeignKey
+
+from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration, SiteConfigurationHistory
+from student.models import (
+    CourseAccessRole,
+    CourseEnrollment,
+    CourseEnrollmentAllowed,
+    ManualEnrollmentAudit,
+    UserSignupSource,
+    LanguageProficiency,
+    SocialLink,
+    UserAttribute,
+    UserStanding,
+    UserTestGroup,
+)
+
+from organizations.models import Organization, OrganizationCourse
+
+
+class Command(BaseCommand):
+    """
+    Export a Tahoe website for customer offboarding.
+    """
+    def __init__(self, *args, **kwargs):
+        self.debug = False
+        self.default_path = os.getcwd()
+
+        super(Command, self).__init__(*args, **kwargs)
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'domain',
+            help='The domain of the organization to be deleted.',
+            type=str,
+        )
+        parser.add_argument(
+            '-o', '--output',
+            help='The location you want to direct your output to.',
+            default=self.default_path,
+            type=str,
+        )
+        parser.add_argument(
+            '-d', '--debug',
+            action='store_true',
+            default=settings.DEBUG,
+            help='Execute in debug mode (Will not commit or save changes).'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Verifies the input and packs the site objects.
+        """
+        self.debug = options['debug']
+        domain = options['domain']
+
+        self.stdout.write('Inspecting project for potential problems...')
+        self.check(display_num_errors=True)
+
+        self.stdout.write(self.style.MIGRATE_HEADING('Exporting "%s" in progress...' % domain))
+        site = self.get_site(domain)
+
+        export_data = {
+            'date': datetime.now(),
+            'site_domain': site.name,
+            'objects': self.generate_objects(site),
+        }
+
+        output = json.dumps(
+            export_data,
+            sort_keys=True,
+            indent=1,
+            cls=DjangoJSONEncoder
+        )
+
+        self.debug_message('\nCommand output >>>')
+        self.debug_message(self.style.SQL_KEYWORD(output))
+
+        path = self.generate_file_path(site, options['output'])
+        self.write_to_file(path, output)
+
+        self.stdout.write(self.style.SUCCESS('\nSuccessfully exported "%s" site' % site.domain))
+
+    def get_site(self, domain):
+        """
+        Locates the site to be exported and return its instance.
+
+        :param domain: The domain of the ite to be returned.
+        :return: Returns the site object.
+        """
+        self.debug_message('Exctracting the site object for {} ...'.format(domain))
+
+        try:
+            return Site.objects.get(domain=domain)
+        except Site.DoesNotExist:
+            raise CommandError('Cannot find a site for the provided domain "%s"!' % domain)
+
+    def generate_objects(self, site):
+        """
+        Takes care of generating site objects.
+        """
+        self.debug_message('Generating site:%s objects...' % site.name)
+
+        organizations = Organization.objects.filter(sites__id=site.id)
+        objects = {
+            'site': self.process_site(site),
+            'organizations': [
+                self.process_organization(org) for org in organizations
+            ],
+            'courses': self.process_courses(organizations),
+            'configurations': self.process_site_configurations(site),
+            'configurations_history': self.process_site_configurations_history(site),
+            'users': self.process_users(site),
+        }
+
+        return objects
+
+    def process_courses(self, organizations):
+        """
+        Processes site courses.
+        """
+        query_set = OrganizationCourse.objects.filter(organization__in=organizations)
+        self.debug_message('Processing organizations courses (%d total)...' % query_set.count())
+
+        courses = []
+        for course in query_set:
+            self.stdout.write('Processing {} course data...'.format(course.course_id))
+            course_id = CourseKey.from_string(course.course_id)
+            course_overview = CourseOverview.get_from_id_if_exists(course_id)
+
+            courses.append({
+                'course_id': course.course_id,
+                'active': course.active,
+                'enrollments': self.process_enrollments(course_overview, course_id=course_id),
+                'course_overview': self.process_course_overview(course_overview, course_id=course_id),
+                'enrollment_allowed': self.process_enrollment_allowed(course_id),
+                'access_roles': self.process_access_roles(course_id),
+            })
+
+        return courses
+
+    def process_users(self, site):
+        """
+        Processes site users.
+        """
+        signup_source_qs = UserSignupSource.objects.filter(site=site)
+
+        self.debug_message('Processing {} site users ({} total)...'.format(
+            site.name, signup_source_qs.count()))
+
+        return [{
+            'user_name': source.user.username,
+            'first_name': source.user.first_name,
+            'last_name': source.user.last_name,
+            'active': source.user.is_active,
+            'last_login': source.user.last_login,
+            'permissions': [permission for permission in source.user.user_permissions.all()],
+            'date_joined': source.user.date_joined,
+            'profile': self.process_user_profile(source.user),
+            'standing': self.process_user_standing(source.user),
+            'test_groups': self.process_user_test_groups(source.user),
+            'languages': self.process_user_languages(source.user),
+            'social_links': self.process_social_links(source.user),
+            'attributes': self.process_attributes(source.user),
+        } for source in signup_source_qs]
+
+    def process_access_roles(self, course_id):
+        """
+        Processes access roles for a given course.
+        """
+        access_roles_qs = CourseAccessRole.objects.filter(course_id=course_id)
+
+        self.debug_message('Processing {} access roles ({} total)...'.format(
+            course_id, access_roles_qs.count()))
+
+        return [{
+            'user': role.user.username,
+            'org': role.org,
+            'role': role.role,
+        } for role in access_roles_qs]
+
+    def process_enrollment_allowed(self, course_id):
+        """
+        Processes allowed enrollments for a given course ID.
+        """
+        enrollment_allowed_qs = CourseEnrollmentAllowed.objects.filter(course_id=course_id)
+        self.debug_message('Processing {} allowed enrollments ({} total)...'.format(
+            course_id, enrollment_allowed_qs.count()))
+
+        return [{
+            'email': record.email,
+            'auto_enroll': record.auto_enroll,
+            'user': record.user.username if record.user else None,
+            'created': record.created,
+        } for record in enrollment_allowed_qs]
+
+    def process_attributes(self, user):
+        """
+        Processes user specific attributes.
+        """
+        user_attributes_qs = UserAttribute.objects.filter(user=user)
+        self.debug_message('Processing {} user attributes ({} total)...'.format(user.username, user_attributes_qs.count()))
+
+        return [{
+            'name': attribute.name,
+            'value': attribute.value,
+        } for attribute in user_attributes_qs]
+
+    def process_social_links(self, user):
+        """
+        Processes user social links.
+        """
+        social_links_qs = SocialLink.objects.filter(user_profile=user.profile)
+        self.stdout.write('Processing {} user social links ({} total)...'.format(
+            user.username, social_links_qs.count()))
+
+        return [{
+            'platform': link.platform,
+            'social_link': link.social_link,
+        } for link in social_links_qs]
+
+    def process_user_languages(self, user):
+        """
+        Processes user's language proficiency.
+        """
+        languages_qs = LanguageProficiency.objects.filter(user_profile=user.profile)
+        self.debug_message('Processing {} user social languages ({} total)...'.format(user.username, languages_qs.count()))
+        return [language.code for language in languages_qs]
+
+    def process_user_test_groups(self, user):
+        """
+        Processes user test groups.
+        """
+        test_groups_qs = UserTestGroup.objects.filter(users__id=user.id)
+        self.debug_message('Processing {} user test groups...'.format(user.username, test_groups_qs.count()))
+
+        return [{
+            'name': test_group.name,
+            'description': test_group.description,
+        } for test_group in test_groups_qs]
+
+    def process_user_standing(self, user):
+        """
+        Processes user standing.
+        """
+        self.debug_message('Processing {} user standing...'.format(user.username))
+
+        try:
+            standing = UserStanding.objects.get(user=user)
+        except UserStanding.DoesNotExist:
+            return {}
+
+        return {
+            'account_status': standing.account_status,
+            'changed_by': standing.changed_by.username,
+            'standing_last_changed_at': standing.standing_last_changed_at,
+        }
+
+    def process_user_profile(self, user):
+        """
+        Processes user profile.
+        """
+        self.debug_message('Processing {} user profile...'.format(user.username))
+        profile = user.profile
+
+        return {
+            'name': profile.name,
+            'courseware': profile.courseware,
+            'language': profile.language,
+            'location': profile.location,
+            'year_of_birth': profile.year_of_birth,
+            'gender': profile.gender_display,
+            'level_of_education': profile.level_of_education_display,
+            'mailing_address': profile.mailing_address,
+            'city': profile.city,
+            'country': profile.country.name if profile.country else '',
+            'goals': profile.goals,
+            'allow_certificate': profile.allow_certificate,
+            'bio': profile.bio,
+            'profile_image_uploaded_at': profile.profile_image_uploaded_at,
+        }
+
+    def process_enrollments(self, course_overview, course_id=''):
+        """
+        Processes course enrollments.
+        """
+        enrollments = CourseEnrollment.objects.filter(course=course_overview)
+        self.debug_message('Processing {} course enrollments ({} total)...'.format(
+            course_id, enrollments.count()))
+
+        records = []
+        for enrollment in enrollments:
+            records.append({
+                'user': enrollment.user.username,
+                'created': enrollment.created,
+                'active': enrollment.is_active,
+                'mode': enrollment.mode,
+                'audit': self.process_enrollment_audit(enrollment)
+            })
+
+        return records
+
+    def process_enrollment_audit(self, enrollment):
+        """
+        Processes enrollment audit in MySQL db.
+        """
+        enrollment_audits = ManualEnrollmentAudit.objects.filter(enrollment=enrollment)
+
+        self.stdout.write('Processing {} enrollment audit ({} total)...'.format(
+            enrollment.user.username, enrollment_audits.count()))
+
+        return [{
+            'enrolled_by': audit.enrolled_by.username,
+            'enrolled_email': audit.enrolled_email,
+            'time_stamp': audit.time_stamp,
+            'state_transition': audit.state_transition,
+            'reason': audit.reason,
+            'role': audit.role,
+        } for audit in enrollment_audits]
+
+    def process_course_overview(self, course_overview, course_id=''):
+        """
+        Processes a course overview object.
+        """
+        self.debug_message('Processing {} course overview...'.format(course_id))
+        if not course_overview:
+            return {}
+
+        return {
+            'version': course_overview.version,
+            'org': course_overview.org,
+            'display_name': course_overview.display_name,
+            'display_number_with_default': course_overview.display_number_with_default,
+            'display_org_with_default': course_overview.display_org_with_default,
+
+            # Start/end dates
+            'start': course_overview.start,
+            'end': course_overview.end,
+            'advertised_start': course_overview.advertised_start,
+            'announcement': course_overview.announcement,
+
+            # URLs
+            'course_image_url': course_overview.course_image_url,
+            'social_sharing_url': course_overview.social_sharing_url,
+            'end_of_course_survey_url': course_overview.end_of_course_survey_url,
+
+            # Certification data
+            'certificates_display_behavior': course_overview.certificates_display_behavior,
+            'certificates_show_before_end': course_overview.certificates_show_before_end,
+            'cert_html_view_enabled': course_overview.cert_html_view_enabled,
+            'has_any_active_web_certificate': course_overview.has_any_active_web_certificate,
+            'cert_name_short': course_overview.cert_name_short,
+            'cert_name_long': course_overview.cert_name_long,
+            'certificate_available_date': course_overview.certificate_available_date,
+
+            # Grading
+            'lowest_passing_grade': course_overview.lowest_passing_grade,
+
+            # Access parameters
+            'days_early_for_beta': course_overview.days_early_for_beta,
+            'mobile_available': course_overview.mobile_available,
+            'visible_to_staff_only': course_overview.visible_to_staff_only,
+            'pre_requisite_courses_json': course_overview._pre_requisite_courses_json,
+
+            # Enrollment details
+            'enrollment_start': course_overview.enrollment_start,
+            'enrollment_end': course_overview.enrollment_end,
+            'enrollment_domain': course_overview.enrollment_domain,
+            'invitation_only': course_overview.invitation_only,
+            'max_student_enrollments_allowed': course_overview.max_student_enrollments_allowed,
+
+            # Catalog information
+            'catalog_visibility': course_overview.catalog_visibility,
+            'short_description': course_overview.short_description,
+            'course_video_url': course_overview.course_video_url,
+            'effort': course_overview.effort,
+            'self_paced': course_overview.self_paced,
+            'marketing_url': course_overview.marketing_url,
+            'eligible_for_financial_aid': course_overview.eligible_for_financial_aid,
+            'language': course_overview.language,
+        }
+
+    def process_site(self, site):
+        self.stdout.write('Processing {} site...'.format(site.name))
+        return {
+            'name': site.name,
+            'domain': site.domain,
+        }
+
+    def process_organization(self, organization):
+        """
+        Processes a given organization's data.
+        """
+        self.debug_message('Processing {} organization data...'.format(organization.name))
+        return {
+            'name': organization.name,
+            'short_name': organization.short_name,
+            'description': organization.description,
+            'logo': organization.logo.url if organization.logo else '',
+            'active': organization.active,
+            'UUID': organization.edx_uuid,
+            'created': organization.created,
+            'users': self.process_organization_users(organization)
+        }
+
+    def process_organization_users(self, organization):
+        """
+        Processes a given organization's users.
+        """
+        self.debug_message('Processing {} organization users...'.format(organization.name))
+        return [{
+            'username': mapping.user.username,
+            'active': mapping.is_active,
+        } for mapping in organization.userorganizationmapping_set.all()]
+
+    def process_site_configurations(self, site):
+        """
+        Processes a given site's configurations
+        """
+        self.debug_message('Processing {} site configurations...'.format(site.name))
+
+        try:
+            site_configs = SiteConfiguration.objects.get(site=site)
+        except Site.DoesNotExist:
+            self.stdout.write('Cannot find %s site configs' % site.domain)
+            return {}
+
+        return {
+            'enabled': site_configs.enabled,
+            'values': site_configs.values,
+            'sass_variables': site_configs.sass_variables,
+            'page_elements': site_configs.page_elements,
+        }
+
+    def process_site_configurations_history(self, site):
+        """
+        Process configurations history for a given site.
+        """
+        self.debug_message('Processing %s site configurations history...' % site.name)
+
+        return [
+            {
+                'enabled': record.enabled,
+                'values': record.values,
+            } for record in SiteConfigurationHistory.objects.filter(site=site)
+        ]
+
+    def generate_file_path(self, site, output):
+        """
+        Determines and returns the output file name.
+        If the user specified a full path, then just return it. If a partial path
+        has been specified, we add the file name to it and return. Other wise, we
+        combine our base path with the file name and return them.
+        """
+        base = output or self.default_path
+
+        if base.endswith('.json'):
+            self.debug_message('Using the user\'s output path: %s' % output)
+            return base
+
+        now = datetime.now()
+        timestamp = (now - datetime(1970, 1, 1)).total_seconds()
+
+        self.debug_message('Generating file name and path...')
+        file_name = '{}_{}.json'.format(site.name, timestamp)
+        path = os.path.join(base, file_name)
+
+        self.debug_message('Generated output location:%s' % path)
+        return path
+
+    def write_to_file(self, path, content):
+        """
+        Writes content in the specified path.
+        """
+        with open(path, 'w') as file:
+            file.write(content)
+
+        self.stdout.write(self.style.SQL_KEYWORD('\nExported objects saved in %s' % path))
+
+    def debug_message(self, message):
+        """
+        Helps simplifying the process of printing debug message
+        """
+        if self.debug:
+            self.stdout.write(message)

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -12,8 +12,6 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import override_settings, TestCase
 
-from student.models import ManualEnrollmentAudit, UserTestGroup, LanguageProficiency, SocialLink, UserAttribute, CourseAccessRole, UserSignupSource, CourseEnrollmentAllowed, ManualEnrollmentAudit, CourseEnrollment
-from student.tests.factories import CourseEnrollmentFactory, UserFactory, UserStandingFactory, CourseAccessRoleFactory, CourseEnrollmentAllowedFactory
 from openedx.core.djangoapps.appsembler.sites.management.commands.create_devstack_site import Command
 from openedx.core.djangoapps.appsembler.sites.management.commands.export_site import Command as ExportSiteCommand
 from openedx.core.djangoapps.appsembler.sites.management.commands.offboard import Command as OffboardSiteCommand
@@ -27,6 +25,24 @@ from openedx.core.djangoapps.appsembler.api.tests.factories import (
     OrganizationFactory,
     OrganizationCourseFactory,
     UserOrganizationMappingFactory,
+)
+from student.models import (
+    CourseAccessRole,
+    CourseEnrollment,
+    CourseEnrollmentAllowed,
+    LanguageProficiency,
+    ManualEnrollmentAudit,
+    SocialLink,
+    UserAttribute,
+    UserSignupSource,
+    UserTestGroup,
+)
+from student.tests.factories import (
+    CourseAccessRoleFactory,
+    CourseEnrollmentAllowedFactory,
+    CourseEnrollmentFactory,
+    UserFactory,
+    UserStandingFactory,
 )
 
 from organizations.models import Organization, OrganizationCourse

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -758,13 +758,13 @@ class TestOffboardSiteCommand(ModuleStoreTestCase):
 
         data = self.command.process_courses([organization])
         assert data == [{
-                'course_id': course.course_id,
-                'active': course.active,
-                'enrollments': [],
-                'course_overview': {},
-                'enrollment_allowed': [],
-                'access_roles': [],
-            } for course in query_set]
+            'course_id': course.course_id,
+            'active': course.active,
+            'enrollments': [],
+            'course_overview': {},
+            'enrollment_allowed': [],
+            'access_roles': [],
+        } for course in query_set]
 
     @patch('django.core.files.File.write')
     def test_write_to_file(self, mock_write):

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -1,20 +1,35 @@
 import hashlib
+import os
 import pkg_resources
+import uuid
 from mock import patch, mock_open
 from StringIO import StringIO
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-from openedx.core.djangoapps.appsembler.sites.management.commands.create_devstack_site import Command
-from openedx.core.djangoapps.appsembler.sites.management.commands.export_site import Command as ExportSiteCommand
-from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
-from openedx.core.djangoapps.theming.models import SiteTheme
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import override_settings, TestCase
 
-from organizations.models import Organization
+from student.models import ManualEnrollmentAudit, UserTestGroup, LanguageProficiency, SocialLink, UserAttribute, CourseAccessRole, UserSignupSource, CourseEnrollmentAllowed, ManualEnrollmentAudit, CourseEnrollment
+from student.tests.factories import CourseEnrollmentFactory, UserFactory, UserStandingFactory, CourseAccessRoleFactory, CourseEnrollmentAllowedFactory
+from openedx.core.djangoapps.appsembler.sites.management.commands.create_devstack_site import Command
+from openedx.core.djangoapps.appsembler.sites.management.commands.export_site import Command as ExportSiteCommand
+from openedx.core.djangoapps.appsembler.sites.management.commands.offboard import Command as OffboardSiteCommand
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration, SiteConfigurationHistory
+from openedx.core.djangoapps.theming.models import SiteTheme
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
+from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from openedx.core.djangoapps.appsembler.api.tests.factories import (
+    CourseOverviewFactory,
+    OrganizationFactory,
+    OrganizationCourseFactory,
+    UserOrganizationMappingFactory,
+)
+
+from organizations.models import Organization, OrganizationCourse
 from provider.constants import CONFIDENTIAL
 from provider.oauth2.models import AccessToken, RefreshToken, Client
 from student.roles import CourseCreatorRole
@@ -236,6 +251,23 @@ class TestExportSiteCommand(TestCase):
         mock_file.assert_called_once_with(path, 'w')
         assert mock_write.called_with(content)
 
+    def test_generate_file_path(self):
+        # With output.json
+        output = 'new_file.json'
+        path = self.command.generate_file_path(self.site, output)
+        assert path == output
+
+        # With output
+        output = 'new_file'
+        path = self.command.generate_file_path(self.site, output)
+        assert path.endswith('.json')
+        assert path.startswith('%s/' % output)
+
+        # With no output
+        path = self.command.generate_file_path(self.site, None)
+        assert path.endswith('.json')
+        assert path.startswith('%s/' % os.getcwd())
+
     @staticmethod
     def fake_process_instance(instance):
         """
@@ -262,3 +294,490 @@ class TestExportSiteCommand(TestCase):
                 objects.append(key)
 
         return instance, objects
+
+
+class TestOffboardSiteCommand(ModuleStoreTestCase):
+    """
+    Test ./manage.py lms offboard site.domain.com
+    """
+
+    def setUp(self):
+        super(TestOffboardSiteCommand, self).setUp()
+
+        self.site_name = 'site'
+        self.site_domain = '{}.localhost:18000'.format(self.site_name)
+
+        self.site = Site.objects.create(domain=self.site_domain, name=self.site_name)
+        SiteConfigurationFactory.create(site=self.site)
+
+        self.command = OffboardSiteCommand()
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.write_to_file', return_value='called')
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.check')
+    def test_handle(self, mock_check, mock_write_to_file):
+        out = StringIO()
+        call_command('offboard', self.site_domain, stdout=out)
+
+        assert mock_check.called
+        assert mock_write_to_file.called
+
+        assert 'Offboarding "%s" in progress' % self.site_domain in out.getvalue()
+        assert 'Successfully offboarded' in out.getvalue()
+        assert 'Command output >>>' not in out.getvalue()
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.write_to_file', return_value='called')
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.check')
+    def test_handle_debug(self, mock_check, mock_write_to_file):
+        out = StringIO()
+        call_command('offboard', self.site_domain, debug=True, stdout=out)
+
+        assert mock_check.called
+        assert mock_write_to_file.called
+
+        assert 'Offboarding "%s" in progress' % self.site_domain in out.getvalue()
+        assert 'Command output >>>' in out.getvalue()
+        assert 'Successfully offboard' in out.getvalue()
+
+    def test_handle_system_check_fails(self):
+        """
+        According to Django, serious problems are raised as a CommandError wheb calling
+        this `check` function. Proccessing should stop in case we got a serious problem.
+
+        https://docs.djangoproject.com/en/1.11/howto/custom-management-commands/#django.core.management.BaseCommand.check
+        """
+
+        with patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.check', side_effect=CommandError()):
+            with self.assertRaises(CommandError):
+                call_command('offboard', self.site_domain, debug=True)
+            with self.assertRaises(CommandError):
+                call_command('offboard', self.site_domain)
+
+    def test_generate_file_path(self):
+        # With output.json
+        output = 'new_file.json'
+        path = self.command.generate_file_path(self.site, output)
+        assert path == output
+
+        # With output
+        output = 'new_file'
+        path = self.command.generate_file_path(self.site, output)
+        assert path.endswith('.json')
+        assert path.startswith('%s/' % output)
+
+        # With no output
+        path = self.command.generate_file_path(self.site, None)
+        assert path.endswith('.json')
+        assert path.startswith('%s/' % os.getcwd())
+
+    def test_get_site(self):
+        assert self.site == self.command.get_site(self.site_domain)
+
+        with self.assertRaises(CommandError):
+            self.command.get_site('invailed-domain')
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_site', return_value='process_site')
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_organization', return_value=[])
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_courses', return_value=[])
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_site_configurations', return_value={})
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_site_configurations_history', return_value=[])
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_users', return_value=[])
+    def test_generate_objects(self, mock1, mock2, mock3, mock4, mock5, mock6):
+        data = self.command.generate_objects(self.site)
+        assert data == {
+            'site': 'process_site',
+            'organizations': [],
+            'courses': [],
+            'configurations': {},
+            'configurations_history': [],
+            'users': [],
+        }
+
+    def test_process_site(self):
+        data = self.command.process_site(self.site)
+        assert data == {
+            'name': self.site.name,
+            'domain': self.site.domain,
+        }
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_organization_users', return_value=['user1', 'user2'])
+    def test_process_organization(self, mock_process_organization_users):
+        organization = OrganizationFactory.create(name='test')
+        data = self.command.process_organization(organization)
+        assert data == {
+            'name': organization.name,
+            'short_name': organization.short_name,
+            'description': organization.description,
+            'logo': '',
+            'active': organization.active,
+            'UUID': organization.edx_uuid,
+            'created': organization.created,
+            'users': ['user1', 'user2']
+        }
+
+    def test_process_organization_users(self):
+        organization = OrganizationFactory.create(name='test')
+        new_user_count = 3
+
+        assert organization.userorganizationmapping_set.count() == 0
+        users = self.create_org_users(org=organization, new_user_count=new_user_count)
+        assert organization.userorganizationmapping_set.count() == new_user_count
+
+        data = self.command.process_organization_users(organization)
+        assert len(data) == new_user_count
+        assert data == [{
+            'username': mapping.user.username,
+            'active': mapping.is_active,
+        } for mapping in organization.userorganizationmapping_set.all()]
+
+    def test_process_site_configurations(self):
+        data = self.command.process_site_configurations(self.site)
+        site_configs = SiteConfiguration.objects.get(site=self.site)
+
+        assert data == {
+            'enabled': site_configs.enabled,
+            'values': site_configs.values,
+            'sass_variables': site_configs.sass_variables,
+            'page_elements': site_configs.page_elements,
+        }
+
+    def test_process_site_configurations_history(self):
+        data = self.command.process_site_configurations_history(self.site)
+        assert data == [
+            {
+                'enabled': record.enabled,
+                'values': record.values,
+            } for record in SiteConfigurationHistory.objects.filter(site=self.site)
+        ]
+
+    def test_process_course_overview(self):
+        empty_data = self.command.process_course_overview(None)
+        assert empty_data == {}
+
+        course_overview = CourseOverviewFactory()
+        data = self.command.process_course_overview(course_overview)
+        assert data == {
+            'version': course_overview.version,
+            'org': course_overview.org,
+            'display_name': course_overview.display_name,
+            'display_number_with_default': course_overview.display_number_with_default,
+            'display_org_with_default': course_overview.display_org_with_default,
+            'start': course_overview.start,
+            'end': course_overview.end,
+            'advertised_start': course_overview.advertised_start,
+            'announcement': course_overview.announcement,
+            'course_image_url': course_overview.course_image_url,
+            'social_sharing_url': course_overview.social_sharing_url,
+            'end_of_course_survey_url': course_overview.end_of_course_survey_url,
+            'certificates_display_behavior': course_overview.certificates_display_behavior,
+            'certificates_show_before_end': course_overview.certificates_show_before_end,
+            'cert_html_view_enabled': course_overview.cert_html_view_enabled,
+            'has_any_active_web_certificate': course_overview.has_any_active_web_certificate,
+            'cert_name_short': course_overview.cert_name_short,
+            'cert_name_long': course_overview.cert_name_long,
+            'certificate_available_date': course_overview.certificate_available_date,
+            'lowest_passing_grade': course_overview.lowest_passing_grade,
+            'days_early_for_beta': course_overview.days_early_for_beta,
+            'mobile_available': course_overview.mobile_available,
+            'visible_to_staff_only': course_overview.visible_to_staff_only,
+            'pre_requisite_courses_json': course_overview._pre_requisite_courses_json,
+            'enrollment_start': course_overview.enrollment_start,
+            'enrollment_end': course_overview.enrollment_end,
+            'enrollment_domain': course_overview.enrollment_domain,
+            'invitation_only': course_overview.invitation_only,
+            'max_student_enrollments_allowed': course_overview.max_student_enrollments_allowed,
+            'catalog_visibility': course_overview.catalog_visibility,
+            'short_description': course_overview.short_description,
+            'course_video_url': course_overview.course_video_url,
+            'effort': course_overview.effort,
+            'self_paced': course_overview.self_paced,
+            'marketing_url': course_overview.marketing_url,
+            'eligible_for_financial_aid': course_overview.eligible_for_financial_aid,
+            'language': course_overview.language,
+        }
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_enrollment_audit', return_value=[])
+    def test_process_enrollments(self, mock):
+        course_overview = CourseOverviewFactory()
+        enrollment = CourseEnrollmentFactory(course=course_overview)
+
+        data = self.command.process_enrollments(course_overview)
+        assert data == [{
+            'user': enrollment.user.username,
+            'created': enrollment.created,
+            'active': enrollment.is_active,
+            'mode': enrollment.mode,
+            'audit': []
+        }]
+
+    def test_process_user_profile(self):
+        user = UserFactory()
+        data = self.command.process_user_profile(user)
+        profile = user.profile
+
+        assert data == {
+            'name': profile.name,
+            'courseware': profile.courseware,
+            'language': profile.language,
+            'location': profile.location,
+            'year_of_birth': profile.year_of_birth,
+            'gender': profile.gender_display,
+            'level_of_education': profile.level_of_education_display,
+            'mailing_address': profile.mailing_address,
+            'city': profile.city,
+            'country': profile.country.name if profile.country else '',
+            'goals': profile.goals,
+            'allow_certificate': profile.allow_certificate,
+            'bio': profile.bio,
+            'profile_image_uploaded_at': profile.profile_image_uploaded_at,
+        }
+
+    def test_process_user_standing(self):
+        user = UserFactory()
+        empty_data = self.command.process_user_standing(user)
+
+        assert empty_data == {}
+        from student.models import UserStanding
+
+        standing = UserStandingFactory.create(
+            user=user,
+            account_status=UserStanding.ACCOUNT_DISABLED,
+            changed_by=user
+        )
+        data = self.command.process_user_standing(user)
+
+        assert data == {
+            'account_status': standing.account_status,
+            'changed_by': standing.changed_by.username,
+            'standing_last_changed_at': standing.standing_last_changed_at,
+        }
+
+    def test_process_user_test_groups(self):
+        test_group = UserTestGroup.objects.create(name='test', description='test')
+        user = UserFactory()
+
+        test_group.users.add(user)
+        test_group.save()
+
+        data = self.command.process_user_test_groups(user)
+        assert data == [{
+            'name': test_group.name,
+            'description': test_group.description,
+        }]
+
+    def test_process_user_languages(self):
+        user = UserFactory()
+        languages_qs = LanguageProficiency.objects.filter(user_profile=user.profile)
+        assert languages_qs.count() == 0
+
+        LanguageProficiency.objects.create(
+            user_profile=user.profile,
+            code='AR'
+        )
+        LanguageProficiency.objects.create(
+            user_profile=user.profile,
+            code='EN'
+        )
+
+        data = self.command.process_user_languages(user)
+
+        languages_qs = LanguageProficiency.objects.filter(user_profile=user.profile)
+        assert languages_qs.count() == 2
+        assert data == [language.code for language in languages_qs]
+
+    def test_process_social_links(self):
+        user = UserFactory()
+
+        social_links_qs = SocialLink.objects.filter(user_profile=user.profile)
+        assert social_links_qs.count() == 0
+
+        SocialLink.objects.create(
+            user_profile=user.profile,
+            platform='facebook',
+            social_link='https://www.facebook.com/username'
+        )
+        SocialLink.objects.create(
+            user_profile=user.profile,
+            platform='twitter',
+            social_link='https://www.twitter.com/username'
+        )
+
+        social_links_qs = SocialLink.objects.filter(user_profile=user.profile)
+        assert social_links_qs.count() == 2
+
+        data = self.command.process_social_links(user)
+        assert data == [{
+            'platform': link.platform,
+            'social_link': link.social_link,
+        } for link in social_links_qs]
+
+    def test_process_attributes(self):
+        user = UserFactory()
+
+        user_attributes_qs = UserAttribute.objects.filter(user=user)
+        assert user_attributes_qs.count() == 0
+
+        UserAttribute.objects.create(user=user, name='test1', value='test1')
+        UserAttribute.objects.create(user=user, name='test2', value='test2')
+
+        user_attributes_qs = UserAttribute.objects.filter(user=user)
+        assert user_attributes_qs.count() == 2
+
+        data = self.command.process_attributes(user)
+        assert data == [{
+            'name': attribute.name,
+            'value': attribute.value,
+        } for attribute in user_attributes_qs]
+
+    def test_process_access_roles(self):
+        course = CourseFactory.create()
+        access_roles_count = 3
+
+        access_roles_qs = CourseAccessRole.objects.filter(course_id=course.id)
+        assert access_roles_qs.count() == 0
+
+        for _ in range(access_roles_count):
+            CourseAccessRoleFactory(course_id=course.id, user=UserFactory.create(), role='Wizard')
+
+        access_roles_qs = CourseAccessRole.objects.filter(course_id=course.id)
+        assert access_roles_qs.count() == access_roles_count
+
+        data = self.command.process_access_roles(course.id)
+        assert len(data) == access_roles_count
+        assert data == [{
+            'user': role.user.username,
+            'org': role.org,
+            'role': role.role,
+        } for role in access_roles_qs]
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_attributes', return_value={})
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_social_links', return_value=[])
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_user_languages', return_value=[])
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_user_test_groups', return_value={})
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_user_standing', return_value={})
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_user_profile', return_value={})
+    def test_process_users(self, mock1, mock2, mock3, mock4, mock5, mock6):
+        users_count = 3
+
+        signup_source_qs = UserSignupSource.objects.filter(site=self.site)
+        assert signup_source_qs.count() == 0
+
+        for _ in range(users_count):
+            UserSignupSource.objects.create(user=UserFactory(), site=self.site)
+
+        signup_source_qs = UserSignupSource.objects.filter(site=self.site)
+        assert signup_source_qs.count() == users_count
+
+        data = self.command.process_users(self.site)
+        assert len(data) == users_count
+        assert data == [{
+            'user_name': source.user.username,
+            'first_name': source.user.first_name,
+            'last_name': source.user.last_name,
+            'active': source.user.is_active,
+            'last_login': source.user.last_login,
+            'permissions': [permission for permission in source.user.user_permissions.all()],
+            'date_joined': source.user.date_joined,
+            'profile': {},
+            'standing': {},
+            'test_groups': {},
+            'languages': [],
+            'social_links': [],
+            'attributes': {},
+        } for source in signup_source_qs]
+
+    def test_process_enrollment_allowed(self):
+        allowed_enrollments_count = 3
+        course = CourseFactory.create()
+        enrollment_allowed_qs = CourseEnrollmentAllowed.objects.filter(course_id=course.id)
+
+        assert enrollment_allowed_qs.count() == 0
+
+        for _ in range(allowed_enrollments_count):
+            CourseEnrollmentAllowedFactory(email=UserFactory().email, course_id=course.id)
+
+        enrollment_allowed_qs = CourseEnrollmentAllowed.objects.filter(course_id=course.id)
+        assert enrollment_allowed_qs.count() == allowed_enrollments_count
+
+        data = self.command.process_enrollment_allowed(course.id)
+        assert len(data) == allowed_enrollments_count
+        assert data == [{
+            'email': record.email,
+            'auto_enroll': record.auto_enroll,
+            'user': record.user.username if record.user else None,
+            'created': record.created,
+        } for record in enrollment_allowed_qs]
+
+    def test_process_enrollment_audit(self):
+        audit_count = 3
+        course = CourseFactory()
+        enrollment = CourseEnrollment.enroll(user=UserFactory(), course_key=course.id)
+
+        enrollment_audits = ManualEnrollmentAudit.objects.filter(enrollment=enrollment)
+        assert enrollment_audits.count() == 0
+
+        for _ in range(audit_count):
+            ManualEnrollmentAudit.objects.create(
+                enrollment=enrollment,
+                reason='PII here',
+                enrolled_email=UserFactory().email,
+                enrolled_by=UserFactory()
+            )
+
+        enrollment_audits = ManualEnrollmentAudit.objects.filter(enrollment=enrollment)
+        assert enrollment_audits.count() == audit_count
+
+        data = self.command.process_enrollment_audit(enrollment)
+        assert data == [{
+            'enrolled_by': audit.enrolled_by.username,
+            'enrolled_email': audit.enrolled_email,
+            'time_stamp': audit.time_stamp,
+            'state_transition': audit.state_transition,
+            'reason': audit.reason,
+            'role': audit.role,
+        } for audit in enrollment_audits]
+
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_enrollments', return_value=[])
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_course_overview', return_value={})
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_enrollment_allowed', return_value=[])
+    @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_access_roles', return_value=[])
+    def test_process_courses(self, mock1, mock2, mock3, mock4):
+        courses_count = 3
+        organization = OrganizationFactory.create(name='test')
+
+        query_set = OrganizationCourse.objects.filter(organization__in=[organization])
+        assert query_set.count() == 0
+
+        for i in range(courses_count):
+            OrganizationCourseFactory(
+                organization=organization,
+                course_id=str(CourseFactory().id)
+            )
+
+        query_set = OrganizationCourse.objects.filter(organization__in=[organization])
+        assert query_set.count() == courses_count
+
+        data = self.command.process_courses([organization])
+        assert data == [{
+                'course_id': course.course_id,
+                'active': course.active,
+                'enrollments': [],
+                'course_overview': {},
+                'enrollment_allowed': [],
+                'access_roles': [],
+            } for course in query_set]
+
+    @patch('django.core.files.File.write')
+    def test_write_to_file(self, mock_write):
+        path = '/dummy/path.json'
+        content = '{"tetst": "contetnt"}'
+
+        with patch("__builtin__.open", mock_open()) as mock_file:
+            self.command.write_to_file(path, content)
+
+        mock_file.assert_called_once_with(path, 'w')
+        assert mock_write.called_with(content)
+
+    @staticmethod
+    def create_org_users(org, new_user_count):
+        return [UserOrganizationMappingFactory(
+            organization=org).user for i in xrange(new_user_count)]


### PR DESCRIPTION
A script responsible for gathering the data on edX Platform and export them in a JSON file format. Later to add some pipeline processes to it.

------

This command is fundamentally different from our `export_site` command in the following sense:

`export_site` focuses more on exporting a whole website to be able to import it back later. should include all the dependencies, more debugging data, and properly tested to guarantee stability over the next releases.
On the other hand, the `offboard` command we are introducing today, is more of a pipeline to offboard a certain customer when their contract ends. It should handle the following:

- A data dump, to hand off to the customer. Shouldn't be comprehensive as in `export_size`. The structure of the data can be altered without any known risks, and filters all the data that are not useful to the customer (Some data might be necessary to function a website, but unnecessary for a customer to get). (This PR)
- Shut down all third-party apps, monitoring services, etc... (Later)
- Any other action needed to close the site, like site deletion for example. (Later)

### Notes
- This is a read-only command that shouldn't write anything to the database.
- Haven't noticed any performance issues on large data, but we can use a read-replica later to read from.

### Related PRs
- [amc#347 Introducing offboarding data script](https://github.com/appsembler/amc/pull/347)

### Usage
```
$ python manage.py lms offboard <subdomain>
```