### PR TITLE
Trial: Studio /site-unavailable/ view has own template

### DIFF
--- a/cms/djangoapps/appsembler_tiers/tests.py
+++ b/cms/djangoapps/appsembler_tiers/tests.py
@@ -14,7 +14,7 @@ from openedx.core.djangoapps.appsembler.multi_tenant_emails.tests.test_utils imp
 )
 
 
-class SiteUnavailableRedirectViewTest(TestCase):
+class SiteUnavailableStudioViewTest(TestCase):
     """
     Unit tests for the Tiers views.
     """
@@ -23,7 +23,7 @@ class SiteUnavailableRedirectViewTest(TestCase):
     PASSWORD = 'xyz'
 
     def setUp(self):
-        super(SiteUnavailableRedirectViewTest, self).setUp()
+        super(SiteUnavailableStudioViewTest, self).setUp()
         self.url = reverse('site_unavailable')
 
         with override_settings(DEFAULT_SITE_THEME='edx-theme-codebase'):
@@ -32,7 +32,7 @@ class SiteUnavailableRedirectViewTest(TestCase):
 
     def test_site_unavailable_page_non_logged_in(self):
         """
-        The trial page needs a logged in user.
+        The trial page needs a logged in user because Studio isn't multi-site aware.
         """
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_302_FOUND, response.content
@@ -42,7 +42,7 @@ class SiteUnavailableRedirectViewTest(TestCase):
         """
         Ensure trial expire page shows up with site information.
         """
-        assert self.client.login(username=self.admin.username, password=self.PASSWORD)
+        assert self.client.login(username=self.admin.username, password=self.PASSWORD), 'Admin should log in'
         response = self.client.get(self.url)
-        assert response.status_code == status.HTTP_302_FOUND, response.content
-        assert response['Location'] == 'http://blue2/site-unavailable/', response.content
+        message = 'The trial site of {} has expired.'.format(self.BLUE)
+        assert message in response.content, 'Trial page works.'

--- a/cms/djangoapps/appsembler_tiers/views.py
+++ b/cms/djangoapps/appsembler_tiers/views.py
@@ -3,28 +3,25 @@ Studio views for the tiers app.
 """
 
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import redirect
-from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.views.generic import View
+from django.views.generic import TemplateView
 
-from openedx.core.djangoapps.appsembler.sites.utils import (
-    get_site_by_organization,
-    get_single_user_organization,
-)
+from openedx.core.djangoapps.appsembler.sites.utils import get_single_user_organization
 
 
-class SiteUnavailableRedirectView(View):
+class SiteUnavailableRedirectView(TemplateView):
     """
-    Studio view to redirect to the LMS view (above).
+    Studio Site Unavailable view.
+
+    This works in the Studio and shows a message.
     """
+    template_name = 'site-unavailable.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(SiteUnavailableRedirectView, self).get_context_data(**kwargs)
+        context['organization'] = get_single_user_organization(self.request.user)
+        return context
 
     @method_decorator(login_required)
-    def get(self, request):
-        organization = get_single_user_organization(request.user)
-        site = get_site_by_organization(organization)
-        return redirect('{protocol}://{domain}{page}'.format(
-            protocol='https' if request.is_secure() else 'http',
-            domain=site.domain,  # This don't will redirect to the Tahoe domain. Custom domains are not supported yet.
-            page=reverse('site_unavailable'),
-        ))
+    def get(self, request, *args, **kwargs):
+        return super(SiteUnavailableRedirectView, self).get(request, *args, **kwargs)

--- a/cms/templates/site-unavailable.html
+++ b/cms/templates/site-unavailable.html
@@ -1,0 +1,4 @@
+## mako
+## Appsembler: This file is specific to Tahoe and used by the Studio SiteUnavailableView.
+
+The trial site of ${organization.name} has expired.


### PR DESCRIPTION
RED-953. Fixes to make **Option 1** to display the message in Studio instead of redirecting to LMS:

> Option 1, is that we create a template (and a view) in CMS that simply says
> 
> “Your site has expired, please contact us”
> 
> The downside it will show (like Studio) Appsembler logo, while the template you’ve created in LMS shows the customer logo.
> 
> Is there any reason why we chose to display the message inside LMS? I see that Option 1 is totally valid.

Why? [See the Jira card comment](https://appsembler.atlassian.net/browse/RED-953?focusedCommentId=28015).