### PR TITLE
remove honeycomb instrumentation for some modulestore operations

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -3,7 +3,6 @@ This module provides an abstraction for working with XModuleDescriptors
 that are stored in a database an accessible using their Location as an identifier
 """
 
-import beeline
 import logging
 import re
 import json
@@ -240,7 +239,6 @@ class BulkOperationsMixin(object):
         """
         pass
 
-    @beeline.traced(name="xmodule._begin_bulk_operation")
     def _begin_bulk_operation(self, course_key, ignore_case=False):
         """
         Begin a bulk operation on course_key.
@@ -263,7 +261,6 @@ class BulkOperationsMixin(object):
         """
         pass
 
-    @beeline.traced(name="xmodule._end_bulk_operation")
     def _end_bulk_operation(self, structure_key, emit_signals=True, ignore_case=False):
         """
         End the active bulk operation on structure_key (course or library key).

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -199,7 +199,6 @@ class SignalHandler(object):
             log.info('Sent %s signal to %s with kwargs %s. Response was: %s', signal_name, receiver, kwargs, response)
 
 
-@beeline.traced(name="xmodule.load_function")
 def load_function(path):
     """
     Load a function by name.
@@ -211,7 +210,6 @@ def load_function(path):
     Returns:
         The imported object 'function'.
     """
-    beeline.add_context_field("path", path)
     if ':' in path:
         module_path, _, method_path = path.rpartition(':')
         module = import_module(module_path)
@@ -314,7 +312,6 @@ def create_modulestore_instance(
 _MIXED_MODULESTORE = None
 
 
-@beeline.traced(name="xmodule.modulestore()")
 def modulestore():
     """
     Returns the Mixed modulestore


### PR DESCRIPTION
These have been pretty much eliminated as sources of performance issues themselves. Now the spans are just noise, so we can get rid of them.
