### PR TITLE
Appsembler/gymnasium/eucalyptus/develop

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -41,17 +41,6 @@ from pipeline_mako import render_require_js_path_overrides
       </title>
   </%block>
 
-  % if not allow_iframing:
-      <script type="text/javascript">
-        /* immediately break out of an iframe if coming from the marketing website */
-        (function(window) {
-          if (window.location !== window.top.location) {
-            window.top.location = window.location;
-          }
-        })(this);
-      </script>
-  % endif
-
   <%
     jsi18n_path = "js/i18n/{language}/djangojs.js".format(language=LANGUAGE_CODE)
   %>


### PR DESCRIPTION
Aquent asked us to remove the iframe restriction for their site to be able to participate in a contest their site get validated by ami.responsivedesign.is/ but right now because of iframe restrictions it's not working. i let them know about security concerns this can bring but they are ok with that and asked me to push this to prod server