### PR TITLE
juniper mte: enable and test_account_deletion.py

### DIFF
--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_deletion.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_account_deletion.py
@@ -2,13 +2,11 @@
 Tests for the Account Deletion (Retirement) view.
 """
 
-from mock import patch
-from unittest import skipIf
+from mock import patch, Mock
 import pytest
 
 from django.urls import reverse
 from django.core import mail
-from django.conf import settings
 from rest_framework.test import APITestCase
 from rest_framework import status
 
@@ -26,7 +24,10 @@ from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (
 @lms_multi_tenant_test
 @patch.dict('django.conf.settings.FEATURES', {'SKIP_EMAIL_VALIDATION': True})
 @pytest.mark.usefixtures("setup_retirement_states")
-@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix in Juniper')
+@patch(
+    'openedx.core.djangoapps.ace_common.templatetags.ace._get_google_analytics_tracking_url',
+    Mock(return_value='http://url.com/')
+)
 class MultiTenantDeactivateLogoutViewTest(APITestCase):
     """
     Tests to ensure the DeactivateLogoutView works well with multi-tenant emails.

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -55,7 +55,6 @@ def process_request(request):
     "reset password tests should only run in LMS"
 )
 @ddt.ddt
-@patch('student.forms.get_current_site', Mock(return_value=Mock(domain='example.com')))  # Appsembler: Fix broken tests.
 class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
     """
     Tests that clicking reset password sends email, and doesn't activate the user


### PR DESCRIPTION
RED-1470. Fixing more MTE tests, mostly just broken tests without the need for fixing the code itself.