### PR TITLE
Fix missing nltk version pin for common/lib/chem

### DIFF
--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -8,7 +8,7 @@ setup(
         "pyparsing==2.0.7",
         "numpy==1.6.2",
         "scipy==0.14.0",
-        "nltk==2.0.6",
+        "nltk>=2.0,<3.5",
         "markupsafe",  # Should be replaced by other utilities. See LEARNER-5853 for more details.
     ],
 )


### PR DESCRIPTION
It looks like version 2.0.6 of nltk must have once existed but isn't available on PyPI or as a Git release. Max version to last version allowing Py2.7