### PR TITLE
Add course id to multi-course enrollment APIs

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/tests/test_enrollment_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_enrollment_api.py
@@ -265,7 +265,6 @@ class EnrollmentApiPostTest(BaseEnrollmentApiTestCase):
             if rec['identifier'] in new_users_emails:
                 assert CourseEnrollmentAllowed.objects.filter(
                     email=rec['identifier']).exists()
-
                 assert rec['before'] == dict(enrollment=False,
                                              auto_enroll=False,
                                              user=False,
@@ -307,6 +306,8 @@ class EnrollmentApiPostTest(BaseEnrollmentApiTestCase):
         results = response.data['results']
         assert CourseEnrollmentAllowed.objects.count() == len(self.my_course_overviews)
         assert len(results) == len(self.my_course_overviews), 'Ensure result from all courses are returned'
+        assert results[0]['course'] == str(self.my_course_overviews[0].id), 'Flag on: Course ID should be in results'
+        assert results[1]['course'] == str(self.my_course_overviews[1].id), 'Flag on: Course ID should be in results'
 
     def test_enroll_learner_in_two_courses_with_bug(self):
         """
@@ -331,6 +332,7 @@ class EnrollmentApiPostTest(BaseEnrollmentApiTestCase):
         results = response.data['results']
         assert CourseEnrollmentAllowed.objects.count() == len(self.my_course_overviews)
         assert len(results) == 1, 'Ensure the flag preserves the original bug in results'
+        assert 'course' not in results[0], 'Flag is off: Course ID should NOT be returned in results'
 
     def test_enroll_with_other_site_course(self):
 

--- a/openedx/core/djangoapps/appsembler/api/v1/api.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/api.py
@@ -14,6 +14,7 @@ from lms.djangoapps.instructor.views.tools import get_student_from_identifier
 from openedx.core.djangoapps.appsembler.api.sites import (
     get_site_for_course
 )
+from openedx.core.djangoapps.appsembler.api.v1.waffle import FIX_ENROLLMENT_RESULTS_BUG
 
 from student.models import (
     ALLOWEDTOENROLL_TO_ENROLLED,
@@ -138,11 +139,14 @@ def enroll_learners_in_course(course_id, identifiers, enroll_func, **kwargs):
             ManualEnrollmentAudit.create_manual_enrollment_audit(
                 request_user, email, state_transition, reason, enrollment_obj, role
             )
-            results.append({
+            result = {
                 'identifier': identifier,
                 'before': before.to_dict(),
                 'after': after.to_dict(),
-            })
+            }
+            if FIX_ENROLLMENT_RESULTS_BUG.is_enabled():  # TODO: RED-1387 Clean up after release
+                result['course'] = str(course_id)
+            results.append(result)
     return results
 
 
@@ -208,9 +212,12 @@ def unenroll_learners_in_course(course_id, identifiers, unenroll_func, **kwargs)
             ManualEnrollmentAudit.create_manual_enrollment_audit(
                 request_user, email, state_transition, reason, enrollment_obj, role
             )
-            results.append({
+            result = {
                 'identifier': identifier,
                 'before': before.to_dict(),
                 'after': after.to_dict(),
-            })
+            }
+            if FIX_ENROLLMENT_RESULTS_BUG.is_enabled():  # TODO: RED-1387 Clean up after release
+                result['course'] = str(course_id)
+            results.append(result)
     return results

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -366,7 +366,7 @@ class EnrollmentViewSet(TahoeAuthMixin, viewsets.ModelViewSet):
                         else:
                             email_params = {}
 
-                        if not FIX_ENROLLMENT_RESULTS_BUG.is_enabled():
+                        if not FIX_ENROLLMENT_RESULTS_BUG.is_enabled():  # TODO: RED-1387 Clean up after release
                             # RED-1386: Preserve the original bug behaviour and put it behind a feature flag to
                             # decouple deployment from release.
                             results = []


### PR DESCRIPTION
Fixed for the Unenrollment API RED-35. Adding more `course` to the results list in response.

## Bug
The results list doesn't mention which course is which, just the identifier. This pull request fixes it.
```
$ curl -X POST -s https://omarrustici.staging-tahoe.appsembler.com/tahoe/api/v1/enrollments/ \
     -H "Content-Type: application/json" \
     -d@/edx/src/tahoe-api.json
{
  action: "enroll",
  courses: [
    "course-v1:omarrustici+omarrustici+2020",
    "course-v1:omarrustici+Hello+Hello2",
  ],
  email_learners: false,
  results: [
    {
      identifier: "robot+test+54@example.com",
      after: {
        enrollment: false,
        auto_enroll: true,
        user: false,
        allowed: true,
      },
      before: {
        enrollment: false,
        auto_enroll: true,
        user: false,
        allowed: true,
      },
    },
    {
      identifier: "robot+test+54@example.com",
      after: {
        enrollment: false,
        auto_enroll: true,
        user: false,
        allowed: true,
      },
      before: {
        enrollment: false,
        auto_enroll: true,
        user: false,
        allowed: true,
      },
    },
  ],
  auto_enroll: true,
}
```

```javascript
// tahoe-api.json
{
  "action": "enroll",
  "courses": [
    "course-v1:omarrustici+omarrustici+2020",
    "course-v1:omarrustici+Hello+Hello2"
  ],
  "identifiers": [
    "robot+test+54@example.com"
  ],
  "auto_enroll": true
}
```