### PR TITLE
GitHub action to sync Juniper with Hawthorn

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,3 +15,14 @@ jobs:
           BRANCH_PREFIX: "appsembler/tahoe/develop"
           PULL_REQUEST_BRANCH: "appsembler/tahoe/master"
           PULL_REQUEST_REVIEWERS: "johnbaldwin melvinsoft OmarIthawi thraxil"
+  hawthorn-to-juniper-sync:
+    name: PullRequestAction
+    runs-on: ubuntu-latest
+    steps:
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@1.0.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_PREFIX: "appsembler/tahoe/develop"
+          PULL_REQUEST_BRANCH: "appsembler/juniper-upgrade"
+          PULL_REQUEST_REVIEWERS: "johnbaldwin melvinsoft OmarIthawi thraxil"


### PR DESCRIPTION
Same as the one that we use for production. This one saves us the manual pull request when we make Hawthorn updates.