### PR TITLE
reduce some honeycomb tracing on sites middleware

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -12,7 +12,6 @@ log = logging.getLogger(__name__)
 
 class CustomDomainsRedirectMiddleware(object):
 
-    @beeline.traced(name="CustomDomainsRedirectMiddleware.process_request")
     def process_request(self, request):
         cache_general = caches['default']
         hostname = request.get_host()
@@ -20,7 +19,7 @@ class CustomDomainsRedirectMiddleware(object):
             cache_key = '{prefix}-{site}'.format(prefix=settings.CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX, site=hostname)
             custom_domain = cache_general.get(cache_key)
             if custom_domain is None:
-                beeline.add_context_field("custom_domain_cache_hit", False)
+                beeline.add_trace_field("custom_domain_cache_hit", False)
                 try:
                     alternative_domain = AlternativeDomain.objects.select_related('site').get(domain=hostname)
                     custom_domain = alternative_domain.site.domain
@@ -28,13 +27,10 @@ class CustomDomainsRedirectMiddleware(object):
                     custom_domain = ""
                 cache_general.set(cache_key, custom_domain, settings.CUSTOM_DOMAINS_REDIRECT_CACHE_TIMEOUT)
             else:
-                beeline.add_context_field("custom_domain_cache_hit", True)
+                beeline.add_trace_field("custom_domain_cache_hit", True)
 
             if custom_domain:
-                beeline.add_context_field("custom_domain_perform_redirect", True)
                 return redirect("https://" + custom_domain)
-            else:
-                beeline.add_context_field("custom_domain_perform_redirect", False)
 
             return
 
@@ -44,7 +40,6 @@ class RedirectMiddleware(object):
     Redirects requests for URLs persisted using the django.contrib.redirects.models.Redirect model.
     With the exception of the main site.
     """
-    @beeline.traced(name="RedirectMiddleware.process_request")
     def process_request(self, request):
         """
         Redirects the current request if there is a matching Redirect model
@@ -52,17 +47,16 @@ class RedirectMiddleware(object):
         """
         site = request.site
         try:
-            beeline.add_context_field("site_id", site.id)
+            beeline.add_trace_field("site_id", site.id)
             in_whitelist = any(map(
                 lambda p: p in request.path,
                 settings.MAIN_SITE_REDIRECT_WHITELIST))
             if (site.id == settings.SITE_ID) and not in_whitelist:
-                beeline.add_context_field("unknown_site_redirect", True)
                 return redirect("https://appsembler.com/tahoe/")
         except Exception:
             # I'm not entirely sure this middleware get's called only in LMS or in other apps as well.
             # Soooo just in case
-            beeline.add_context_field("redirect_middleware_exception", True)
+            beeline.add_trace_field("redirect_middleware_exception", True)
             pass
         cache_key = '{prefix}-{site}'.format(prefix=settings.REDIRECT_CACHE_KEY_PREFIX, site=site.domain)
         redirects = cache.get(cache_key)

--- a/openedx/core/djangoapps/appsembler/sites/models.py
+++ b/openedx/core/djangoapps/appsembler/sites/models.py
@@ -20,29 +20,27 @@ def _cache_key_for_site_host(site_host):
     return 'site:host:%s' % (site_host,)
 
 
-@beeline.traced(name="patched_get_site_by_id")
 def patched_get_site_by_id(self, site_id):
-    beeline.add_context_field("site_id", site_id)
+    beeline.add_trace_field("site_id", site_id)
     key = _cache_key_for_site_id(site_id)
     site = cache.get(key)
     if site is None:
-        beeline.add_context_field("get_site_by_id_cache_hit", False)
+        beeline.add_trace_field("get_site_by_id_cache_hit", False)
         site = self.get(pk=site_id)
         SITE_CACHE[site_id] = site
     else:
-        beeline.add_context_field("get_site_by_id_cache_hit", True)
+        beeline.add_trace_field("get_site_by_id_cache_hit", True)
     cache.add(key, site)
     return site
 
 
-@beeline.traced(name="patched_get_site_by_request")
 def patched_get_site_by_request(self, request):
 
     host = request.get_host()
     key = _cache_key_for_site_host(host)
     site = cache.get(key)
     if site is None:
-        beeline.add_context_field("get_site_by_request_cache_hit", False)
+        beeline.add_trace_field("get_site_by_request_cache_hit", False)
         try:
             # First attempt to look up the site by host with or without port.
             site = self.get(domain__iexact=host)
@@ -54,7 +52,7 @@ def patched_get_site_by_request(self, request):
             site = self.get(domain__iexact=domain)
         SITE_CACHE[host] = site
     else:
-        beeline.add_context_field("get_site_by_request_cache_hit", True)
+        beeline.add_trace_field("get_site_by_request_cache_hit", True)
     cache.add(key, site)
     return site
 


### PR DESCRIPTION
The `CustomDomainsRedirectMiddleware.process_request`, `RedirectMiddleware.process_request`, `patched_get_site_by_id`, and `patched_get_site_by_request` functions are now pretty well understood and optimized. Since those get called on essentially every request, it adds up to a lot of spans though. This PR removes the spans (which should help quite a bit on keeping us within our Honeycomb quota). Some of the fields that were in the spans are still useful though, so those have been converted to trace fields. That means they will be available on the top-level trace for each request and we can easily filter or aggregate on them (eg, get a report of every request that had a cache miss).
