### PR TITLE
juniper mte: migrate login.py hawthorn fixes

### DIFF
--- a/cms/djangoapps/appsembler_tiers/tests.py
+++ b/cms/djangoapps/appsembler_tiers/tests.py
@@ -34,7 +34,7 @@ class SiteUnavailableStudioViewTest(TestCase):
         """
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_302_FOUND, response.content
-        assert response['Location'] == '/signin?next=/site-unavailable/', response.content
+        assert response['Location'] == '/signin_redirect_to_lms?next=/site-unavailable/', response.content
 
     def test_site_unavailable_page(self):
         """
@@ -43,4 +43,4 @@ class SiteUnavailableStudioViewTest(TestCase):
         assert self.client.login(username=self.admin.username, password=self.PASSWORD), 'Admin should log in'
         response = self.client.get(self.url)
         message = 'The trial site of {} has expired.'.format(self.BLUE)
-        assert message in response.content, 'Trial page works.'
+        assert message in response.content.decode(response.charset), 'Trial page works.'

--- a/lms/djangoapps/appsembler_tiers/tests.py
+++ b/lms/djangoapps/appsembler_tiers/tests.py
@@ -25,5 +25,6 @@ class SiteUnavailableViewTest(TestCase):
         """
         with with_organization_context(self.BLUE):
             response = self.client.get(self.url)
+            body = response.content.decode(response.charset)
             message = 'The trial site of {} has expired.'.format(self.BLUE)
-            assert message in response.content, 'Trial page works.'
+            assert message in body, 'Trial page works.'

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/__init__.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/__init__.py
@@ -3,11 +3,3 @@ This app enabled Multi-Tenant Emails on Tahoe via migrations and other helpers.
 
 This app rolls back what the `common/djangoapps/database_fixups` does.
 """
-
-
-from django.conf import settings
-
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    def test_dummy():
-        """Dummy test function so tox succeeds."""
-        pass

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/__init__.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/__init__.py
@@ -6,6 +6,3 @@ This app exists solely to rollback what the `common/djangoapps/database_fixups` 
 
 from django.conf import settings
 from unittest import SkipTest
-
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise SkipTest('Fix MTE tests')

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_change_email.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_change_email.py
@@ -2,7 +2,7 @@
 Test cases to cover Accounts change email related to APPSEMBLER_MULTI_TENANT_EMAILS.
 """
 
-from unittest import skipUnless
+from unittest import skipUnless, skipIf
 import json
 
 from rest_framework import status
@@ -19,6 +19,7 @@ from .test_utils import with_organization_context, create_org_user
 
 @skip_unless_lms
 @skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This tests multi-tenancy')
+@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix in Juniper')
 class TestAccountsAPI(APITestCase):
     """
     Unit tests for the Accounts views.

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_deletion.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_deletion.py
@@ -3,10 +3,12 @@ Tests for the Account Deletion (Retirement) view.
 """
 
 from mock import patch
+from unittest import skipIf
 import pytest
 
 from django.urls import reverse
 from django.core import mail
+from django.conf import settings
 from rest_framework.test import APITestCase
 from rest_framework import status
 
@@ -24,6 +26,7 @@ from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (
 @lms_multi_tenant_test
 @patch.dict('django.conf.settings.FEATURES', {'SKIP_EMAIL_VALIDATION': True})
 @pytest.mark.usefixtures("setup_retirement_states")
+@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix in Juniper')
 class MultiTenantDeactivateLogoutViewTest(APITestCase):
     """
     Tests to ensure the DeactivateLogoutView works well with multi-tenant emails.

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_amc_signup.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_amc_signup.py
@@ -1,5 +1,5 @@
 import json
-from unittest import skipUnless
+from unittest import skipUnless, skipIf
 from mock import patch, Mock
 import uuid
 
@@ -16,6 +16,7 @@ from .test_utils import with_organization_context
 
 
 @skip_unless_lms
+@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix in Juniper')
 @skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This only tests multi-tenancy')
 @patch(
     # Patch to avoids error when importing from CMS

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_login_view.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_login_view.py
@@ -19,7 +19,7 @@ from .test_utils import with_organization_context, create_org_user
 @skip_unless_lms
 @override_settings(
     AUTHENTICATION_BACKENDS=(
-        # Match the Appsembler configuration in appsembler.settings..aws_common
+        # Match the Appsembler configuration in appsembler.settings..production_common
         'organizations.backends.DefaultSiteBackend',
         'organizations.backends.SiteMemberBackend',
         'organizations.backends.OrganizationMemberBackend',
@@ -28,9 +28,9 @@ from .test_utils import with_organization_context, create_org_user
 @skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This only tests multi-tenancy')
 class MultiTenantLoginTest(CacheIsolationTestCase):
     """
-    Test student.views.login_user() view.
+    Test user_authn's login_user() view.
 
-    This is similar to student.tests.test_login.LoginTest focuses on our multi-tenant tests including but not
+    This is similar to user_authn's LoginTest focuses on our multi-tenant tests including but not
     limited to `APPSEMBLER_MULTI_TENANT_EMAILS` i.e. these tests test
     the `organizations.backends.OrganizationMemberBackend` backend we rely on for Tahoe security.
     """
@@ -48,7 +48,7 @@ class MultiTenantLoginTest(CacheIsolationTestCase):
         self.client = Client()
         cache.clear()
         # Store the login url
-        self.url = reverse('login')
+        self.url = reverse('login_api')
 
     def test_auth_backends(self):
         """

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_registration_view.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_registration_view.py
@@ -1,5 +1,5 @@
 import json
-from unittest import skipUnless
+from unittest import skipUnless, skipIf
 
 from django.conf import settings
 from django.test.utils import override_settings
@@ -15,6 +15,7 @@ from .test_utils import with_organization_context
 @skip_unless_lms
 @override_settings(DEFAULT_SITE_THEME='edx-theme-codebase')
 @skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This only tests multi-tenancy')
+@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix in Juniper')
 class MultiTenantRegistrationViewTest(APITestCase):
     """
     Tests to ensure the registration end-point allow multi-tenant emails.

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_tahoe_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_tahoe_registration_api.py
@@ -3,7 +3,7 @@ Tests to ensure the Tahoe Registration API end-point allows multi-tenant emails.
 """
 
 from mock import patch
-from unittest import skipUnless
+from unittest import skipUnless, skipIf
 
 from django.conf import settings
 from django.urls import reverse
@@ -22,6 +22,7 @@ APPSEMBLER_API_VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.api.v1.views'
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.permission_classes', [])
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.throttle_classes', [])
 @skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This only tests multi-tenancy')
+@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix in Juniper')
 class MultiTenantRegistrationAPITest(APITestCase):
     """
     Tests to ensure the Tahoe Registration API end-point allow multi-tenant emails.


### PR DESCRIPTION
RED-1583. 

Ironwood moved the `login.py` file so a lot of changes were lost. The git command below shows those changes:

```$ git log --no-merges --oneline open-release/hawthorn.master..appsembler/tahoe/develop -- common/djangoapps/student/views/login.py```

- 964d842 Fix weird MultipleObjectsReturned for staff in two courses
- 3ca9487 Fixes RED-1365 and RED-1213: Allow course role staff to login in Studio
- e0ffc72 Multi-Tenant Emails: Fixes for Studio login
- 61230b4 Multi-Tenant Emails: New AMC Trial Sign-up
- 056b3ea fix MTE feature flag settings checks
- 7ec7f453c41ae541f9ce60259f24643484204243 Multi-Tenant Emails: Login fixes and tests (mostly just this commit)

### Scope
 - This PR does not address Studio fixes. Studio fixes are to be done in RED-1571.
 - This PR only fixes tests related to `login.py` file. Other views are out of the scope but will be fixed in the [Juniper MTE Epic](https://appsembler.atlassian.net/browse/RED-1582).