### PR TITLE
RED-1457: Display activation links in /admin

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -5,10 +5,18 @@ from django.contrib import admin
 from django.contrib.admin.sites import NotRegistered
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
+from organizations.models import Organization
+
+from openedx.core.djangoapps.appsembler.sites.utils import (
+    get_single_user_organization,
+    get_site_by_organization,
+)
 from openedx.core.djangoapps.waffle_utils import WaffleSwitch
 from openedx.core.lib.courses import clean_course_id
 from student import STUDENT_WAFFLE_NAMESPACE
@@ -261,8 +269,59 @@ class CourseEnrollmentAllowedAdmin(admin.ModelAdmin):
         model = CourseEnrollmentAllowed
 
 
+@admin.register(Registration)
+class RegistrationAdmin(admin.ModelAdmin):
+    """ Admin interface for the Registration model. """
+    list_display = ('username', 'email', 'organization', 'activation_link',)
+    search_fields = ('user__email', 'user__username', 'user__organizations__name',)
+
+    def username(self, obj):
+        """ Show the username. """
+        return obj.user.username
+
+    def email(self, obj):
+        """ Show the user email. """
+        return obj.user.email
+
+    def organization(self, obj):
+        """ Show the organization name. """
+        try:
+            org = get_single_user_organization(obj.user)
+        except Organization.DoesNotExist:
+            return None
+
+        return org.short_name
+
+    def activation_link(self, obj):
+        """ Display the activation link and allow copying it. """
+        if obj.user.is_active:
+            return 'Learner is active.'
+
+        try:
+            organization = get_single_user_organization(obj.user)
+            site = get_site_by_organization(organization)
+        except Organization.DoesNotExist:
+            return 'Error: missing organization.'
+
+        link = reverse('activate', kwargs={'key': obj.activation_key})
+
+        return format_html(
+            """ <a href="//{domain}{link}"
+                   onclick="alert('Do not click on the link. {title}'); return false;"
+                   title="{title}">
+                   Email confirmation link (copy it)
+                </a>
+            """,
+            domain=site.domain,
+            link=link,
+            title='Copy the link and send it to learner.'
+        )
+
+    class Meta(object):
+        model = Registration
+
+
 admin.site.register(UserTestGroup)
-admin.site.register(Registration)
 admin.site.register(PendingNameChange)
 admin.site.register(DashboardConfiguration, ConfigurationModelAdmin)
 admin.site.register(RegistrationCookieConfiguration, ConfigurationModelAdmin)

--- a/common/djangoapps/student/tests/test_tahoe_admin.py
+++ b/common/djangoapps/student/tests/test_tahoe_admin.py
@@ -1,0 +1,43 @@
+"""
+Tests for customization in the admin.py for Tahoe.
+"""
+from mock import patch, Mock
+
+from organizations.models import Organization
+from student.admin import RegistrationAdmin
+
+
+@patch('student.admin.get_single_user_organization', Mock(side_effect=Organization.DoesNotExist))
+def test_activation_link_no_org():
+    """
+    Missing organizations are handled gracefully.
+    """
+    registration = Mock(user=Mock(is_active=False))
+    admin = RegistrationAdmin(Mock(), Mock())
+    link = admin.activation_link(registration)
+    assert link == 'Error: missing organization.'
+
+
+def test_activation_link_learner_is_active():
+    """
+    Don't show the link for active learners.
+    """
+    registration = Mock(user=Mock(is_active=True))
+    admin = RegistrationAdmin(Mock(), Mock())
+    link = admin.activation_link(registration)
+    assert link == 'Learner is active.'
+
+
+@patch('student.admin.get_single_user_organization', Mock())
+@patch('student.admin.get_site_by_organization', Mock(return_value=Mock(domain='somesite.org')))
+def test_activation_link():
+    """
+    The link prints well and only for copying.
+    """
+    registration = Mock(user=Mock(is_active=False), activation_key='xyz')
+    admin = RegistrationAdmin(Mock(), Mock())
+
+    link = admin.activation_link(registration)
+    assert '//somesite.org/activate/xyz' in link
+    assert 'return false;' in link, 'Should prevent clicking'
+    assert 'Email confirmation link' in link

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,6 @@ commands =
     {env:TRAVIS_FIXES}
     pytest \
         common/djangoapps/student/ \
-        common/djangoapps/student/tests/test_activate_account.py \
         common/djangoapps/util/tests/test_milestones_helpers.py \
         common/djangoapps/xblock_django/ \
         common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py \


### PR DESCRIPTION
RED-1457. In LMS/Studio `/admin` now we have a nicer admin:

![image](https://user-images.githubusercontent.com/645156/98666426-1324aa00-235e-11eb-9f36-60f4bdbf9133.png)
