### PR TITLE
honeycomb: instrumenting save_child_position()

### DIFF
--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -484,6 +484,7 @@ class XModuleMixin(XModuleFields, XBlock):
         else:
             return [self.display_name_with_default_escaped]
 
+    @beeline.traced(name="x_module.get_children")
     def get_children(self, usage_id_filter=None, usage_key_filter=None):  # pylint: disable=arguments-differ
         """Returns a list of XBlock instances for the children of
         this module"""
@@ -492,6 +493,7 @@ class XModuleMixin(XModuleFields, XBlock):
         if usage_id_filter is None and usage_key_filter is not None:
             usage_id_filter = usage_key_filter
 
+        beeline.add_context_field("usage_id_filter", usage_id_filter)
         return [
             child
             for child
@@ -499,11 +501,13 @@ class XModuleMixin(XModuleFields, XBlock):
             if child is not None
         ]
 
+    @beeline.traced(name="x_module.get_child")
     def get_child(self, usage_id):
         """
         Return the child XBlock identified by ``usage_id``, or ``None`` if there
         is an error while retrieving the block.
         """
+        beeline.add_context_field("usage_id", usage_id)
         try:
             child = super(XModuleMixin, self).get_child(usage_id)
         except ItemNotFoundError:
@@ -529,6 +533,7 @@ class XModuleMixin(XModuleFields, XBlock):
         not children of this module"""
         return []
 
+    @beeline.traced(name="x_module.get_display_items")
     def get_display_items(self):
         """
         Returns a list of descendent module instances that will display
@@ -540,6 +545,7 @@ class XModuleMixin(XModuleFields, XBlock):
 
         return items
 
+    @beeline.traced(name="x_module.XModuleMixin.displayable_items")
     def displayable_items(self):
         """
         Returns list of displayable modules contained by this module. If this
@@ -920,6 +926,7 @@ class XModule(HTMLSnippet, XModuleMixin):
         """
         return self.descriptor.get_children()
 
+    @beeline.traced(name="x_module.XModule.displayable_items")
     def displayable_items(self):
         """
         Returns list of displayable modules contained by this module. If this


### PR DESCRIPTION
From this trace: https://ui.honeycomb.io/appsembler/datasets/tahoe-hawthorn-prod/result/AKJBe6fg7ra/trace/eah2UsbDDe3

it appears that a call to `save_child_position()` took about 30s and we don't have any instrumentation inside there.

So this is the next step to figure out where the time is disappearing to in that function.
