### PR TITLE
display job names in github/travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,17 +31,18 @@ env:
     # Avoid caching edx-platform's entry_points
     - TRAVIS_FIXES="pip install -r requirements/edx/local.in"
     - BOTO_CONFIG="/etc/nonexistent.cfg"
-  jobs:
-    - TOXENV=pep8
-    - TOXENV=common-minimal
-    - TOXENV=common
-    - TOXENV=lms-1
-    - TOXENV=lms-2
-    - TOXENV=mte
-    - TOXENV=studio
 
-script:
-  - tox $ARGS
+- jobs:
+  include:
+  - name: pep8
+  - name: common-minimal
+  - name: common
+  - name: lms-1
+  - name: lms-2
+  - name: mte
+  - name: studio
+
+script: tox -e $TRAVIS_JOB_NAME
 
 branches:
   # Reduce our TravisCI usage by skipping all pull request branches to reduce effect on the environment (earth),


### PR DESCRIPTION
Clicking on the travis build icon 🟡 shows a list of jobs in GitHub but without clear names. This pr should puts names on the table:

<kbd>![image](https://user-images.githubusercontent.com/645156/97955851-47c1c000-1db8-11eb-80c6-569859140e32.png)</kbd>
