### PR TITLE
RED-1650: switch to main branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,5 @@ branches:
   # so `continuous-integration/travis-ci/push` shouldn't be built anymore.
   only:
     - /^appsembler\/(tahoe|hawthorn)\/(develop|master)$/
-    - appsembler/juniper-upgrade
+    - main
+


### PR DESCRIPTION
RED-1650 and the [`main` branch decision](https://appsembler.atlassian.net/wiki/spaces/JUP/pages/964100251/Decision+Juniper+branches+naming+for+Red+and+Black+Team).


### Notes

 - [x] I've created new `main` and `prod` and marked them as protected branches to avoid getting them deleted by accident
 - [x] I've removed the protection on and deleted the `appsembler/juniper-upgrade`. It was on 909b50dd2fb6f75960fa64e1ce1323918a25b314 which is now in both `main` and `prod` branches.
 - [x] I've updated the references of `appsembler/juniper-upgrade` to `main`
   * sync action from hawthorn: #743 
   * edx-configs for Juniper sandbox: https://github.com/appsembler/edx-configs/pull/969