### PR TITLE
Set SESSION_INACTIVITY_TIMEOUT_IN_SECONDS via SiteConfigs

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -341,7 +341,6 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                     email_learners = serializer.data.get('email_learners')
                     identifiers = serializer.data.get('identifiers')
                     auto_enroll = serializer.data.get('auto_enroll')
-                    # results = []  # Start with an empty array
                     for course_id in serializer.data.get('courses'):
                         course_key = as_course_key(course_id)
                         if email_learners:
@@ -350,7 +349,6 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                                                             secure=request.is_secure())
                         else:
                             email_params = {}
-                        # results.append(enroll_learners_in_course(...))  # Append results from each course
                         results = enroll_learners_in_course(course_id=course_key,
                                                             identifiers=identifiers,
                                                             enroll_func=partial(enroll_email,

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -341,6 +341,7 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                     email_learners = serializer.data.get('email_learners')
                     identifiers = serializer.data.get('identifiers')
                     auto_enroll = serializer.data.get('auto_enroll')
+                    # results = []  # Start with an empty array
                     for course_id in serializer.data.get('courses'):
                         course_key = as_course_key(course_id)
                         if email_learners:
@@ -349,6 +350,7 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                                                             secure=request.is_secure())
                         else:
                             email_params = {}
+                        # results.append(enroll_learners_in_course(...))  # Append results from each course
                         results = enroll_learners_in_course(course_id=course_key,
                                                             identifiers=identifiers,
                                                             enroll_func=partial(enroll_email,

--- a/openedx/core/djangoapps/session_inactivity_timeout/middleware.py
+++ b/openedx/core/djangoapps/session_inactivity_timeout/middleware.py
@@ -28,7 +28,11 @@ class SessionInactivityTimeout(object):
             #Can't log out if not logged in
             return
 
-        timeout_in_seconds = getattr(settings, "SESSION_INACTIVITY_TIMEOUT_IN_SECONDS", None)
+        from openedx.core.djangoapps.site_configuration import (  # Appsembler: Avoid import errors
+            helpers as configuration_helpers,
+        )
+        setting_key = 'SESSION_INACTIVITY_TIMEOUT_IN_SECONDS'
+        timeout_in_seconds = configuration_helpers.get_value(setting_key, getattr(settings, setting_key, None))
 
         # Do we have this feature enabled?
         if timeout_in_seconds:

--- a/openedx/core/djangoapps/session_inactivity_timeout/middleware.py
+++ b/openedx/core/djangoapps/session_inactivity_timeout/middleware.py
@@ -32,7 +32,11 @@ class SessionInactivityTimeout(object):
             helpers as configuration_helpers,
         )
         setting_key = 'SESSION_INACTIVITY_TIMEOUT_IN_SECONDS'
-        timeout_in_seconds = configuration_helpers.get_value(setting_key, getattr(settings, setting_key, None))
+        platform_wide_setting = getattr(settings, setting_key, None)
+        site_config_setting = configuration_helpers.get_value(setting_key)
+
+        # Appsembler: Falsy site values defaults to platform-wide. This helps to uncomplicate AMC.
+        timeout_in_seconds = site_config_setting or platform_wide_setting
 
         # Do we have this feature enabled?
         if timeout_in_seconds:

--- a/tox.ini
+++ b/tox.ini
@@ -130,6 +130,7 @@ commands =
         lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py \
         lms/djangoapps/courseware/tests/test_access.py \
         lms/djangoapps/courseware/tests/test_access_control_backends.py \
+        lms/djangoapps/courseware/tests/test_navigation.py  \
         lms/djangoapps/django_comment_client/ \
         lms/djangoapps/grades/tests/integration/test_events.py \
         lms/djangoapps/instructor/ \


### PR DESCRIPTION
RED-1223. Making `SESSION_INACTIVITY_TIMEOUT_IN_SECONDS` configurable via AMC.

### Update on Sept 12th
Now the commit (https://github.com/appsembler/edx-platform/pull/683/commits/34a47f32e028f3924d22485429800dff86470098) makes falsy timeout (null, zero or just empty string) defaults to the platform-wide `lms.auth.json` setting because AMC sends `null` value to the SiteConfiguration API.

<kbd>![image](https://user-images.githubusercontent.com/645156/92992448-b0489b00-f4f3-11ea-8191-c69704984a24.png)</kbd>

The technical difference is using `or` instead of the standard `dict.get` default value (Pesudo-code):
```diff
-timeout_in_seconds = values.get('timeout', settings.timeout)
+timeout_in_seconds = values.get('timeout') or settings.timeout
```