### PR TITLE
fix CMS context processors declaration

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -365,7 +365,7 @@ MAKO_TEMPLATE_DIRS_BASE = [
     CMS_ROOT / 'djangoapps' / 'pipeline_js' / 'templates',
 ]
 
-CONTEXT_PROCESSORS = (
+CONTEXT_PROCESSORS = [
     'django.template.context_processors.request',
     'django.template.context_processors.static',
     'django.contrib.messages.context_processors.messages',
@@ -373,7 +373,7 @@ CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',  # this is required for admin
     'django.template.context_processors.csrf',
     'help_tokens.context_processor',
-)
+]
 
 # Django templating
 TEMPLATES = [


### PR DESCRIPTION
This PR fixed RED-1642, intercom widget not being displayed on CMS. 

It took me a while to find the error, the intercome widget, along with Analytics and other widgets/js content is added through Appsembler's specific CONTEXT_PROCESSORS, we were declaring the CONTEXT_PROCESSORS as tuple instead of a list in the `cms/envs/common.py` file, that's why we weren't loading any of the custom CONTEXT_PROCESSORS that are added later in the code.