### PR TITLE
Fix slow and bulky test failures on django views

### DIFF
--- a/lms/djangoapps/tests/test_tahoe_500_error.py
+++ b/lms/djangoapps/tests/test_tahoe_500_error.py
@@ -1,0 +1,42 @@
+"""
+Test case to address slow 500 error failures.
+"""
+
+import pytest
+
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_working_contact_page(client):
+    """
+    Sanity check to ensure contact page works.
+
+    If this test fails just pick another page like login.
+    """
+    url = reverse('contact')
+    response = client.get(url)
+    assert response.status_code == 200, response.content
+
+
+def test_failing_contact_page(client, capsys):
+    """
+    Ensure no repeated handling of exceptions showing in views tests failures.
+
+    Otherwise debugging test failures views means scrolling through thousands of error lines of the same error below:
+
+     - "During handling of the above exception, another exception occurred"
+
+    This test needs `pytest.mark.django_db` but removing it on purpose to simulate a broken test which results in an
+    HTTP 500 error.
+    """
+    url = reverse('contact')
+    with pytest.raises(Exception) as exception:
+        # Simulates a server-error
+        client.get(url)
+    assert 'Context is already bound to a template' not in str(exception), 'Avoid nested errors in server-error.html'
+    assert 'Database access not allowed, use the "django_db" mark' in str(exception)
+
+    captured = capsys.readouterr()
+    nested_errors_message = 'During handling of the above exception, another exception occurred:'
+    assert captured.count(nested_errors_message) == 0, 'No nested errors in server-error.html should happen'

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -71,7 +71,9 @@ if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
 # These are used by Django to render these error codes. Do not remove.
 # pylint: disable=invalid-name
 handler404 = static_template_view_views.render_404
-handler500 = static_template_view_views.render_500
+
+if settings.TAHOE_ENABLE_CUSTOM_ERROR_VIEW:
+    handler500 = static_template_view_views.render_500
 
 notification_prefs_urls = [
     url(r'^notification_prefs/enable/', notification_prefs_views.ajax_enable),

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -48,6 +48,8 @@ def plugin_settings(settings):
     # and fix test issues
     settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS = True
 
+    settings.TAHOE_ENABLE_CUSTOM_ERROR_VIEW = True  # Use the Django default error page during testing
+
     if not settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
         # TODO: Fix middlewares
         _middleware_list = list(settings.MIDDLEWARE)

--- a/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
@@ -20,6 +20,8 @@ def plugin_settings(settings):
     settings.TAHOE_SILENT_MISSING_CSS_CONFIG = True  # see ./common.py
     settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS = True  # see ./common.py
 
+    settings.TAHOE_ENABLE_CUSTOM_ERROR_VIEW = False  # see ./common.py
+
     if settings.FEATURES.get('APPSEMBLER_MULTI_TENANT_EMAILS', False):
         settings.INSTALLED_APPS += (
             'openedx.core.djangoapps.appsembler.multi_tenant_emails',


### PR DESCRIPTION
RED-1615. The same error is reproducible in `open-release/juniper.master` which is weird.

### TODO

 - [x] Figure out why `DEBUG = False` in tests. This unusual.
    * Apparently it's not a new thing in Django: https://stackoverflow.com/questions/7447134/how-do-you-set-debug-to-true-when-running-a-django-test