### PR TITLE
Revert "speeding up travis builds; docker and remove sudo"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,22 @@
-dist: focal
 language: python
-
-addons:
-  apt:
-    packages:
-      - python-dev
-      - libxml2-dev
-      - libxmlsec1-dev
-
 python:
-  - 3.5
-
-git:
-  depth: false
-
+  - "3.5"
 
 services:
   - mongodb
+
+node_js: 6
 
 cache:
   directories:
     - $HOME/edxapp_toxenv/
   pip: true
+  npm: true
+
+before_install:
+  - sudo rm -f /etc/boto.cfg
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install python-dev libxml2-dev libxmlsec1-dev
 
 install:
   - pip install tox
@@ -30,7 +25,6 @@ env:
   global:
     # Avoid caching edx-platform's entry_points
     - TRAVIS_FIXES="pip install -r requirements/edx/local.in"
-    - BOTO_CONFIG="/etc/nonexistent.cfg"
 
 - jobs:
   include:


### PR DESCRIPTION
This reverts commit 6f2247c053edb5a6883077138d80739e1bdeb1fc (PR #716)

Travis stopped running after this PR was merged. Probably something was wrong in the configs.

If my guess is correct, this PR build probably won't run as well. The plan is to have future PRs working on `appsembler/juniper-upgrade`.