### PR TITLE
unskip most student app tests; clean up old code

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -16,13 +16,10 @@ from django.utils.translation import ugettext_lazy as _
 from edx_ace import ace
 from edx_ace.recipient import Recipient
 
-from organizations.models import UserOrganizationMapping
-from openedx.core.djangoapps.appsembler.sites.utils import is_request_for_new_amc_site
-
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.theming.helpers import get_current_request, get_current_site
+from openedx.core.djangoapps.theming.helpers import get_current_site
 from openedx.core.djangoapps.user_api import accounts as accounts_settings
 from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -16,7 +16,6 @@ from student.tests.factories import UserFactory
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-@unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix broken tests')
 class TestActivateAccount(TestCase):
     """Tests for account creation"""
 

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -26,10 +26,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 
-import unittest
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
 
 class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
     """Test the django admin course roles form saving data in db.

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -19,9 +19,6 @@ from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestStudentDashboardEmailView(SharedModuleStoreTestCase):

--- a/common/djangoapps/student/tests/test_certificates.py
+++ b/common/djangoapps/student/tests/test_certificates.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from mock import patch
 from pytz import UTC
-from unittest import skip
+from unittest import skipIf
 
 from course_modes.models import CourseMode
 from lms.djangoapps.certificates.api import get_certificate_url
@@ -27,10 +27,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 PAST_DATE = datetime.datetime.now(UTC) - datetime.timedelta(days=2)
 FUTURE_DATE = datetime.datetime.now(UTC) + datetime.timedelta(days=2)
-
-
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
 
 
 class CertificateDisplayTestBase(SharedModuleStoreTestCase):
@@ -258,7 +254,7 @@ class CertificateDisplayTestHtmlView(CertificateDisplayTestBase):
     @ddt.data('verified', 'honor')
     @override_settings(CERT_NAME_SHORT='Test_Certificate')
     @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
-    @skip('Appsembler: Broken because of our certificate customizations. Could not fix it myself -- Omar')
+    @skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, ' Broken because of our certificate customizations. Could not fix it')
     def test_display_download_certificate_button(self, enrollment_mode):
         """
         Tests if CERTIFICATES_HTML_VIEW is True
@@ -300,7 +296,7 @@ class CertificateDisplayTestLinkedHtmlView(CertificateDisplayTestBase):
     @ddt.data('verified')
     @override_settings(CERT_NAME_SHORT='Test_Certificate')
     @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
-    @skip('Appsembler: Broken because of our certificate customizations. Could not fix it myself -- Omar')
+    @skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, ' Broken because of our certificate customizations. Could not fix it')
     def test_linked_student_to_web_view_credential(self, enrollment_mode):
 
         cert = self._create_certificate(enrollment_mode)

--- a/common/djangoapps/student/tests/test_credit.py
+++ b/common/djangoapps/student/tests/test_credit.py
@@ -20,11 +20,6 @@ from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
-
 TEST_CREDIT_PROVIDER_SECRET_KEY = "931433d583c84ca7ba41784bad3232e6"
 
 

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -123,14 +123,14 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
     ]
 
     @ddt.data('plain_text', 'html')
-    @unittest.skip('Appsembler: Broken tests because of multi-tenant hostname fixes. Could not fix it myself -- Omar')
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, ' Broken due to multi-tenant hostname fixes. Could not fix it.')
     def test_activation_email(self, test_body_type):
         self._create_account()
         self._assert_activation_email(self.ACTIVATION_SUBJECT, self.OPENEDX_FRAGMENTS, test_body_type)
 
     @with_comprehensive_theme("edx.org")
     @ddt.data('plain_text', 'html')
-    @unittest.skip('Appsembler: Broken tests because of multi-tenant hostname fixes. Could not fix it myself -- Omar')
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, ' Broken due to multi-tenant hostname fixes. Could not fix it.')
     def test_activation_email_edx_domain(self, test_body_type):
         self._create_account()
         self._assert_activation_email(self.ACTIVATION_SUBJECT, self.OPENEDX_FRAGMENTS, test_body_type)

--- a/common/djangoapps/student/tests/test_linkedin.py
+++ b/common/djangoapps/student/tests/test_linkedin.py
@@ -3,9 +3,9 @@
 
 
 import ddt
-from unittest import skip
+from unittest import skipIf
 from django.conf import settings
-from django.test import override_settings, TestCase
+from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
 from six.moves.urllib.parse import quote, urlencode
 
@@ -14,8 +14,7 @@ from student.models import LinkedInAddToProfileConfiguration
 
 
 @ddt.ddt
-@override_settings(DEFAULT_SITE_THEME='edx-theme-codebase')
-@skip('Appsembler: Broken tests, likely because of our theme modifications. Cannot be sure -- Omar.')
+@skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, ' Broken tests, likely because of our theme modifications. Cannot be sure.')
 class LinkedInAddToProfileUrlTests(TestCase):
     """Tests for URL generation of LinkedInAddToProfileConfig. """
 

--- a/common/djangoapps/student/tests/test_recent_enrollments.py
+++ b/common/djangoapps/student/tests/test_recent_enrollments.py
@@ -26,10 +26,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
-
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt
 class TestRecentEnrollments(ModuleStoreTestCase, XssTestMixin):
@@ -275,7 +271,7 @@ class TestRecentEnrollments(ModuleStoreTestCase, XssTestMixin):
         (False, True,),
     )
     @ddt.unpack
-    @unittest.skip('Appsembler: Broken tests. Likely because of our theme changes. Skipping for now -- Omar')
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Broken tests. Likely because of our theme changes.')
     def test_donate_button_with_enabled_site_configuration(self, enable_donation_config, enable_donation_site_config):
         # Enable the enrollment success message and donations
         self._configure_message_timeout(10000)

--- a/common/djangoapps/student/tests/test_refunds.py
+++ b/common/djangoapps/student/tests/test_refunds.py
@@ -35,10 +35,6 @@ TEST_API_URL = 'http://www-internal.example.com/api'
 JSON = 'application/json'
 
 
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
-
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class RefundableTest(SharedModuleStoreTestCase):

--- a/common/djangoapps/student/tests/test_userstanding.py
+++ b/common/djangoapps/student/tests/test_userstanding.py
@@ -13,9 +13,6 @@ from django.urls import reverse
 from student.models import UserStanding
 from student.tests.factories import UserFactory, UserStandingFactory
 
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
 
 class UserStandingTest(TestCase):
     """test suite for user standing view for enabling and disabling accounts"""

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -29,9 +29,6 @@ from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
 
 @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -46,11 +46,6 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
-
 PASSWORD = 'test'
 
 
@@ -581,7 +576,6 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         response = self.client.get(reverse('dashboard'))
         self.assertNotContains(response, 'You are not enrolled in any courses yet.')
 
-    @unittest.expectedFailure  # TODO: `EMPTY_DASHBOARD_MESSAGE` is broken in the Appsembler theme -- Omar
     def test_show_empty_dashboard_message(self):
         """
         Verify that when the EMPTY_DASHBOARD_MESSAGE feature is set,

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -56,10 +56,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls
 log = logging.getLogger(__name__)
 
 
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken tests')
-
-
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 @ddt.ddt
 class CourseEndingTest(TestCase):
@@ -557,7 +553,6 @@ class DashboardTest(ModuleStoreTestCase, TestVerificationBase):
 
 
 @ddt.ddt
-@override_settings(DEFAULT_SITE_THEME='edx-theme-codebase')
 class DashboardTestsWithSiteOverrides(SiteMixin, ModuleStoreTestCase):
     """
     Tests for site settings overrides used when rendering the dashboard view
@@ -579,7 +574,7 @@ class DashboardTestsWithSiteOverrides(SiteMixin, ModuleStoreTestCase):
         ('testserver2.com', {'ENABLE_VERIFIED_CERTIFICATES': True, 'DISPLAY_COURSE_MODES_ON_DASHBOARD': True}),
     )
     @ddt.unpack
-    @unittest.expectedFailure  # Appsembler: Broken tests for reasons not known to me -- Omar
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Broken tests for reasons.')
     def test_course_mode_visible(self, site_domain, site_configuration_values):
         """
         Test that the course mode for courses is visible on the dashboard

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -44,13 +44,7 @@ from edxmako.shortcuts import marketing_link, render_to_response, render_to_stri
 from entitlements.models import CourseEntitlement
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.catalog.utils import get_programs_with_type
-from openedx.core.djangoapps.appsembler.sites.utils import (
-    get_current_organization,
-    is_request_for_amc_admin,
-    is_request_for_new_amc_site,
-    add_course_creator_role,
-)
-from openedx.core.djangoapps.theming.helpers import get_current_request
+from openedx.core.djangoapps.appsembler.sites.utils import get_current_organization
 from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
@@ -58,8 +52,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.theming import helpers as theming_helpers
 from openedx.core.djangoapps.user_api.preferences import api as preferences_api
 from openedx.core.djangolib.markup import HTML, Text
-from organizations.models import Organization, UserOrganizationMapping
-from organizations.models import Organization, UserOrganizationMapping
 from student.helpers import DISABLE_UNENROLL_CERT_STATES, cert_info, generate_activation_email_context
 from student.message_types import AccountActivation, EmailChange, EmailChangeConfirmation, RecoveryEmailCreate
 from student.models import (


### PR DESCRIPTION
Squashes 11 `MONKEYPATCH` marks and enables most tests on the `student` app.

I've done `$ git diff main..open-release/juniper.master -- common/djangoapps/student/` and cleaned some good old/unused code.