### PR TITLE
(WIP) multi-tenant configs for set_user_info_cookie SESSION_COOKIE_DOMAIN

### DIFF
--- a/common/djangoapps/student/cookies.py
+++ b/common/djangoapps/student/cookies.py
@@ -14,6 +14,7 @@ from django.dispatch import Signal
 from django.utils.http import cookie_date
 
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from student.models import CourseEnrollment
 
 CREATE_LOGON_COOKIE = Signal(providing_args=['user', 'response'])
@@ -30,10 +31,12 @@ def standard_cookie_settings(request):
         expires_time = time.time() + max_age
         expires = cookie_date(expires_time)
 
+    domain = configuration_helpers.get_value('SESSION_COOKIE_DOMAIN') or settings.SESSION_COOKIE_DOMAIN
+
     cookie_settings = {
         'max_age': max_age,
         'expires': expires,
-        'domain': settings.SESSION_COOKIE_DOMAIN,
+        'domain': domain,
         'path': '/',
         'httponly': None,
     }

--- a/common/djangoapps/student/tests/test_cookies.py
+++ b/common/djangoapps/student/tests/test_cookies.py
@@ -57,3 +57,6 @@ class CookieTests(SharedModuleStoreTestCase):
         }
 
         self.assertDictEqual(actual, expected)
+
+    @skipIf(settings.ROOT_URLCONF == 'lms.urls', '')
+    def test_multi_site_cookie_domain(self):


### PR DESCRIPTION
See: [Marketing site integration demo](https://appsembler.atlassian.net/wiki/spaces/RT/blog/2020/09/29/899776541/Marketing+site+integration+demo).