### PR TITLE
RED-1464: Add UserStanding admin for CSMs on main site

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
@@ -96,7 +96,13 @@ def plugin_settings(settings):
 
     # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
     # from the redirect mechanics.
-    settings.MAIN_SITE_REDIRECT_WHITELIST = ['api', 'admin', 'oauth', 'status', '/heartbeat']
+    settings.MAIN_SITE_REDIRECT_WHITELIST = [
+        'api',
+        'admin',
+        'oauth',
+        'status',
+        '/heartbeat',
+    ]
 
     settings.USE_S3_FOR_CUSTOMER_THEMES = True
 

--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
@@ -102,6 +102,8 @@ def plugin_settings(settings):
         'oauth',
         'status',
         '/heartbeat',
+        '/accounts/manage_user_standing',
+        '/accounts/disable_account_ajax',
     ]
 
     settings.USE_S3_FOR_CUSTOMER_THEMES = True


### PR DESCRIPTION
To avoid having them go to the redirect mess of appsembler.com/tahoe/. This PR enables an ugly but very useful CSM tool on https://staging-tahoe.appsembler.com/accounts/manage_user_standing:


Note: I've included a separate commit for reformat to make future git diffs nicer.
See the related Esme issue: RED-1464.

### TODO
 - [x] Document the tool for CSMs
 - [x] Conclude the issue on RED-1464 with Esme

### Screenshot
![image](https://user-images.githubusercontent.com/645156/95780437-91951a00-0cd4-11eb-8837-53390bcb0cb5.png)


