### PR TITLE
Fix almost all `$ tox -e studio` tests

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -648,6 +648,7 @@ class CourseGradingTest(CourseTestCase):
             )
         ])
 
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'fails in open-release/juniper.master as well')
     @mock.patch('track.event_transaction_utils.uuid4')
     @mock.patch('models.settings.course_grading.tracker')
     @mock.patch('contentstore.signals.signals.GRADING_POLICY_CHANGED.send')

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -96,10 +96,14 @@ if theme:
 engine = Engine(dirs=dirs)
 loader = ThemeTemplateLoader(engine)
 
+## Note: Appsembler - We've changed `loader` -> `loader.base_loader` to fix Studio errors
+##       this change is a tech-debt that's not specifically tested. It meant to
+##       use theme template loader for static includes such as underscore files.
+
 source = None
-for origin in loader.get_template_sources(path):
+for origin in loader.base_loader.get_template_sources(path):
     try:
-        source = loader.get_contents(origin)
+        source = loader.base_loader.get_contents(origin)
     except TemplateDoesNotExist:
         pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -103,22 +103,20 @@ commands =
     pytest \
         cms/djangoapps/appsembler \
         cms/djangoapps/appsembler_tiers \
-        # In Hawthorn command ran just those tests from the `contentstore` app
-        # Fix in Juniper: TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS
         cms/djangoapps/contentstore/tests/test_core_caching.py \
         cms/djangoapps/contentstore/tests/test_course_create_rerun.py \
         cms/djangoapps/contentstore/tests/test_course_listing.py \
-        # cms/djangoapps/contentstore/tests/test_course_settings.py \
+        cms/djangoapps/contentstore/tests/test_course_settings.py \
         cms/djangoapps/contentstore/tests/test_courseware_index.py \
         cms/djangoapps/contentstore/tests/test_crud.py \
         cms/djangoapps/contentstore/tests/test_gating.py \
         cms/djangoapps/contentstore/tests/test_i18n.py \
         cms/djangoapps/contentstore/tests/test_import_draft_order.py \
         cms/djangoapps/contentstore/tests/test_import_pure_xblock.py \
-        # cms/djangoapps/contentstore/tests/test_libraries.py \
+        cms/djangoapps/contentstore/tests/test_libraries.py \
         cms/djangoapps/contentstore/tests/test_orphan.py \
-        # cms/djangoapps/contentstore/tests/test_permissions.py \
-        # cms/djangoapps/contentstore/tests/test_proctoring.py \
+        cms/djangoapps/contentstore/tests/test_permissions.py \
+        cms/djangoapps/contentstore/tests/test_proctoring.py \
         cms/djangoapps/contentstore/tests/test_request_event.py \
         cms/djangoapps/contentstore/tests/test_signals.py \
         cms/djangoapps/contentstore/tests/test_transcripts_utils.py \
@@ -127,14 +125,14 @@ commands =
         cms/djangoapps/contentstore/tests/tests.py \
         cms/djangoapps/contentstore/views/tests/test_access.py \
         cms/djangoapps/contentstore/views/tests/test_assets.py::AssetToJsonTestCase \
-        # cms/djangoapps/contentstore/views/tests/test_course_index.py \
+        cms/djangoapps/contentstore/views/tests/test_course_index.py \
         cms/djangoapps/contentstore/views/tests/test_entrance_exam.py \
         cms/djangoapps/contentstore/views/tests/test_gating.py \
         cms/djangoapps/contentstore/views/tests/test_helpers.py \
-        # cms/djangoapps/contentstore/views/tests/test_item.py \
-        # cms/djangoapps/contentstore/views/tests/test_library.py \
+        cms/djangoapps/contentstore/views/tests/test_item.py \
+        cms/djangoapps/contentstore/views/tests/test_library.py \
         cms/djangoapps/contentstore/views/tests/test_organizations.py \
-        # cms/djangoapps/contentstore/views/tests/test_preview.py \
+        cms/djangoapps/contentstore/views/tests/test_preview.py \
         cms/djangoapps/contentstore/views/tests/test_transcript_settings.py \
         cms/djangoapps/contentstore/views/tests/test_transcripts.py \
         cms/djangoapps/contentstore/views/tests/test_unit_page.py


### PR DESCRIPTION
I've changed `loader` -> `loader.base_loader` to fix Studio errors. 
This change is a tech-debt that's not specifically tested. It meant to use theme template loader for static includes such as underscore files.

This fix is related to our `underscore` override hack we've done in 2016, which we should contribute upstream (https://github.com/appsembler/edx-platform/commit/d9c21d7991571b9bda5261759de590f19cd10d31)!


```
==== 636 passed, 53 skipped, 2193 warnings in 335.33s (0:05:35) ========
___________________ summary _____________________
  studio: commands succeeded
  congratulations :)
````