### PR TITLE
Fix devstack customer_themes static dir

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
@@ -31,7 +31,7 @@ def plugin_settings(settings):
         # LMS-generated files looks like: `appsembler-academy.tahoe.appsembler.com.css`
         customer_themes_dir = path.join(settings.COMPREHENSIVE_THEME_DIRS[0], 'customer_themes')
         if path.isdir(customer_themes_dir):
-            settings.STATICFILES_DIRS.insert(0, customer_themes_dir)
+            settings.STATICFILES_DIRS.insert(0, ('customer_themes', customer_themes_dir))
 
     # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
     # from the redirect mechanics.


### PR DESCRIPTION
Set the customer_themes static dir prefix for devstack (no S3) customer theme file storage to match expectation in SiteConfiguration model method

Resolves issue where template code is required to check for `settings.USE_S3_FOR_CUSTOMER_THEMES` to know the correct static path prefix for the customer CSS file.  After this change, they will be stored at `/static/customer_themes/foo.css` regardless of whether storage is S3 or staticfiles directory.