### PR TITLE
whitelist /usr/bin/echo for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ deps =
 whitelist_externals =
     /bin/bash
     /bin/echo
+    /usr/bin/echo
     /bin/tar
     /usr/bin/curl
 


### PR DESCRIPTION
eliminates warning messages in docker
