### PR TITLE
RED-1498: cherry-pick fixed from anders-juniper-leeroy-jenkins

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/routers.py
+++ b/openedx/core/djangoapps/appsembler/sites/routers.py
@@ -26,7 +26,7 @@ class TiersDbRouter(object):
         """
         if obj1._meta.app_label == 'tiers' or \
            obj2._meta.app_label == 'tiers':
-                return True
+            return True
         return None
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):

--- a/openedx/core/djangoapps/appsembler/sites/routers.py
+++ b/openedx/core/djangoapps/appsembler/sites/routers.py
@@ -1,9 +1,14 @@
+"""
+Database routers for Tiers app.
+"""
+
 
 class TiersDbRouter(object):
     """
     A router to control all database operations on models in the
     tiers application.
     """
+
     def db_for_read(self, model, **hints):
         """
         Attempts to read tiers models go to tiers db.
@@ -24,8 +29,7 @@ class TiersDbRouter(object):
         """
         Allow relations if a model in the tiers app is involved.
         """
-        if obj1._meta.app_label == 'tiers' or \
-           obj2._meta.app_label == 'tiers':
+        if obj1._meta.app_label == 'tiers' or obj2._meta.app_label == 'tiers':
             return True
         return None
 

--- a/openedx/core/lib/api/api_key_permissions.py
+++ b/openedx/core/lib/api/api_key_permissions.py
@@ -4,6 +4,7 @@ Appsembler: Module to have `is_request_has_valid_api_key` to break circular depe
 
 from django.conf import settings
 
+from edx_django_utils.monitoring import set_custom_metric
 from openedx.core.lib.log_utils import audit_log
 
 
@@ -24,6 +25,7 @@ def is_request_has_valid_api_key(request):
         audit_log("ApiKeyHeaderPermission used",
                   path=request.path,
                   ip=request.META.get("REMOTE_ADDR"))
+        set_custom_metric('deprecated_api_key_header', True)
         return True
 
     return False

--- a/openedx/core/lib/api/permissions.py
+++ b/openedx/core/lib/api/permissions.py
@@ -33,7 +33,6 @@ class ApiKeyHeaderPermission(permissions.BasePermission):
         the X-Edx-Api-Key HTTP header is present in the request and
         matches the setting.
 
-        """
         Appsembler: Actual implementation is now moved to
                     `is_request_has_valid_api_key` to break circular
                     dependency.

--- a/openedx/core/lib/api/permissions.py
+++ b/openedx/core/lib/api/permissions.py
@@ -37,7 +37,6 @@ class ApiKeyHeaderPermission(permissions.BasePermission):
                     `is_request_has_valid_api_key` to break circular
                     dependency.
         """
-        set_custom_metric('deprecated_api_key_header', True)
         return is_request_has_valid_api_key(request)
 
 

--- a/openedx/core/lib/api/permissions.py
+++ b/openedx/core/lib/api/permissions.py
@@ -33,6 +33,7 @@ class ApiKeyHeaderPermission(permissions.BasePermission):
         the X-Edx-Api-Key HTTP header is present in the request and
         matches the setting.
 
+        """
         Appsembler: Actual implementation is now moved to
                     `is_request_has_valid_api_key` to break circular
                     dependency.

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -1,5 +1,4 @@
 django-extensions==1.5.9
-libsass==0.11.1
 python-intercom==0.2.13
 raven==6.10.0
 django-anymail==5.0

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -3,7 +3,7 @@ libsass==0.11.1
 python-intercom==0.2.13
 raven==6.10.0
 django-anymail==5.0
-django-tiers==0.2.1
+django-tiers==0.2.2
 dj-database-url==0.4.2
 psycopg2-binary==2.8.3
 django-compat==1.0.14

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -1,5 +1,5 @@
 django-extensions==1.5.9
-python-intercom==0.2.13
+python-intercom==3.1.0
 raven==6.10.0
 django-anymail==5.0
 django-tiers==0.2.2


### PR DESCRIPTION
RED-1498.

@thraxil I've gone through the commits in the `anders-juniper-leeroy-jenkins` branch and found needed ones for the `appsembler/juniper-upgrade` branch.

I've cherry-picked required ones and wrote some notes:

```
$ git log --oneline --author=anders master..anders-juniper-leeroy-jenkins
```

- b5cae0f52c working on getting tox/travis working: **not sure how to pick it**
- 420af0df87 pep8 fixes: **picked**
- ce910bbf03 update python-interco: **picked**
- 8a8aba0de2 remove libsass double requirement: **picked**
- b2d3cd15f4 use python3.8 for travis environment: **now reverting back to 3.5**
- 0d8d2de142 update tox environments: **not sure how to pick it**
- 540b500d47 run travis on this branch: **replaced with 8fc7b6e43**
- 4c5158a495 juniper merge: **ignored**
- 1dc7ee23ce ironwood merge: **ignored**
- ebdb5ea75f Merge branch 'appsembler/tahoe/develop' into appsembler/tahoe/master: **ignored**
- 4e5824d4c3 bump django-tiers to 0.1.0: **Now 0.2.2**
- 1be2f8684c honeycomb setup (celery): **Not needed. See:** https://github.com/appsembler/edx-platform/blob/89f12c9b85723cb0918735db17e299814d47d43c/openedx/core/djangoapps/appsembler/settings/settings/production_common.py#L92-L94

