### PR TITLE
setup for running tox within docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,63 +1,126 @@
-FROM ubuntu:16.04
+FROM ubuntu:focal as base
 
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+# Warning: This file is experimental.
 
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y \
-    apt-transport-https \
+# Install system requirements
+RUN apt-get update && \
+    # Global requirements
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes \
     build-essential \
-    gcc \
+    curl \
+    # If we don't need gcc, we should remove it.
     g++ \
-    gettext \
+    gcc \
     git \
     git-core \
-    gfortran \
-    golang \
-    graphviz \
-    graphviz-dev \
     language-pack-en \
-    libblas-dev \
-    liblapack-dev \
-    libatlas-base-dev \
     libfreetype6-dev \
-    libssl-dev \
-    libffi-dev \
-    libgeos-dev \
-    libjpeg8-dev \
-    libsqlite3-dev \
     libmysqlclient-dev \
-    libpng12-dev \
-    libpq-dev \
+    libssl-dev \
     libxml2-dev \
     libxmlsec1-dev \
     libxslt1-dev \
-    memcached \
-    mongodb \
-    openssl \
-    pkg-config \
-    python-apt \
-    python-dev \
-    python-mysqldb \
-    python-cryptography \
-    python-pip \
-    python-setuptools \
-    python-virtualenv \
-    software-properties-common \
     swig \
-  && pip install setuptools -U \
-  && pip install virtualenv \
-  && pip install more-itertools==5.0.0 \
-  && pip install tox
+    # openedx requirements
+    gettext \
+    gfortran \
+    graphviz \
+    libffi-dev \
+    libfreetype6-dev \
+    libgeos-dev \
+    libgraphviz-dev \
+    libjpeg8-dev \
+    liblapack-dev \
+    libpng-dev \
+    libsqlite3-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libxslt1-dev \
+    ntp \
+    pkg-config \
+    python3-dev \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
 
-# COPY nodesource.gpg.key /tmp/nodesource.gpg.key
-# RUN apt-key add /tmp/nodesource.gpg.key \
-#   && echo 'deb https://deb.nodesource.com/node_8.x xenial main' > /etc/apt/sources.list.d/nodesource.list \
-#   && echo 'deb-src https://deb.nodesource.com/node_8.x xenial main' >> /etc/apt/sources.list.d/nodesource.list \
-#   && apt-get update \
-#   && apt-get install -y nodejs
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
-WORKDIR /app
-COPY . /app
+WORKDIR /edx/app/edxapp/edx-platform
 
-ENTRYPOINT ["/app/scripts/docker_tox.sh"]
+ENV PATH /edx/app/edxapp/nodeenv/bin:${PATH}
+ENV PATH ./node_modules/.bin:${PATH}
+ENV CONFIG_ROOT /edx/etc/
+ENV PATH /edx/app/edxapp/edx-platform/bin:${PATH}
+ENV SETTINGS production
+RUN mkdir -p /edx/etc/
+
+ENV VIRTUAL_ENV=/edx/app/edxapp/venvs/edxapp
+RUN python3.8 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install Python requirements
+COPY setup.py setup.py
+COPY common common
+COPY openedx openedx
+COPY lms lms
+COPY cms cms
+COPY requirements/pip.txt requirements/pip.txt
+COPY requirements/edx/base.txt requirements/edx/base.txt
+RUN pip install -r requirements/pip.txt
+RUN pip install -r requirements/edx/base.txt
+
+# Copy just JS requirements and install them.
+COPY package.json package.json
+COPY package-lock.json package-lock.json
+RUN nodeenv /edx/app/edxapp/nodeenv --node=12.11.1 --prebuilt
+RUN npm set progress=false && npm install
+
+ENV LMS_CFG /edx/etc/lms.yml
+ENV STUDIO_CFG /edx/etc/studio.yml
+COPY lms/devstack.yml /edx/etc/lms.yml
+COPY cms/devstack.yml /edx/etc/studio.yml
+
+# Copy over remaining code.
+# We do this as late as possible so that small changes to the repo don't bust
+# the requirements cache.
+COPY . .
+
+FROM base as lms
+ENV SERVICE_VARIANT lms
+ENV DJANGO_SETTINGS_MODULE lms.envs.production
+EXPOSE 8000
+CMD gunicorn -c /edx/app/edxapp/edx-platform/lms/docker_lms_gunicorn.py --name lms --bind=0.0.0.0:8000 --max-requests=1000 --access-logfile - lms.wsgi:application
+
+FROM lms as lms-newrelic
+RUN pip install newrelic
+CMD newrelic-admin run-program gunicorn -c /edx/app/edxapp/edx-platform/lms/docker_lms_gunicorn.py --name lms --bind=0.0.0.0:8000 --max-requests=1000 --access-logfile - lms.wsgi:application
+
+FROM lms as lms-devstack
+# TODO: This compiles static assets.
+# However, it's a bit of a hack, it's slow, and it's inefficient because makes the final Docker cache layer very large.
+# We ought to be able to this higher up in the Dockerfile, and do it the same for Prod and Devstack.
+RUN mkdir -p test_root/log
+ENV DJANGO_SETTINGS_MODULE ""
+RUN NO_PREREQ_INSTALL=1 paver update_assets lms --settings devstack_decentralized
+ENV DJANGO_SETTINGS_MODULE lms.envs.devstack_decentralized
+
+FROM base as studio
+ENV SERVICE_VARIANT cms
+ENV DJANGO_SETTINGS_MODULE cms.envs.production
+EXPOSE 8010
+CMD gunicorn -c /edx/app/edxapp/edx-platform/cms/docker_cms_gunicorn.py --name cms --bind=0.0.0.0:8010 --max-requests=1000 --access-logfile - cms.wsgi:application
+
+FROM studio as studio-newrelic
+RUN pip install newrelic
+CMD newrelic-admin run-program gunicorn -c /edx/app/edxapp/edx-platform/cms/docker_cms_gunicorn.py --name cms --bind=0.0.0.0:8010 --max-requests=1000 --access-logfile - cms.wsgi:application
+
+FROM studio as studio-devstack
+# TODO: This compiles static assets.
+# However, it's a bit of a hack, it's slow, and it's inefficient because makes the final Docker cache layer very large.
+# We ought to be able to this higher up in the Dockerfile, and do it the same for Prod and Devstack.
+RUN mkdir -p test_root/log
+ENV DJANGO_SETTINGS_MODULE ""
+RUN NO_PREREQ_INSTALL=1 paver update_assets cms --settings devstack_decentralized
+ENV DJANGO_SETTINGS_MODULE cms.envs.devstack_decentralized

--- a/Dockerfile.tox
+++ b/Dockerfile.tox
@@ -1,0 +1,5 @@
+FROM edxops/edxapp:latest
+RUN apt-get update \
+    && apt-get install -y \
+    mongodb
+WORKDIR /edx/app/edxapp/edx-platform

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,13 @@ upgrade: ## update the pip requirements files to use the latest releases satisfy
 
 .PHONY: docker-tox
 docker-tox:
-	docker build . -t edx-platform-tox
-	docker run edx-platform-tox
+	docker build .  -f Dockerfile.tox -t edx-platform-tox
+	docker run -it -e "NO_PYTHON_UNINSTALL=1" -e "PIP_INDEX_URL=https://pypi.python.org/simple" -e TERM \
+	-v `pwd`:/edx/app/edxapp/edx-platform:cached \
+	-v edxapp_lms_assets:/edx/var/edxapp/staticfiles/ \
+	-v edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules \
+	-v edxapp_toxenv:/root/edxapp_toxenv \
+	edx-platform-tox /edx/app/edxapp/devstack.sh /bin/bash /edx/app/edxapp/edx-platform/scripts/docker_tox.sh
 
 .PHONY: cloudbuild
 cloudbuild:


### PR DESCRIPTION
This adds a halfway decent setup for running the `tox` tests in a local docker container. This is nice if you don't want to install all the libraries and dependencies that you need to run `tox` directly (but you do have docker installed).

`make docker-tox` will take a while the first time it's run since it needs to pull the base image and build the tox environments. For me, that was somewhere around 20-30 minutes. It mounts a volume to store the tox environment though, so subsequent runs (as long as the pip requirements haven't changed) ought to be faster. For me, it's about 11 minutes to run the current set of tests.

The `Dockerfile` that was in the repo already was my first attempt at getting this setup working back in hawthorn. At the time, hawthorn upstream didn't include a `Dockerfile`. Juniper upstream still doesn't either. Upstream `master` now does though, so I've just replaced the `Dockerfile` here with the current upstream version. Then added `Dockerfile.tox` to just add the necessary `mongodb` package and capture any additional tweaks we need to make.

It's currently using `FROM edxops/edxapp:latest` as the base image. That eventually should probably change so we're using a pinned Juniper image and are protected against breaking changes. The base image is mostly just used to bring in the right system packages though and it shouldn't be that tight a coupling; `tox` installs whatever's specified in the checked out requirements. Right now, I'm honestly just impressed that the setup works at all and I'll take that as a win.

If someone is doing a lot of work on `edx-platform`, it's probably worth setting up everything locally so they can run the `tox` tests directly. However, that can be a lot of work so I think this is potentially a good intermediate setup between that and having to push to github to get Travis tests to run or setting up a full devstack.