### PR TITLE
Update completable block types for course outline

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -339,7 +339,8 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
         ]
     }
     css = {'scss': [resource_string(__name__, 'css/lti/lti.scss')]}
-    js_module_name = "LTI"
+    js_module_name = 'LTI'
+    icon_class = 'problem'
 
     def get_input_fields(self):
         # LTI provides a list of default parameters that might be passed as

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -136,6 +136,14 @@ def get_course_outline_block_tree(request, course_id):
         'word_cloud',
         'lti',
         'lti_consumer',
+        # Appsembler completable blocks installed to Tahoe
+        # TODO: this really should be dynamic
+        'done',
+        'freetextresponse',
+        'openassessment',
+        'problem-builder',
+        'sga',
+        'ubcpi'
     ]
     all_blocks = get_blocks(
         request,

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -133,7 +133,9 @@ def get_course_outline_block_tree(request, course_id):
         'discussion',
         'drag-and-drop-v2',
         'poll',
-        'word_cloud'
+        'word_cloud',
+        'lti',
+        'lti_consumer',
     ]
     all_blocks = get_blocks(
         request,

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -143,7 +143,8 @@ def get_course_outline_block_tree(request, course_id):
         'openassessment',
         'problem-builder',
         'edx_sga',
-        'ubcpi'
+        'ubcpi',
+        'scormxblock'
     ]
     all_blocks = get_blocks(
         request,

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -142,7 +142,7 @@ def get_course_outline_block_tree(request, course_id):
         'freetextresponse',
         'openassessment',
         'problem-builder',
-        'sga',
+        'edx_sga',
         'ubcpi'
     ]
     all_blocks = get_blocks(


### PR DESCRIPTION
Add LTI Consumer, Staff Graded Assignment, Peer Instruction, ORA, SCORMXBlock, Done, Free Text Response and Problem Builder block types to those that will display their completion in course outline.