### PR TITLE
Trial: Prevent Studio access for expired sites

### DIFF
--- a/cms/djangoapps/appsembler_tiers/__init__.py
+++ b/cms/djangoapps/appsembler_tiers/__init__.py
@@ -1,0 +1,5 @@
+"""
+Views and urls related to the `tiers` app.
+
+This app redirects to the LMS `appsembler_tiers` app.
+"""

--- a/cms/djangoapps/appsembler_tiers/tests.py
+++ b/cms/djangoapps/appsembler_tiers/tests.py
@@ -1,0 +1,48 @@
+"""
+Tests for the tiers integration in Studio.
+"""
+
+from __future__ import unicode_literals
+
+from django.urls import reverse
+from django.test import TestCase, override_settings
+from rest_framework import status
+
+from openedx.core.djangoapps.appsembler.multi_tenant_emails.tests.test_utils import (
+    with_organization_context,
+    create_org_user,
+)
+
+
+class SiteUnavailableRedirectViewTest(TestCase):
+    """
+    Unit tests for the Tiers views.
+    """
+
+    BLUE = 'blue2'
+    PASSWORD = 'xyz'
+
+    def setUp(self):
+        super(SiteUnavailableRedirectViewTest, self).setUp()
+        self.url = reverse('site_unavailable')
+
+        with override_settings(DEFAULT_SITE_THEME='edx-theme-codebase'):
+            with with_organization_context(self.BLUE) as org:
+                self.admin = create_org_user(org, password=self.PASSWORD)
+
+    def test_site_unavailable_page_non_logged_in(self):
+        """
+        The trial page needs a logged in user.
+        """
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_302_FOUND, response.content
+        assert response['Location'] == '/signin?next=/site-unavailable/', response.content
+
+    def test_site_unavailable_page(self):
+        """
+        Ensure trial expire page shows up with site information.
+        """
+        assert self.client.login(username=self.admin.username, password=self.PASSWORD)
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_302_FOUND, response.content
+        assert response['Location'] == 'http://blue2/site-unavailable/', response.content

--- a/cms/djangoapps/appsembler_tiers/urls.py
+++ b/cms/djangoapps/appsembler_tiers/urls.py
@@ -1,0 +1,13 @@
+"""
+URLs for the tiers app to be included in the LMS.
+"""
+
+from django.conf.urls import url
+
+from cms.djangoapps.appsembler_tiers.views import (
+    SiteUnavailableRedirectView,
+)
+
+urlpatterns = [
+    url(r'^site-unavailable/$', SiteUnavailableRedirectView.as_view(), name='site_unavailable'),
+]

--- a/cms/djangoapps/appsembler_tiers/views.py
+++ b/cms/djangoapps/appsembler_tiers/views.py
@@ -1,0 +1,30 @@
+"""
+Studio views for the tiers app.
+"""
+
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import View
+
+from openedx.core.djangoapps.appsembler.sites.utils import (
+    get_site_by_organization,
+    get_single_user_organization,
+)
+
+
+class SiteUnavailableRedirectView(View):
+    """
+    Studio view to redirect to the LMS view (above).
+    """
+
+    @method_decorator(login_required)
+    def get(self, request):
+        organization = get_single_user_organization(request.user)
+        site = get_site_by_organization(organization)
+        return redirect('{protocol}://{domain}{page}'.format(
+            protocol='https' if request.is_secure() else 'http',
+            domain=site.domain,  # This don't will redirect to the Tahoe domain. Custom domains are not supported yet.
+            page=reverse('site_unavailable'),
+        ))

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -228,6 +228,8 @@ if True:  # if: settings.FEATURES.get('CERTIFICATES_HTML_VIEW'):
             certificates_list_handler, name='certificates_list_handler')
     ]
 
+urlpatterns.append(url(r'^', include('cms.djangoapps.appsembler_tiers.urls')))
+
 # Maintenance Dashboard
 urlpatterns.append(url(r'^maintenance/', include('maintenance.urls', namespace='maintenance')))
 

--- a/common/test/appsembler/edx-theme-codebase/customer_specific/lms/templates/site-unavailable.html
+++ b/common/test/appsembler/edx-theme-codebase/customer_specific/lms/templates/site-unavailable.html
@@ -1,0 +1,4 @@
+## mako
+<%! from openedx.core.djangoapps.appsembler.sites.utils import get_current_organization %>
+
+The trial site of ${get_current_organization().name} has expired.

--- a/lms/djangoapps/appsembler_tiers/__init__.py
+++ b/lms/djangoapps/appsembler_tiers/__init__.py
@@ -1,0 +1,5 @@
+"""
+Views and urls related to the `tiers` app.
+
+This app gets redirects to the Studio `appsembler_tiers` app.
+"""

--- a/lms/djangoapps/appsembler_tiers/tests.py
+++ b/lms/djangoapps/appsembler_tiers/tests.py
@@ -1,0 +1,33 @@
+"""
+Tests for the tiers integration in the LMS.
+"""
+
+from __future__ import unicode_literals
+
+from django.urls import reverse
+from django.test import TestCase
+
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+from openedx.core.djangoapps.appsembler.multi_tenant_emails.tests.test_utils import with_organization_context
+
+
+class SiteUnavailableViewTest(TestCase):
+    """
+    Unit tests for the Tiers views.
+    """
+
+    BLUE = 'blue2'
+
+    def setUp(self):
+        super(SiteUnavailableViewTest, self).setUp()
+        self.url = reverse('site_unavailable')
+
+    def test_site_unavailable_page(self):
+        """
+        Ensure trial expire page shows up with site information.
+        """
+        with with_organization_context(self.BLUE):
+            response = self.client.get(self.url)
+            message = 'The trial site of {} has expired.'.format(self.BLUE)
+            assert message in response.content, 'Trial page works.'

--- a/lms/djangoapps/appsembler_tiers/urls.py
+++ b/lms/djangoapps/appsembler_tiers/urls.py
@@ -1,0 +1,13 @@
+"""
+URLs for the tiers app (LMS part).
+"""
+
+from django.conf.urls import url
+
+from lms.djangoapps.appsembler_tiers.views import (
+    SiteUnavailableView,
+)
+
+urlpatterns = [
+    url(r'^site-unavailable/$', SiteUnavailableView.as_view(), name='site_unavailable'),
+]

--- a/lms/djangoapps/appsembler_tiers/views.py
+++ b/lms/djangoapps/appsembler_tiers/views.py
@@ -11,4 +11,4 @@ class SiteUnavailableView(TemplateView):
 
     This works in the LMS and shows a message.
     """
-    template_name = 'site-unavailable.html'
+    template_name = 'static_templates/site-unavailable.html'

--- a/lms/djangoapps/appsembler_tiers/views.py
+++ b/lms/djangoapps/appsembler_tiers/views.py
@@ -1,0 +1,14 @@
+"""
+Views for the tiers app.
+"""
+
+from django.views.generic import TemplateView
+
+
+class SiteUnavailableView(TemplateView):
+    """
+    LMS Site Unavailable view.
+
+    This works in the LMS and shows a message.
+    """
+    template_name = 'site-unavailable.html'

--- a/lms/templates/static_templates/site-unavailable.html
+++ b/lms/templates/static_templates/site-unavailable.html
@@ -1,4 +1,5 @@
 ## mako
+## Appsembler: This file is specific to Tahoe and used by the SiteUnavailableView.
 <%! from openedx.core.djangoapps.appsembler.sites.utils import get_current_organization %>
 
 The trial site of ${get_current_organization().name} has expired.

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -7,6 +7,7 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib.admin import autodiscover as django_autodiscover
 from django.utils.translation import ugettext_lazy as _
+from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
 from rest_framework_swagger.views import get_swagger_view
 
@@ -1099,4 +1100,12 @@ urlpatterns += (
     url(r'^tahoe/api/',
         include('openedx.core.djangoapps.appsembler.api.urls',
                 namespace='tahoe-api')),
+)
+
+# Tahoe trial expired redirect
+urlpatterns += (
+    url(r'^site-unavailable/$',
+        TemplateView.as_view(
+            template_name='design-templates/pages/messages/site-expired.html'
+        )),
 )

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -7,7 +7,6 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib.admin import autodiscover as django_autodiscover
 from django.utils.translation import ugettext_lazy as _
-from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
 from rest_framework_swagger.views import get_swagger_view
 
@@ -141,6 +140,8 @@ urlpatterns = [
 
     url(r'^dashboard/', include('learner_dashboard.urls')),
     url(r'^api/experiments/', include('experiments.urls', namespace='api_experiments')),
+
+    url(r'^', include('lms.djangoapps.appsembler_tiers.urls')),
 
     # appsembler management console endpoint for student enrollment
     url(r'^appsembler/api/', include('openedx.core.djangoapps.appsembler.sites.urls')),
@@ -1100,12 +1101,4 @@ urlpatterns += (
     url(r'^tahoe/api/',
         include('openedx.core.djangoapps.appsembler.api.urls',
                 namespace='tahoe-api')),
-)
-
-# Tahoe trial expired redirect
-urlpatterns += (
-    url(r'^site-unavailable/$',
-        TemplateView.as_view(
-            template_name='design-templates/pages/messages/site-expired.html'
-        )),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -126,6 +126,7 @@ commands =
     bash scripts/upgrade_pysqlite.sh
     {env:TRAVIS_FIXES}
     pytest \
+        lms/djangoapps/appsembler_tiers \
         lms/djangoapps/certificates/tests/test_webview_appsembler_changes.py  \
         lms/djangoapps/course_api/ \
         lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py \

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ commands =
     {env:TRAVIS_FIXES}
     pytest \
         cms/djangoapps/appsembler \
+        cms/djangoapps/appsembler_tiers \
         cms/djangoapps/contentstore/tests/test_core_caching.py \
         cms/djangoapps/contentstore/tests/test_course_create_rerun.py \
         cms/djangoapps/contentstore/tests/test_course_listing.py \


### PR DESCRIPTION
In order to fix the issue reported by Maxi in (https://github.com/appsembler/edx-platform/pull/687#issuecomment-692160502), I've made two apps called `appsembler_tiers` one in the Studio and the other one in LMS. Both are simple apps intended to integrate the [`tiers`](https://github.com/appsembler/django-tiers) app more seamlessly with Tahoe Open edX.

### How it Works

 - The AMC admin (customer) logs into Studio.
 - The `tiers` app detects that the site has expired and redirects to `/site-unavailable/` page in Studio
 - But Studio isn't really site aware, hence theming is limited, therefore the Studio view redirects to the LMS `/site-unavailable/` url in LMS
 - The LMS site shows the themed `SiteUnavailableView`

### TODO
 - [x] Add tests and refactor if needed
 - [x] Add a blank template so the theme works for it
 - [x] Add tests for it in Studio

### Out of Scope Improvements
this PR does _not_ address any issues in the `tiers` app itself.

This is more of a maintenance and extension to the `tiers` app that we'll probably refactor into the Site Configuration service. However, we need this feature for the [Trial workflow initiative](https://appsembler.atlassian.net/wiki/spaces/PM/pages/300318809/Tahoe+-+Trial+and+Non-payment+Enforcement).

### Related Links
  - Same as #576 with re-work and tests. RED-953

  - https://github.com/appsembler/edx-configs/pull/845

  - https://github.com/appsembler/edx-platform/pull/576

  - https://github.com/appsembler/edx-theme-customers/pull/115