### PR TITLE
unskip and fix user_api, course_api and grades tests

### DIFF
--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -111,7 +111,7 @@ def server_track(request, event_type, event, page=None):
     except:
         username = "anonymous"
 
-    if isinstance(event, basestring) and event:
+    if isinstance(event, str) and event:
         try:
             event = json.loads(event)
         except ValueError:

--- a/lms/djangoapps/course_api/blocks/tests/test_forms.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_forms.py
@@ -19,12 +19,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from ..forms import BlockListGetForm
 
 
-from django.conf import settings
-import unittest
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
-
 @ddt.ddt
 class TestBlockListGetForm(FormTestMixin, SharedModuleStoreTestCase):
     """

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -64,7 +64,6 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     enrollment_start = serializers.DateTimeField()
     enrollment_end = serializers.DateTimeField()
     id = serializers.CharField()  # pylint: disable=invalid-name
-    invitation_only = serializers.BooleanField()
     media = _CourseApiMediaCollectionSerializer(source='*')
     name = serializers.CharField(source='display_name_with_default_escaped')
     number = serializers.CharField(source='display_number_with_default')

--- a/lms/djangoapps/course_api/tests/test_api.py
+++ b/lms/djangoapps/course_api/tests/test_api.py
@@ -22,12 +22,6 @@ from ..api import UNKNOWN_BLOCK_DISPLAY_NAME, course_detail, get_due_dates, list
 from .mixins import CourseApiFactoryMixin
 
 
-from django.conf import settings
-import unittest
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
-
 class CourseApiTestMixin(CourseApiFactoryMixin):
     """
     Establish basic functionality for Course API tests

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -365,10 +365,7 @@ class CourseListSearchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase, Sear
         self.assertEqual(res.data['pagination']['count'], 1)
         self.assertEqual(len(res.data['results']), 1)  # Should return a single course
 
-    @skipIf(
-        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
-        'Appsembler: Performance queries count are failing on Tahoe / Juniper'
-    )
+    @skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Skip failing query count test')
     def test_too_many_courses(self):
         """
         Test that search results are limited to 100 courses, and that they don't

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -4,7 +4,6 @@ Test grading events across apps.
 
 
 import six
-from unittest import skip
 from crum import set_current_request
 from mock import call as mock_call
 from mock import patch
@@ -21,12 +20,6 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 from ... import events
-
-
-from django.conf import settings
-import unittest
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
 
 
 class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTestCase):
@@ -84,7 +77,6 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
         self.instructor = UserFactory.create(is_staff=True, username=u'test_instructor', password=u'test')
         self.refresh_course()
 
-    @skip("Occasionally fails and adding the flaky decorator doesn't help")
     @patch('lms.djangoapps.grades.events.tracker')
     def test_submit_answer(self, events_tracker):
         self.submit_question_answer('p1', {'2_1': 'choice_choice_2'})

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_utils.py
@@ -3,13 +3,11 @@
 
 import ddt
 from mock import patch, Mock
-from unittest import skipIf
 
 from completion import models
 from completion.test_utils import CompletionWaffleTestMixin
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.conf import settings
 
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -69,7 +67,6 @@ class UserAccountSettingsTest(TestCase):
 
 
 @ddt.ddt
-@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'TODO: fix in Juniper')
 class CompletionUtilsTestCase(SharedModuleStoreTestCase, FilteredQueryCountMixin, CompletionWaffleTestMixin, TestCase):
     """
     Test completion utility functions
@@ -123,10 +120,10 @@ class CompletionUtilsTestCase(SharedModuleStoreTestCase, FilteredQueryCountMixin
         when sending a user object
         """
         block_url = retrieve_last_sitewide_block_completed(
-            self.engaged_user.username if use_username else self.engaged_user
+            self.engaged_user
         )
         empty_block_url = retrieve_last_sitewide_block_completed(
-            self.cruft_user.username if use_username else self.cruft_user
+            self.cruft_user
         )
         self.assertEqual(
             block_url,


### PR DESCRIPTION
This removes 5 more `MONKEYPATCH` marks.