### PR TITLE
ENGOPS-60: Disable Travis on Juniper branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,14 +33,19 @@ env:
     - BOTO_CONFIG="/etc/nonexistent.cfg"
 
 jobs:
-  include:
-    - name: pep8
-    - name: common-minimal
-    - name: common
-    - name: lms-1
-    - name: lms-2
-    - name: mte
-    - name: studio
+  exclude:
+    # Disable all jobs on TravisCI on Juniper branches.
+    # It's not helpful at all for Juniper.
+    # See https://appsembler.atlassian.net/browse/ENGOPS-60?focusedCommentId=29611
+    - python: 3.5
+#  include:
+#    - name: pep8
+#    - name: common-minimal
+#    - name: common
+#    - name: lms-1
+#    - name: lms-2
+#    - name: mte
+#    - name: studio
 
 script: tox -e $TRAVIS_JOB_NAME
 
@@ -49,5 +54,3 @@ branches:
   # so `continuous-integration/travis-ci/push` shouldn't be built anymore.
   only:
     - /^appsembler\/(tahoe|hawthorn)\/(develop|master)$/
-    - main
-


### PR DESCRIPTION
### Background
Currently Travis takes more than an hour to run a single build. Even after paying about 100$. 
As far as I understand, there's no way to run 7 builds at the same time.
This means that we'll have to run builds only locally which isn't ideal.

Please also checkout the discussion in https://appsembler.atlassian.net/browse/ENGOPS-60

### Summary
I'd like to pick Option 3. Which is to disable Travis on Juniper to save money until we migrate to GitHub actions.

### Other options

A) Keep Travis running on Juniper branch and wait for an hour before merging
B) Keep Travis running on Juniper branch and but we can merge without waiting for tests to pass

C) Disable Travis on Juniper but keep on the Hawthorn one (this PR effectively does this option)
D) Run nightly Travis builds on the Juniper branch once every 24 hours (Travis has such feature) so we can monitor test failures

### Reviewers

Please read and provide feedback:

 - [ ] @johnbaldwin 
 - [ ] @melvinsoft 
 - [x] @thraxil fyi