### PR TITLE
unskip most instructor dashboard tests; now they pass

### DIFF
--- a/lms/djangoapps/instructor/tests/__init__.py
+++ b/lms/djangoapps/instructor/tests/__init__.py
@@ -1,4 +1,0 @@
-from django.conf import settings
-import unittest
-if settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    raise unittest.SkipTest('fix broken instructor tests')

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -225,6 +225,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         )
 
     @ddt.data(True, False)
+    @unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'Fails due to missing html element')
     def test_membership_reason_field_visibility(self, enbale_reason_field):
         """
         Verify that reason field is enabled by site configuration flag 'ENABLE_MANUAL_ENROLLMENT_REASON_FIELD'
@@ -254,6 +255,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         else:
             self.assertNotContains(response, reason_field)
 
+    @unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'Fails due to missing html element')
     def test_membership_site_configuration_role(self):
         """
         Verify that the role choices set via site configuration are loaded in the membership tab


### PR DESCRIPTION
Mostly just unskip the whole module. Some test are still skipped, will be fixed in #771.