### PR TITLE
Add completable XBlock types installed in Tahoe to list of types affecting completion marks in course outline

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -339,7 +339,8 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
         ]
     }
     css = {'scss': [resource_string(__name__, 'css/lti/lti.scss')]}
-    js_module_name = "LTI"
+    js_module_name = 'LTI'
+    icon_class = 'problem'
 
     def get_input_fields(self):
         # LTI provides a list of default parameters that might be passed as

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -136,6 +136,14 @@ def get_course_outline_block_tree(request, course_id):
         'word_cloud',
         'lti',
         'lti_consumer',
+        # Appsembler completable blocks installed to Tahoe
+        # TODO: this really should be dynamic
+        'done',
+        'freetextresponse',
+        'openassessment',
+        'problem-builder',
+        'sga',
+        'ubcpi'
     ]
     all_blocks = get_blocks(
         request,

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -133,7 +133,9 @@ def get_course_outline_block_tree(request, course_id):
         'discussion',
         'drag-and-drop-v2',
         'poll',
-        'word_cloud'
+        'word_cloud',
+        'lti',
+        'lti_consumer',
     ]
     all_blocks = get_blocks(
         request,

--- a/tox.ini
+++ b/tox.ini
@@ -143,8 +143,8 @@ commands =
     bash scripts/upgrade_pysqlite.sh
     {env:TRAVIS_FIXES}
     pytest \
-        openedx/core/djangoapps/user_api/
-
+        openedx/core/djangoapps/user_api/ \
+        openedx/features/course_experience/utils.py
 
 [testenv:py27-mte]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,8 @@ commands =
         common/djangoapps/util/tests/test_milestones_helpers.py \
         common/djangoapps/xblock_django/ \
         common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py \
+        common/lib/xmodule/xmodule/tests/test_lti20_unit.py \
+        common/lib/xmodule/xmodule/tests/test_lti_unit.py \
         openedx/core/djangoapps/course_groups/
 
 [testenv:py27-studio]


### PR DESCRIPTION
Unfortunately, you have to update this list in openedx.core.features.course_experience.utils to add all completable types in order for them to have an effect on which parts of the outline are marked complete.

### TODO

 - [x] Omar to enable related tests to the `tox.ini` file
 - [x] ~~Bryan fix tests if needed~~
 - [ ] ~Omar to check if the latest LTI Consumer XBlock is compatible with Hawthorn~