### PR TITLE
Enrollment API: Test for `response['results']` issue

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/tests/test_enrollment_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_enrollment_api.py
@@ -285,6 +285,26 @@ class EnrollmentApiPostTest(BaseEnrollmentApiTestCase):
                 assert not CourseEnrollmentAllowed.objects.filter(
                     email=rec['identifier']).exists()
 
+    def test_enroll_learner_in_two_courses(self):
+        """
+        Enroll a learner in two courses in a single call.
+        """
+        new_users_email = 'alpha@example.com'
+        payload = {
+            'action': 'enroll',
+            'auto_enroll': True,
+            # Enroll both of the registered users and new ones
+            'identifiers': [new_users_email],
+            'email_learners': True,
+            'courses': [str(co.id) for co in self.my_course_overviews],
+        }
+        response = self.call_enrollment_api('post', self.my_site, self.caller, {
+            'data': payload,
+        })
+        results = response.data['results']
+        assert CourseEnrollmentAllowed.objects.count() == len(self.my_course_overviews)
+        assert len(results) == len(self.my_course_overviews), 'Ensure result from all courses are returned'
+
     def test_enroll_with_other_site_course(self):
 
         reg_users = [UserFactory(), UserFactory()]


### PR DESCRIPTION
When the API is called to enroll a user in two courses,
the response should show the status for those two course.
However, it would show the response for only a single course.

Please see the related decision page:

- [Decision: How to fix the v1 Enrollment API multi-course issue?
](https://appsembler.atlassian.net/wiki/spaces/RT/pages/810516481/Decision+How+to+fix+the+v1+Enrollment+API+multi-course+issue)

Yes, it's [one of those](https://xkcd.com/1172/):

<img src="https://user-images.githubusercontent.com/645156/92645627-cbe25480-f2ed-11ea-98b3-83396f27993c.png" width="300" />
