### PR TITLE
getting tests to run on github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: edx-platform tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+    strategy:
+      matrix:
+        python-version: [3.5]
+        tox-env:
+          - pep8
+          - common-minimal
+          - common
+          - lms-1
+          - lms-2
+          - mte
+          - studio
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }} ${{ matrix.tox-env }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y python-dev libxml2-dev libxmlsec1-dev
+        pip install tox
+    - name: Run tox
+      run: |
+        tox -e ${{ matrix.tox-env }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: edx-platform tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Simple port of the Travis CI test suite over to GitHub Actions.

There's still optimization work to be done to cache dependencies, but it's already running the tests faster than Travis was anyway, so I don't think that's our highest priority to work on right now.