### PR TITLE
unskip more Tahoe studio tests

### DIFF
--- a/cms/djangoapps/appsembler/tests/test_appsembler_sites_tasks.py
+++ b/cms/djangoapps/appsembler/tests/test_appsembler_sites_tasks.py
@@ -2,9 +2,7 @@
 Tests for appsembler.sites.tasks.
 """
 import datetime
-import unittest
 
-from django.conf import settings
 from django.test import override_settings
 from organizations.models import UserOrganizationMapping
 from organizations.tests.factories import OrganizationFactory
@@ -30,7 +28,6 @@ IMPORT_SETTINGS = {
 
 
 @override_settings(**IMPORT_SETTINGS)
-@unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix stuck test')
 class ImportCourseOnSiteCreationTestCase(ModuleStoreTestCase):
     """
     Integration tests for the `import_course_on_site_creation` task.

--- a/cms/djangoapps/appsembler/tests/test_multi_tenant_with_invite.py
+++ b/cms/djangoapps/appsembler/tests/test_multi_tenant_with_invite.py
@@ -4,17 +4,14 @@ Tests for APPSEMBLER_MULTI_TENANT_EMAILS in Studio for course team invite.
 
 from mock import patch
 import json
-import unittest
 
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import LibraryFactory
 
-from django.conf import settings
 from contentstore.views import course_team_handler
 from django.test import RequestFactory
 from django.urls import reverse
 from rest_framework import status
-from django.test.utils import override_settings
 from student.roles import CourseInstructorRole, LibraryUserRole
 from organizations.models import OrganizationCourse
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
@@ -26,9 +23,7 @@ from openedx.core.djangoapps.appsembler.multi_tenant_emails.tests.test_utils imp
 from student.roles import CourseCreatorRole, CourseAccessRole
 
 
-@unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix stuck test')
 @patch.dict('django.conf.settings.FEATURES', {'APPSEMBLER_MULTI_TENANT_EMAILS': True})
-@override_settings(DEFAULT_SITE_THEME='edx-theme-codebase')
 class MultiTenantStudioCourseTeamTestCase(ModuleStoreTestCase):
     """
     Testing the Course Team management when the APPSEMBLER_MULTI_TENANT_EMAILS feature is enabled in Studio.

--- a/cms/djangoapps/appsembler/tests/test_multi_tenant_with_invite.py
+++ b/cms/djangoapps/appsembler/tests/test_multi_tenant_with_invite.py
@@ -12,6 +12,7 @@ from contentstore.views import course_team_handler
 from django.test import RequestFactory
 from django.urls import reverse
 from rest_framework import status
+from django.test.utils import override_settings
 from student.roles import CourseInstructorRole, LibraryUserRole
 from organizations.models import OrganizationCourse
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
@@ -24,6 +25,7 @@ from student.roles import CourseCreatorRole, CourseAccessRole
 
 
 @patch.dict('django.conf.settings.FEATURES', {'APPSEMBLER_MULTI_TENANT_EMAILS': True})
+@override_settings(DEFAULT_SITE_THEME='edx-theme-codebase')  # Needed override for Studio tests
 class MultiTenantStudioCourseTeamTestCase(ModuleStoreTestCase):
     """
     Testing the Course Team management when the APPSEMBLER_MULTI_TENANT_EMAILS feature is enabled in Studio.


### PR DESCRIPTION
Now their magically working okay! Most of such tests failed due to a single reason that had been fixed afterward. Two less `MONKEYPATCH` marks.