### PR TITLE
Enable tests in the lms/courseware app

### DIFF
--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -58,11 +58,6 @@ from xmodule.modulestore.tests.django_utils import (
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.partitions.partitions import MINIMUM_STATIC_PARTITION_ID, Group, UserPartition
 
-
-from django.conf import settings
-import unittest
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
 QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 # pylint: disable=protected-access

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -23,11 +23,6 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
-import unittest
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
-
 class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that navigation state is saved properly.

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1204,9 +1204,10 @@ def _downloadable_certificate_message(course, cert_downloadable_status):
         elif not cert_downloadable_status['is_pdf_certificate']:
             return GENERATING_CERT_DATA
 
-    # Hack: Was `return _downloadable_cert_data(download_url=cert_downloadable_status['download_url'])`
-    #       We return none because we don't use PDF certificates
-    return None
+    if not settings.FEATURES['ENABLE_TAHOE_PDF_CERTS']:
+        return None
+
+    return _downloadable_cert_data(download_url=cert_downloadable_status['download_url'])
 
 
 def _missing_required_verification(student, enrollment_mode):
@@ -1233,11 +1234,14 @@ def _certificate_message(student, course, enrollment_mode):
     if _missing_required_verification(student, enrollment_mode):
         return UNVERIFIED_CERT_DATA
 
-    # TODO: Check in Juniper. Do we have tests for it? -- Omar
-    if certs_api.has_html_certificates_enabled(course) and certs_api.get_active_web_certificate(course) is not None:
-        return REQUESTING_CERT_DATA
-    else:
-        return None
+    if not settings.FEATURES['ENABLE_TAHOE_PDF_CERTS']:
+        has_html_certs = certs_api.has_html_certificates_enabled(course)
+        active_web_certificate = certs_api.get_active_web_certificate(course) is not None
+
+        if not (has_html_certs and active_web_certificate):
+            return None
+
+    return REQUESTING_CERT_DATA
 
 
 def _get_cert_data(student, course, enrollment_mode, course_grade=None):
@@ -1252,9 +1256,9 @@ def _get_cert_data(student, course, enrollment_mode, course_grade=None):
     """
     cert_data = _certificate_message(student, course, enrollment_mode)
 
-    if not cert_data:
-        # Appsembler: Address None `cert_data` because we don't use PDFs
-        return
+    if not settings.FEATURES['ENABLE_TAHOE_PDF_CERTS']:
+        if not cert_data:
+            return
 
     if not CourseMode.is_eligible_for_certificate(enrollment_mode, status=cert_data.cert_status):
         return INELIGIBLE_PASSING_CERT_DATA.get(enrollment_mode)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1205,6 +1205,7 @@ def _downloadable_certificate_message(course, cert_downloadable_status):
             return GENERATING_CERT_DATA
 
     # Hack: Was `return _downloadable_cert_data(download_url=cert_downloadable_status['download_url'])`
+    #       We return none because we don't use PDF certificates
     return None
 
 
@@ -1250,6 +1251,11 @@ def _get_cert_data(student, course, enrollment_mode, course_grade=None):
         returns dict if course certificate is available else None.
     """
     cert_data = _certificate_message(student, course, enrollment_mode)
+
+    if not cert_data:
+        # Appsembler: Address None `cert_data` because we don't use PDFs
+        return
+
     if not CourseMode.is_eligible_for_certificate(enrollment_mode, status=cert_data.cert_status):
         return INELIGIBLE_PASSING_CERT_DATA.get(enrollment_mode)
 

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -27,6 +27,11 @@ def plugin_settings(settings):
         0, 'beeline.middleware.django.HoneyMiddleware'
     )
 
+    # Disable PDF certificates on Tahoe by default because we only support HTML certificate
+    # This is a custom Tahoe feature flag.
+    # TODO: Add tests for the feature
+    settings.FEATURES['ENABLE_TAHOE_PDF_CERTS'] = False
+
     settings.DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] += (
         'openedx.core.djangoapps.appsembler.intercom_integration.context_processors.intercom',
         'openedx.core.djangoapps.appsembler.analytics.context_processors.google_analytics',


### PR DESCRIPTION
Two more `MONKEYPATCHING` squashed.

I've refactored some of the Ficus work https://github.com/appsembler/edx-platform/pull/212 regarding PDF certs behind a feature flag. We can override this flag via ansible but we probably shouldn't even bother to put it in Ansible. It's meant to stay `False`.