### PR TITLE
fix escaping on default index page

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -890,7 +890,7 @@ def _get_initial_page_elements():
                                                 "margin-top": "marg-t-5",
                                                 "margin-left": "marg-l-20",
                                                 "text-content": {
-                                                    "en": "You\u2019ll get to see how the Sample course is built and create your own courses."
+                                                    "en": "You'll get to see how the Sample course is built and create your own courses."
                                                 },
                                                 "font-family": "font--primary--regular",
                                                 "text-alignment": "text-align--center"
@@ -966,7 +966,7 @@ def _get_initial_page_elements():
                                                 "margin-top": "marg-t-5",
                                                 "margin-left": "marg-l-20",
                                                 "text-content": {
-                                                    "en": "In the Management Console, you\u2019ll define your site's look and feel and manage site-wide content (e.g. certificates, SSO, custom domain)."
+                                                    "en": "In the Management Console, you'll define your site's look and feel and manage site-wide content (e.g. certificates, SSO, custom domain)."
                                                 },
                                                 "font-family": "font--primary--regular",
                                                 "text-alignment": "text-align--center"


### PR DESCRIPTION
Just a small fix on escaping of characters in default index page template.