### PR TITLE
honeycomb trace course home view

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1,6 +1,7 @@
 """
 Courseware views functions
 """
+import beeline
 import json
 import logging
 import urllib
@@ -475,6 +476,7 @@ class CourseTabView(EdxFragmentView):
     """
     View that displays a course tab page.
     """
+    @beeline.traced(name="CourseTabView.get")
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(ensure_valid_course_key)
     @method_decorator(data_sharing_consent_required)
@@ -587,6 +589,7 @@ class CourseTabView(EdxFragmentView):
         """
         return tab.uses_bootstrap
 
+    @beeline.traced(name="CourseTabView.create_page_context")
     def create_page_context(self, request, course=None, tab=None, **kwargs):
         """
         Creates the context for the fragment's template.
@@ -624,6 +627,7 @@ class CourseTabView(EdxFragmentView):
         )
         return context
 
+    @beeline.traced(name="CourseTabView.render_to_fragment")
     def render_to_fragment(self, request, course=None, page_context=None, **kwargs):
         """
         Renders the course tab to a fragment.
@@ -631,6 +635,7 @@ class CourseTabView(EdxFragmentView):
         tab = page_context['tab']
         return tab.render_to_fragment(request, course, **kwargs)
 
+    @beeline.traced(name="CourseTabView.render_standalone_response")
     def render_standalone_response(self, request, fragment, course=None, tab=None, page_context=None, **kwargs):
         """
         Renders this course tab's fragment to HTML for a standalone page.
@@ -645,6 +650,7 @@ class CourseTabView(EdxFragmentView):
             return render_to_response('courseware/tab-view-v2.html', page_context)
 
 
+@beeline.traced(name="courseware.views.syllabus")
 @ensure_csrf_cookie
 @ensure_valid_course_key
 def syllabus(request, course_id):
@@ -913,6 +919,7 @@ def progress(request, course_id, student_id=None):
         return _progress(request, course_key, student_id)
 
 
+@beeline.traced(name="courseware.views._progress")
 def _progress(request, course_key, student_id):
     """
     Unwrapped version of "progress".

--- a/openedx/core/djangoapps/plugin_api/views.py
+++ b/openedx/core/djangoapps/plugin_api/views.py
@@ -2,6 +2,7 @@
 Views for building plugins.
 """
 
+import beeline
 import logging
 
 from django.conf import settings
@@ -115,6 +116,7 @@ class EdxFragmentView(FragmentView):
         """
         return None
 
+    @beeline.traced(name="EdxFragmentView.render_standalone_response")
     def render_standalone_response(self, request, fragment, **kwargs):
         """
         Renders a standalone page for the specified fragment.

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -2,6 +2,7 @@
 Views for the course home page.
 """
 
+import beeline
 from django.urls import reverse
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string
@@ -46,6 +47,7 @@ class CourseHomeView(CourseTabView):
     """
     The home page for a course.
     """
+    @beeline.traced(name="CourseHomeView.get")
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True))
     @method_decorator(ensure_valid_course_key)


### PR DESCRIPTION
I'm trying to fill in the big blank spot in this trace:

https://ui.honeycomb.io/appsembler/datasets/tahoe-hawthorn-prod/result/AKJBe6fg7ra/trace/56WUo6hWzP7

for the course home view. Taking a bit of a shotgun approach since the code uses `web_fragments.views.FragmentView` as an abstract base class and the execution bounces around a bit so I'm not totally sure what is getting called, but this should help me narrow that down.
