### PR TITLE
Allow course role staff to login into studio

### DIFF
--- a/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
+++ b/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
@@ -2,17 +2,24 @@
 Tests for APPSEMBLER_MULTI_TENANT_EMAILS in Studio login.
 """
 
+import ddt
+import pytest
+from unittest import skipIf
+from django.core.exceptions import MultipleObjectsReturned
 from mock import patch
+from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 
-from student.roles import CourseCreatorRole, CourseAccessRole
+from student.roles import CourseAccessRole, CourseCreatorRole, CourseInstructorRole, CourseStaffRole
 
 from student.tests.factories import UserFactory
 
 
+@ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'APPSEMBLER_MULTI_TENANT_EMAILS': True})
+@skipIf(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in CMS')
 class MultiTenantStudioLoginTestCase(TestCase):
     """
     Testing the APPSEMBLER_MULTI_TENANT_EMAILS feature when enabled in Studio.
@@ -21,6 +28,10 @@ class MultiTenantStudioLoginTestCase(TestCase):
     BLUE = 'blue1'
     EMAIL = 'customer@example.com'
     PASSWORD = 'xyz'
+    FAILURE_MESSAGE = (
+        'Email or password is incorrect. '
+        'Please ensure that you are a course staff in order to use Studio.'
+    )
 
     def setUp(self):
         super(MultiTenantStudioLoginTestCase, self).setUp()
@@ -49,7 +60,55 @@ class MultiTenantStudioLoginTestCase(TestCase):
         })
         assert response.status_code == status.HTTP_200_OK, response.content
         assert not response.json()['success']
-        assert response.json()['value'] == 'Email or password is incorrect.'
+        assert response.json()['value'] == self.FAILURE_MESSAGE
+
+    @ddt.data(CourseStaffRole.ROLE, CourseInstructorRole.ROLE)
+    def test_login_for_course_staff(self, course_role_name):
+        """
+        Test the APPSEMBLER_MULTI_TENANT_EMAILS feature when enabled in Studio for Course{Instructor,Staff}Role's.
+        """
+        CourseAccessRole.objects.create(user=self.customer, role=course_role_name)
+        response = self.client.post(self.url, {
+            'email': self.EMAIL,
+            'password': self.PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()['success'], response.content
+
+    @patch('student.views.login.log')
+    def test_error_on_two_emails_found(self, mock_log):
+        """
+        Test that two users with CourseCreatorRole if found 500 shows up.
+
+        Not fun but allows us to triage issues properly if enough issues
+        were reported instead of a silent error.
+        """
+        CourseAccessRole.objects.create(user=self.customer, role=CourseCreatorRole.ROLE)
+
+        # Add a CourseInstructorRole with the same email.
+        customer_2 = UserFactory.create(email=self.EMAIL, password='another_password')
+        CourseAccessRole.objects.create(user=customer_2, role=CourseInstructorRole.ROLE)
+
+        assert not mock_log.exception.called, 'Not to be called yet'
+        with pytest.raises(MultipleObjectsReturned):
+            self.client.post(self.url, {
+                'email': self.EMAIL,
+                'password': self.PASSWORD,
+            })
+        assert mock_log.exception.called, 'Should be called to log our custom message'
+
+    @ddt.data(CourseStaffRole.ROLE, CourseInstructorRole.ROLE)
+    def test_login_for_course_staff(self, course_role_name):
+        """
+        Test the APPSEMBLER_MULTI_TENANT_EMAILS feature when enabled in Studio for Course{Instructor,Staff}Role's.
+        """
+        CourseAccessRole.objects.create(user=self.customer, role=course_role_name)
+        response = self.client.post(self.url, {
+            'email': self.EMAIL,
+            'password': self.PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()['success'], response.content
 
     def test_failed_login(self):
         """
@@ -62,4 +121,4 @@ class MultiTenantStudioLoginTestCase(TestCase):
         })
         assert response.status_code == status.HTTP_200_OK, response.content
         assert not response.json()['success']
-        assert response.json()['value'] == 'Email or password is incorrect.'
+        assert response.json()['value'] == self.FAILURE_MESSAGE

--- a/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
+++ b/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
@@ -110,6 +110,39 @@ class MultiTenantStudioLoginTestCase(TestCase):
         assert response.status_code == status.HTTP_200_OK, response.content
         assert response.json()['success'], response.content
 
+    def test_login_for_course_staff_but_learner_on_another_site(self):
+        """
+        Test the login for a learner in a site but a staff in another.
+
+        When APPSEMBLER_MULTI_TENANT_EMAILS feature when enabled in Studio
+        """
+        # Add a learner with the same email.
+        _learner_2 = UserFactory.create(email=self.EMAIL, password='another_password')
+
+        CourseAccessRole.objects.create(user=self.customer, role=CourseStaffRole.ROLE)
+        response = self.client.post(self.url, {
+            'email': self.EMAIL,
+            'password': self.PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()['success'], response.content
+
+    def test_login_for_course_staff_in_two_courses(self):
+        """
+        Test the login for a course staff for two courses.
+
+        When APPSEMBLER_MULTI_TENANT_EMAILS feature when enabled in Studio.
+        This is created to fix a Django ORM weirdness with MultipleObjectsReturned.
+        """
+        CourseAccessRole.objects.create(user=self.customer, role=CourseStaffRole.ROLE)
+        CourseAccessRole.objects.create(user=self.customer, role=CourseInstructorRole.ROLE)
+        response = self.client.post(self.url, {
+            'email': self.EMAIL,
+            'password': self.PASSWORD,
+        })
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()['success'], response.content
+
     def test_failed_login(self):
         """
         Test a failed login when the APPSEMBLER_MULTI_TENANT_EMAILS feature in Studio.

--- a/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
+++ b/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
@@ -26,12 +26,12 @@ class MultiTenantStudioLoginTestCase(TestCase):
         super(MultiTenantStudioLoginTestCase, self).setUp()
         self.url = reverse('login_post')  # CMS login endpoint.
         self.customer = UserFactory.create(email=self.EMAIL, password=self.PASSWORD)
-        CourseAccessRole.objects.create(user=self.customer, role=CourseCreatorRole.ROLE)
 
-    def test_login(self):
+    def test_login_with_course_creator_role(self):
         """
-        Test the APPSEMBLER_MULTI_TENANT_EMAILS feature when enabled in Studio.
+        Test the APPSEMBLER_MULTI_TENANT_EMAILS feature when enabled in Studio for CourseCreatorRole.
         """
+        CourseAccessRole.objects.create(user=self.customer, role=CourseCreatorRole.ROLE)
         response = self.client.post(self.url, {
             'email': self.EMAIL,
             'password': self.PASSWORD,
@@ -43,7 +43,6 @@ class MultiTenantStudioLoginTestCase(TestCase):
         """
         Test that users without CourseCreatorRole cannot login into Studio.
         """
-        CourseAccessRole.objects.filter(user=self.customer).delete()  # Remove CourseCreatorRole
         response = self.client.post(self.url, {
             'email': self.EMAIL,
             'password': self.PASSWORD,
@@ -56,6 +55,7 @@ class MultiTenantStudioLoginTestCase(TestCase):
         """
         Test a failed login when the APPSEMBLER_MULTI_TENANT_EMAILS feature in Studio.
         """
+        CourseAccessRole.objects.create(user=self.customer, role=CourseCreatorRole.ROLE)
         response = self.client.post(self.url, {
             'email': self.EMAIL,
             'password': 'wrong_password',

--- a/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
+++ b/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
@@ -48,7 +48,7 @@ class MultiTenantStudioLoginTestCase(TestCase):
             'password': self.PASSWORD,
         })
         assert response.status_code == status.HTTP_200_OK, response.content
-        assert response.json()['success']
+        assert response.json()['success'], response.content
 
     def test_login_no_course_creator(self):
         """
@@ -59,8 +59,8 @@ class MultiTenantStudioLoginTestCase(TestCase):
             'password': self.PASSWORD,
         })
         assert response.status_code == status.HTTP_200_OK, response.content
-        assert not response.json()['success']
-        assert response.json()['value'] == self.FAILURE_MESSAGE
+        assert not response.json()['success'], response.content
+        assert response.json()['value'] == self.FAILURE_MESSAGE, response.content
 
     @ddt.data(CourseStaffRole.ROLE, CourseInstructorRole.ROLE)
     def test_login_for_course_staff(self, course_role_name):
@@ -153,5 +153,5 @@ class MultiTenantStudioLoginTestCase(TestCase):
             'password': 'wrong_password',
         })
         assert response.status_code == status.HTTP_200_OK, response.content
-        assert not response.json()['success']
+        assert not response.json()['success'], response.content
         assert response.json()['value'] == self.FAILURE_MESSAGE

--- a/common/djangoapps/student/views/login.py
+++ b/common/djangoapps/student/views/login.py
@@ -179,12 +179,12 @@ def _get_user_by_email(request):
             else:
                 from student import roles as user_roles  # Avoid import errors.
                 return User.objects.get(
-                    courseaccessrole__role__in=[
+                    email=email,
+                    pk__in=CourseAccessRole.objects.filter(role__in=[
                         user_roles.CourseCreatorRole.ROLE,
                         user_roles.CourseInstructorRole.ROLE,
                         user_roles.CourseStaffRole.ROLE,
-                    ],
-                    email=email,
+                    ]).values('user_id'),
                 )
         except (UserOrganizationMapping.DoesNotExist, User.DoesNotExist):
             _log_failed_get_user_by_email(email)


### PR DESCRIPTION
 - Fixes RED-1365: Allow course role staff to login in Studio like Course Creator does.
 - Fixes RED-1213: Add a clearer message to reflect our changes with MTE. 
   ![image](https://user-images.githubusercontent.com/645156/92622028-3fc03500-f2cd-11ea-8699-4a906b9cb8f9.png)


 - Refactor MultiTenantStudioLoginTestCase: defer role addition into each test case so it's more readable


### Side effect: 500 error on `MultipleObjectsReturned`

When two users are found, studio login will fail with a 500 error. We should find a better way to make Studio multi-tenant. At least, Studio login should be.

I've addressed this by adding a clear log message so CSMs or anyone doing support can detect and fix the issue from the Django admin.