### PR TITLE
Fix slow and bulky test failures on Studio django views; encoding fix;

### DIFF
--- a/cms/djangoapps/appsembler/tests/__init__.py
+++ b/cms/djangoapps/appsembler/tests/__init__.py
@@ -7,8 +7,3 @@ a limitation when such modules depend on `cms` and `pytest` cannot figure that o
 This is likely a sign that there's a need to refactor those modules with cross-dependency, however
 it's not clear how to address that issue.
 """
-
-from django.conf import settings
-import unittest
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')

--- a/cms/djangoapps/appsembler/tests/test_appsembler_sites_tasks.py
+++ b/cms/djangoapps/appsembler/tests/test_appsembler_sites_tasks.py
@@ -2,7 +2,9 @@
 Tests for appsembler.sites.tasks.
 """
 import datetime
+import unittest
 
+from django.conf import settings
 from django.test import override_settings
 from organizations.models import UserOrganizationMapping
 from organizations.tests.factories import OrganizationFactory
@@ -28,6 +30,7 @@ IMPORT_SETTINGS = {
 
 
 @override_settings(**IMPORT_SETTINGS)
+@unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix stuck test')
 class ImportCourseOnSiteCreationTestCase(ModuleStoreTestCase):
     """
     Integration tests for the `import_course_on_site_creation` task.

--- a/cms/djangoapps/appsembler/tests/test_multi_tenant_with_invite.py
+++ b/cms/djangoapps/appsembler/tests/test_multi_tenant_with_invite.py
@@ -4,11 +4,12 @@ Tests for APPSEMBLER_MULTI_TENANT_EMAILS in Studio for course team invite.
 
 from mock import patch
 import json
+import unittest
 
-from django.contrib.auth.models import User
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import LibraryFactory
 
+from django.conf import settings
 from contentstore.views import course_team_handler
 from django.test import RequestFactory
 from django.urls import reverse
@@ -22,12 +23,10 @@ from openedx.core.djangoapps.appsembler.multi_tenant_emails.tests.test_utils imp
     create_org_user,
 )
 
-
 from student.roles import CourseCreatorRole, CourseAccessRole
 
-from student.tests.factories import UserFactory
 
-
+@unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix stuck test')
 @patch.dict('django.conf.settings.FEATURES', {'APPSEMBLER_MULTI_TENANT_EMAILS': True})
 @override_settings(DEFAULT_SITE_THEME='edx-theme-codebase')
 class MultiTenantStudioCourseTeamTestCase(ModuleStoreTestCase):

--- a/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
+++ b/cms/djangoapps/appsembler/tests/test_multi_tenant_with_login.py
@@ -18,8 +18,8 @@ from student.tests.factories import UserFactory
 
 
 @ddt.ddt
+@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'RED-1571: Refactor')
 @patch.dict('django.conf.settings.FEATURES', {'APPSEMBLER_MULTI_TENANT_EMAILS': True})
-@skipIf(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in CMS')
 class MultiTenantStudioLoginTestCase(TestCase):
     """
     Testing the APPSEMBLER_MULTI_TENANT_EMAILS feature when enabled in Studio.

--- a/cms/djangoapps/appsembler/tests/test_tahoe_cms_500_error.py
+++ b/cms/djangoapps/appsembler/tests/test_tahoe_cms_500_error.py
@@ -1,0 +1,42 @@
+"""
+Test case to address slow 500 error failures in the CMS.
+"""
+
+import pytest
+
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_working_studio_page(client):
+    """
+    Sanity check to ensure studio page works.
+
+    If this test fails just pick another page like login.
+    """
+    url = reverse('request_course_creator')
+    response = client.post(url)
+    assert response.status_code == 302, response.content  # Should redirect to login
+
+
+def test_failing_studio_page(client, capsys):
+    """
+    Ensure no repeated handling of exceptions showing in views tests failures.
+
+    Otherwise debugging test failures views means scrolling through thousands of error lines of the same error below:
+
+     - "During handling of the above exception, another exception occurred"
+
+    This test needs `pytest.mark.django_db` but removing it on purpose to simulate a broken test which results in an
+    HTTP 500 error.
+    """
+    url = reverse('request_course_creator')
+    with pytest.raises(Exception) as exception:
+        # Simulates a server-error
+        client.get(url)
+    assert 'Context is already bound to a template' not in str(exception), 'Avoid nested errors in server-error.html'
+    assert 'Database access not allowed, use the "django_db" mark' in str(exception)
+
+    captured = capsys.readouterr()
+    nested_errors_message = 'During handling of the above exception, another exception occurred:'
+    assert captured.count(nested_errors_message) == 0, 'No nested errors in server-error.html should happen'

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -31,7 +31,6 @@ if password_policy_compliance.should_enforce_compliance_on_login():
 # These are used by Django to render these error codes. Do not remove.
 # pylint: disable=invalid-name
 handler404 = contentstore.views.render_404
-handler500 = contentstore.views.render_500
 
 # Pattern to match a course key or a library key
 COURSELIKE_KEY_PATTERN = r'(?P<course_key_string>({}|{}))'.format(
@@ -279,8 +278,13 @@ urlpatterns.append(url(r'^template/(?P<template>.+)$', openedx.core.djangoapps.d
 # display error page templates, for testing purposes
 urlpatterns += [
     url(r'^404$', handler404),
-    url(r'^500$', handler500),
 ]
+
+if settings.TAHOE_ENABLE_CUSTOM_ERROR_VIEW:
+    handler500 = contentstore.views.render_500
+    urlpatterns += [
+        url(r'^500$', handler500),
+    ]
 
 # API docs.
 urlpatterns += make_docs_urls(api_info)

--- a/openedx/core/djangoapps/appsembler/analytics/context_processors.py
+++ b/openedx/core/djangoapps/appsembler/analytics/context_processors.py
@@ -16,7 +16,8 @@ def google_analytics(request):
     user = request.user
     # if user is created through AMC
     if user.is_authenticated and user_has_role(user, CourseCreatorRole()):
-        data['USER_EMAIL_HASH'] = hashlib.sha256(request.user.email).hexdigest()
+        email_hash = hashlib.sha256(request.user.email.encode('utf-8')).hexdigest()
+        data['USER_EMAIL_HASH'] = email_hash
 
     return data
 


### PR DESCRIPTION
RED-1616: Fix slow and bulky test failures on Studio django views. Same as #751.

### Changes
 - Refactor: Skipped tests individually in `cms/djangoapps/appsembler/tests` instead of whole module
 - Fix slow bulky 500 error failures to debug issues in @johnbaldwin's PR #746 
 - Found and fixed the issue in #746 which happened because of the sync with Hawthorn on #730 due to python 3 issues

### Bulky tests

What's a bulky test failures look like? [Go into this Travis log](https://travis-ci.com/github/appsembler/edx-platform/jobs/445819349).

![image](https://user-images.githubusercontent.com/645156/100075355-e6d65680-2e50-11eb-991a-8357d1d2b711.png)
