### PR TITLE
[cherry-pick] Use site.domain instead of SITE_NAME

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -117,7 +117,7 @@ def send_password_reset_email_for_user(user, request, preferred_email=None):
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
         'reset_link': '{protocol}://{site}{link}?track=pwreset'.format(
             protocol='https' if request.is_secure() else 'http',
-            site=configuration_helpers.get_value('SITE_NAME', settings.SITE_NAME),
+            site=site.domain,
             link=reverse('password_reset_confirm', kwargs={
                 'uidb36': int_to_base36(user.id),
                 'token': default_token_generator.make_token(user),


### PR DESCRIPTION
RED-1591. Cherry-picks aaeaec12c1dcf02dca36b4f575aa8dd1ab9bc7ac for Juniper because it was lost due to merge conflicts. Same as https://github.com/appsembler/edx-platform/pull/383.

No tests unfortunately.