### PR TITLE
Manually create OrganizationCourse object while importing tahoe default course

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/tasks.py
+++ b/openedx/core/djangoapps/appsembler/sites/tasks.py
@@ -20,7 +20,7 @@ from student.roles import CourseAccessRole
 
 from opaque_keys.edx.keys import CourseKey
 
-from organizations.models import Organization
+from organizations.models import Organization, OrganizationCourse
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore import ModuleStoreEnum
@@ -117,6 +117,12 @@ def import_course_on_site_creation(organization_id):
                 role='instructor',  # This is called "Course Admin" in Studio.
                 course_id=course_target_id,
                 org=organization.short_name
+            )
+
+            OrganizationCourse.objects.create(
+                organization=organization,
+                course_id=unicode(course_target_id),
+                active=True
             )
 
     # catch all exceptions so we can update the state and properly cleanup the course.


### PR DESCRIPTION
When a user creates a course in Studio, we have a logic in place to create an OrganizationCourse object. That edX default functionality and we really on it to isolate courses courses in our different organization, so it's a key piece for Multi-Tenancy.

When we implemented the Tahoe default course functionality, that clones and import a course after a Trial site creation through AMC Sign up, we omitted to manually create this object, which is causing problem in batch enrollment.

I found the bug while I was debugging MTE email, at the end the bug wasn't related to MTE, it was related to the lack of relationship between the org and the course, for more details you can check here: https://appsembler.atlassian.net/browse/RED-1214