### PR TITLE
`unenroll` action for the API

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/tests/test_enrollment_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_enrollment_api.py
@@ -285,6 +285,26 @@ class EnrollmentApiPostTest(BaseEnrollmentApiTestCase):
                 assert not CourseEnrollmentAllowed.objects.filter(
                     email=rec['identifier']).exists()
 
+    def test_enroll_learner_in_two_courses(self):
+        """
+        Enroll a learner in two courses in a single call.
+        """
+        new_users_email = 'alpha@example.com'
+        payload = {
+            'action': 'enroll',
+            'auto_enroll': True,
+            # Enroll both of the registered users and new ones
+            'identifiers': [new_users_email],
+            'email_learners': True,
+            'courses': [str(co.id) for co in self.my_course_overviews],
+        }
+        response = self.call_enrollment_api('post', self.my_site, self.caller, {
+            'data': payload,
+        })
+        results = response.data['results']
+        assert CourseEnrollmentAllowed.objects.count() == len(self.my_course_overviews)
+        assert len(results) == len(self.my_course_overviews), 'Ensure result from all courses are returned'
+
     def test_enroll_with_other_site_course(self):
 
         reg_users = [UserFactory(), UserFactory()]

--- a/openedx/core/djangoapps/appsembler/api/v1/api.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/api.py
@@ -28,19 +28,13 @@ from student.models import (
     ManualEnrollmentAudit
 )
 
-from organizations.models import (
-    OrganizationCourse,
-    UserOrganizationMapping,
-)
-
 
 log = logging.getLogger(__name__)
 
 
-def enrollment_learners_context(course_id, identifiers):
+def enrollment_learners_context(identifiers):
     """
     Get emails (and learner language) from a list of learner identifiers.
-    :param course_id: The course ID.
     :param identifiers: list of usernames/emails of students.
     :return: iterator of tuples
         (
@@ -50,10 +44,6 @@ def enrollment_learners_context(course_id, identifiers):
             language: string: Learner language,
         )
     """
-    # Ensuring the course is linked to an organization
-    _site = get_site_for_course(course_id)
-    _org = OrganizationCourse.objects.get(course_id=str(course_id))
-
     for identifier in identifiers:
         language = None
         user = None
@@ -97,7 +87,7 @@ def enroll_learners_in_course(course_id, identifiers, enroll_func, **kwargs):
     enrollment_obj = None
     state_transition = DEFAULT_TRANSITION_STATE
 
-    for user, identifier, email, language in enrollment_learners_context(course_id, identifiers):
+    for user, identifier, email, language in enrollment_learners_context(identifiers):
         try:
             # Use django.core.validators.validate_email to check email address
             # validity (obviously, cannot check if email actually /exists/,
@@ -177,7 +167,7 @@ def unenroll_learners_in_course(course_id, identifiers, unenroll_func, **kwargs)
     results = []
     enrollment_obj = None
 
-    for user, identifier, email, language in enrollment_learners_context(course_id, identifiers):
+    for user, identifier, email, language in enrollment_learners_context(identifiers):
         try:
             validate_email(email)  # Raises ValidationError if invalid
             before, after = unenroll_func(

--- a/openedx/core/djangoapps/appsembler/api/v1/api.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/api.py
@@ -45,7 +45,7 @@ def enrollment_learners_context(course_id, identifiers):
     :return: iterator of tuples
         (
             user: User: The User object if found,
-            identifier: string: The dentifier as-is,
+            identifier: string: The identifier as-is -- which is either a username or an email,
             email: string: Learner email by the identifier,
             language: string: Learner language,
         )

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -64,6 +64,7 @@ from openedx.core.djangoapps.appsembler.api.v1.serializers import (
     BulkEnrollmentSerializer,
     UserIndexSerializer,
 )
+from openedx.core.djangoapps.appsembler.api.v1.waffle import FIX_ENROLLMENT_RESULTS_BUG
 
 # TODO: Just move into v1 directory
 from openedx.core.djangoapps.appsembler.api.permissions import (
@@ -355,6 +356,11 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                                                             secure=request.is_secure())
                         else:
                             email_params = {}
+
+                        if not FIX_ENROLLMENT_RESULTS_BUG.is_enabled():
+                            # RED-1386: Preserve the original bug behaviour and put it behind a feature flag to
+                            # decouple deployment from release.
+                            results = []
 
                         if action == 'enroll':
                             results += enroll_learners_in_course(

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -25,6 +25,8 @@ from rest_framework.filters import DjangoFilterBackend
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from organizations.models import OrganizationCourse
+
 from enrollment.serializers import CourseEnrollmentSerializer
 
 # from courseware.courses import get_course_by_id, get_course_with_access
@@ -350,6 +352,13 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
 
                     for course_id in serializer.data.get('courses'):
                         course_key = as_course_key(course_id)
+                        # TODO: The two checks below deserve a refactor to make it clearer or a v2 API that works on a
+                        #       single course and use `instructor/views/api.py:students_update_enrollment` directly.
+                        # Ensuring the course is linked to an organization. It's somewhat a legacy code, keeping
+                        # it just in case.
+                        # _site = get_site_for_course(course_id)
+                        # _org = OrganizationCourse.objects.get(course_id=str(course_id))
+
                         if email_learners:
                             email_params = get_email_params(course=get_course_by_id(course_key),
                                                             auto_enroll=auto_enroll,

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -344,6 +344,9 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                     email_learners = serializer.data.get('email_learners')
                     identifiers = serializer.data.get('identifiers')
                     auto_enroll = serializer.data.get('auto_enroll')
+                    response_code = status.HTTP_201_CREATED if action == 'enroll' else status.HTTP_200_OK
+                    results = []
+
                     for course_id in serializer.data.get('courses'):
                         course_key = as_course_key(course_id)
                         if email_learners:
@@ -354,7 +357,7 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                             email_params = {}
 
                         if action == 'enroll':
-                            results = enroll_learners_in_course(
+                            results += enroll_learners_in_course(
                                 course_id=course_key,
                                 identifiers=identifiers,
                                 enroll_func=partial(
@@ -365,9 +368,8 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                                 ),
                                 request_user=request.user,
                             )
-                            response_code = status.HTTP_201_CREATED
                         else:
-                            results = unenroll_learners_in_course(
+                            results += unenroll_learners_in_course(
                                 course_id=course_key,
                                 identifiers=identifiers,
                                 unenroll_func=partial(
@@ -377,7 +379,6 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                                 ),
                                 request_user=request.user,
                             )
-                            response_code = status.HTTP_200_OK
 
                     response_data = {
                         'auto_enroll': serializer.data.get('auto_enroll'),

--- a/openedx/core/djangoapps/appsembler/api/v1/waffle.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/waffle.py
@@ -1,0 +1,12 @@
+"""
+Waffle flags for Tahoe v1 APIs.
+"""
+
+from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
+
+WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='appsembler_api_v1')
+
+# Fix the Enrollment API results bug gradually
+# TODO: RED-1387: Remove this flag after release
+FIX_ENROLLMENT_RESULTS_BUG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'fix_enrollment_results_bug',
+                                        flag_undefined_default=False)


### PR DESCRIPTION
Jira: RED-1232


### TODO

 - [x] Decide about the [`results` issue with John](https://appsembler.atlassian.net/wiki/spaces/RT/pages/810516481/Draft+Decision+How+to+fix+the+v1+Enrollment+API+multi-course+issue)
 - [x] Fix the `results` issue in v1
 - [x] Add a waffle flag for the `results += ...` behaviour to ship it as soon as possible

### The response `results` problem
When the API is called to enroll a user in two courses,
the response should show the status for those two course.
However, it would show the response for only a single course.

Please see the related decision page for more detailed info:

- [Decision: How to fix the v1 Enrollment API multi-course issue?
](https://appsembler.atlassian.net/wiki/spaces/RT/pages/810516481/Decision+How+to+fix+the+v1+Enrollment+API+multi-course+issue)
- Outcome: **Option 1** - Fix inline but inform customers upfront.

If you're into XKCD [the comic below](https://xkcd.com/1172/) will explain the situation:

<img src="https://user-images.githubusercontent.com/645156/92645627-cbe25480-f2ed-11ea-98b3-83396f27993c.png" width="250" />
