### PR TITLE
Add Indonesian lang (DHIS2 running Tahoe as standalone needs it)

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -47,7 +47,7 @@ locales:
     # - hr  # Croatian
     # - hu  # Hungarian
     # - hy_AM  # Armenian (Armenia)
-    # - id  # Indonesian
+    - id  # Indonesian (not supported in Tahoe SaaS, don't add to dark langs)
     # - it_IT  # Italian (Italy)
     - ja_JP  # Japanese (Japan)
     # - kk_KZ  # Kazakh (Kazakhstan)


### PR DESCRIPTION
Not supported in SaaS product so don't add to Dark Lang config