### PR TITLE
Appsembler Apps Juniper Upgrade - Iniital appsembler_settings update

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
@@ -1,0 +1,57 @@
+"""Tests the Appsembler Apps settings modules
+"""
+import pytest
+from mock import patch
+
+from openedx.core.djangoapps.theming.helpers_dirs import Theme
+
+from openedx.core.djangoapps.appsembler.settings.settings import (
+    devstack_cms,
+    devstack_lms,
+    production_cms,
+    production_lms,
+)
+
+
+def mock_settings(settings):
+    settings.AUTH_TOKENS = {}
+    settings.QUEUE_VARIANT = 'fake-queue-variant'
+    settings.CELERY_QUEUES = {}
+    settings.ALTERNATE_QUEUE_ENVS = []
+    settings.ENV_TOKENS = {
+        'LMS_BASE': 'fake-lms-base',
+        'LMS_ROOT_URL': 'fake-lms-root-url',
+        'EMAIL_BACKEND': 'fake-email-backend',
+        'FEATURES': {}
+    }
+    settings.COMPREHENSIVE_THEME_DIRS = ['/path/to/nowhere']
+    settings.MAIN_SITE_REDIRECT_WHITELIST = []
+
+
+def test_devstack_cms(settings):
+    mock_settings(settings)
+    devstack_cms.plugin_settings(settings)
+
+
+def test_devstack_lms(settings):
+    mock_settings(settings)
+    devstack_lms.plugin_settings(settings)
+
+
+def test_production_cms(settings):
+    mock_settings(settings)
+    production_cms.plugin_settings(settings)
+
+
+@pytest.mark.parametrize('retval, additional_count', [(False, 0), (True, 1)])
+def test_production_lms(settings, retval, additional_count):
+    mock_settings(settings)
+    with patch('openedx.core.djangoapps.appsembler.settings.settings.production_lms.path.isdir',
+               return_value=retval):
+        with patch(
+            'openedx.core.djangoapps.theming.helpers_dirs.get_themes_unchecked',
+            return_value=[Theme('fake-theme', 'fake-theme', '.', '.')]
+        ):
+            expected_dir_len = len(settings.STATICFILES_DIRS) + additional_count
+            production_lms.plugin_settings(settings)
+            assert len(settings.STATICFILES_DIRS) == expected_dir_len

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
@@ -1,7 +1,9 @@
 """Tests the Appsembler Apps settings modules
 """
+
 import pytest
 from mock import patch
+from path import Path
 
 from openedx.core.djangoapps.theming.helpers_dirs import Theme
 
@@ -13,7 +15,22 @@ from openedx.core.djangoapps.appsembler.settings.settings import (
 )
 
 
-def mock_settings(settings):
+class FakeSettings:
+    pass
+
+
+def get_faked_settings():
+    settings = FakeSettings()
+
+    settings.INSTALLED_APPS = []
+    settings.FEATURES = {}
+    settings.AMC_APP_URL = []
+    settings.APPSEMBLER_FEATURES = {}
+    settings.STATICFILES_DIRS = []
+    settings.CACHES = {}
+    settings.ENABLE_COMPREHENSIVE_THEMING = True
+    settings.PROJECT_ROOT = Path('/tmp/')
+
     settings.AUTH_TOKENS = {}
     settings.QUEUE_VARIANT = 'fake-queue-variant'
     settings.CELERY_QUEUES = {}
@@ -26,26 +43,27 @@ def mock_settings(settings):
     }
     settings.COMPREHENSIVE_THEME_DIRS = ['/path/to/nowhere']
     settings.MAIN_SITE_REDIRECT_WHITELIST = []
+    return settings
 
 
-def test_devstack_cms(settings):
-    mock_settings(settings)
+def test_devstack_cms():
+    settings = get_faked_settings()
     devstack_cms.plugin_settings(settings)
 
 
-def test_devstack_lms(settings):
-    mock_settings(settings)
+def test_devstack_lms():
+    settings = get_faked_settings()
     devstack_lms.plugin_settings(settings)
 
 
-def test_production_cms(settings):
-    mock_settings(settings)
+def test_production_cms():
+    settings = get_faked_settings()
     production_cms.plugin_settings(settings)
 
 
 @pytest.mark.parametrize('retval, additional_count', [(False, 0), (True, 1)])
-def test_production_lms(settings, retval, additional_count):
-    mock_settings(settings)
+def test_production_lms(retval, additional_count):
+    settings = get_faked_settings()
     with patch('openedx.core.djangoapps.appsembler.settings.settings.production_lms.path.isdir',
                return_value=retval):
         with patch(

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_settings_config.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_settings_config.py
@@ -1,0 +1,18 @@
+"""Tests the SettingsConfig class
+
+"""
+from django.apps.registry import apps
+
+from openedx.core.djangoapps.appsembler.settings.apps import SettingsConfig
+
+
+def test_config():
+    """
+    Basic test to check that the app loads
+    """
+    app_name = 'openedx.core.djangoapps.appsembler.settings'
+    assert SettingsConfig.name == app_name
+    assert hasattr(SettingsConfig, 'plugin_app')
+    assert apps.is_installed(app_name)
+    app_config = apps.get_containing_app_config(app_name)
+    assert app_config

--- a/tox.ini
+++ b/tox.ini
@@ -192,3 +192,4 @@ deps =
     pycodestyle==2.3.1
 commands =
     pycodestyle .
+


### PR DESCRIPTION
In this commit, we add a couple of test modules:

1. `test_settings` tests each of the environment modules by calling the
`plugin_settings` function
2. `test_settings_config` tests that the `appsembler_settings` app loads


This is just a minimal set of testing for upgrade compatibility