### PR TITLE
Fixed certificate course.display_organization override bug

### DIFF
--- a/lms/djangoapps/certificates/tests/test_webview_appsembler_changes.py
+++ b/lms/djangoapps/certificates/tests/test_webview_appsembler_changes.py
@@ -1,0 +1,48 @@
+"""
+Test changes we've done to the `webview` internal helpers.
+"""
+
+from mock import patch, Mock
+from django.test import TestCase
+
+from lms.djangoapps.certificates.views.webview import _update_organization_context  # pylint: disable=protected-access
+
+
+@patch(
+    'util.organizations_helpers.get_course_organizations',
+    Mock(return_value=[{
+        # List of a single organization.
+        'name': 'org-name',
+        'short_name': 'org-name',
+        'logo': None,
+    }])
+)
+class UpdateOrganizationContextTestCase(TestCase):
+    """
+    Tests for the `_update_organization_context` function.
+    """
+
+    def test_without_course_org_name_override(self):
+        """
+        Ensure `partner_short_name_overridden` is properly set to False by default.
+        """
+        context = {}
+        course = Mock()
+        course.display_organization = None  # Not overridden
+        course.org = 'org-name'
+
+        _update_organization_context(context, course)
+
+        assert not context['partner_short_name_overridden'], 'Should be set to False so certs work properly'
+        assert context['course_partner_short_name'] == 'org-name'
+
+    def test_with_course_org_name_override(self):
+        context = {}
+        course = Mock()
+        course.org = 'org-name'
+        course.display_organization = 'Custom Org Name'  # Not overridden
+
+        _update_organization_context(context, course)
+
+        assert context['partner_short_name_overridden'], 'Should be set to True so certs work properly'
+        assert context['course_partner_short_name'] == 'Custom Org Name'

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -450,7 +450,8 @@ def _update_organization_context(context, course):
     """
     partner_long_name, organization_logo = None, None
     partner_short_name = course.display_organization if course.display_organization else course.org
-    partner_short_name_overridden = True if course.display_organization else False
+    course_partner_short_name = partner_short_name  # Appsembler: Avoid having it overridden by organization.short_name
+    partner_short_name_overridden = bool(course.display_organization)  # Appsembler: Allow certs app to pick smartly
     organizations = organization_api.get_course_organizations(course_id=course.id)
     if organizations:
         #TODO Need to add support for multiple organizations, Currently we are interested in the first one.
@@ -462,6 +463,7 @@ def _update_organization_context(context, course):
     context['organization_long_name'] = partner_long_name
     context['organization_short_name'] = partner_short_name
     context['partner_short_name_overridden'] = partner_short_name_overridden
+    context['course_partner_short_name'] = course_partner_short_name
     context['accomplishment_copy_course_org'] = partner_short_name
     context['organization_logo'] = organization_logo
 

--- a/tox.ini
+++ b/tox.ini
@@ -125,6 +125,7 @@ commands =
     bash scripts/upgrade_pysqlite.sh
     {env:TRAVIS_FIXES}
     pytest \
+        lms/djangoapps/certificates/tests/test_webview_appsembler_changes.py  \
         lms/djangoapps/course_api/ \
         lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py \
         lms/djangoapps/courseware/tests/test_access.py \


### PR DESCRIPTION
Fixes RED-1329


### Bug Description
In addition to what's described in RED-1329. I've found that setting `course.display_organization` makes `organization.short_name` appears instead. Which is not what we want at all.

### Change no. 1

When organizations is enabled `partner_short_name` gets overridden with `org.short_name` the line:

https://github.com/appsembler/edx-platform/blob/4ccbf4ffb47b9ca5c7d845533b6379bc02005bc8/lms/djangoapps/certificates/views/webview.py#L460

This behaviour we don't want, I added a new variable `course_partner_short_name` that's not overridden.


### Change no. 2
Refactored `partner_short_name_overridden` so it's simpler to reason about with `bool()`


### Related PR

 - https://github.com/appsembler/edx-theme-customers/pull/126