### PR TITLE
RED-1438 fix invalidIdentifier for usernames in EnrollmentAPI

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/v1/api.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/api.py
@@ -56,7 +56,7 @@ def enrollment_learners_context(identifiers):
             email = user.email
             language = get_user_email_language(user)
 
-        yield user, email, identifier, language
+        yield user, identifier, email, language
 
 
 def enroll_learners_in_course(course_id, identifiers, enroll_func, **kwargs):


### PR DESCRIPTION
The bug was introduced by #660 in which that providing a username broke the API and prevented enrollment. The issue was with the `enrollment_learners_context` implementation.

See the customer HelpScout thread in RED-1438 for detailed debugging information.