### PR TITLE
Use settings.AMC_APP_URL instead of FEATURES['AMC_APP_URL']

### DIFF
--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -83,8 +83,6 @@ FEATURES['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = True
 
 FEATURES['ENABLE_BULK_ENROLLMENT_VIEW'] = True
 
-FEATURES['AMC_APP_URL'] = 'http://localhost:13000'  # Appsembler: Fix tests asking for the URL.
-
 DEFAULT_MOBILE_AVAILABLE = True
 
 # Need wiki for courseware views to work. TODO (vshnayder): shouldn't need it.

--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
@@ -14,6 +14,9 @@ def plugin_settings(settings):
     settings.OAUTH_ENFORCE_SECURE = False
     settings.SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
+    if not settings.AMC_APP_URL:
+        settings.AMC_APP_URL = 'http://localhost:13000'
+
     # Disable caching in dev environment
     if not settings.FEATURES.get('ENABLE_DEVSTACK_CACHES', False):
         print('\nAppsembler: disabling devstack caches\n', file=sys.stderr)

--- a/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
@@ -10,6 +10,8 @@ def plugin_settings(settings):
     """
     settings.USE_S3_FOR_CUSTOMER_THEMES = False
 
+    settings.AMC_APP_URL = 'http://localhost:13000'  # Tests needs this URL.
+
     # Allow enabling the APPSEMBLER_MULTI_TENANT_EMAILS when running unit tests via environment variables,
     # because it's disabled by default.
     settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'] = \

--- a/openedx/core/djangoapps/appsembler/sites/admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/admin.py
@@ -69,7 +69,7 @@ class TahoeUserAdmin(UserAdmin, HijackUserAdminMixin):
             'opts': self.model._meta,  # pylint: disable=protected-access
             'form': form,
             'amc_user': user,
-            'amc_app_url': settings.FEATURES['AMC_APP_URL'],
+            'amc_app_url': settings.AMC_APP_URL,
             'title': 'Make AMC Admin',
             'tokens': get_amc_tokens(user),
         })

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -37,7 +37,7 @@ class CreateDevstackSiteCommandTestCase(TestCase):
 
     def setUp(self):
         assert settings.ENABLE_COMPREHENSIVE_THEMING
-        Client.objects.create(url=settings.FEATURES['AMC_APP_URL'], client_type=CONFIDENTIAL)
+        Client.objects.create(url=settings.AMC_APP_URL, client_type=CONFIDENTIAL)
 
     def test_no_sites(self):
         """
@@ -88,7 +88,7 @@ class RemoveSiteCommandTestCase(TestCase):
     """
     def setUp(self):
         assert settings.ENABLE_COMPREHENSIVE_THEMING
-        Client.objects.create(url=settings.FEATURES['AMC_APP_URL'], client_type=CONFIDENTIAL)
+        Client.objects.create(url=settings.AMC_APP_URL, client_type=CONFIDENTIAL)
 
         self.to_be_deleted = 'delete'
         self.shall_remain = 'keep'

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -55,7 +55,7 @@ def get_amc_oauth_client():
     """
     Return the AMC OAuth2 Client model instance.
     """
-    return Client.objects.get(url=settings.FEATURES['AMC_APP_URL'])
+    return Client.objects.get(url=settings.AMC_APP_URL)
 
 
 @beeline.traced(name="get_amc_tokens")


### PR DESCRIPTION
It's confusing and breaks fresh devstack installations.

It should be safe to deploy since we already have the required configs in `edx-configs`.

 - https://github.com/appsembler/edx-configs/pull/903
 - https://github.com/appsembler/edx-configs/pull/904

With this change it's not longer needed to modify the `lms.env.json` by hand on a fresh devstack installation.