### PR TITLE
unskip TestCourseRegistrationCodeStatus; always skip GroupConfigurationSearchMongo

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -957,7 +957,7 @@ class TestLibrarySearchIndexer(MixedWithOptionsTestCase):
         self._perform_test_using_store(store_type, self._test_exception)
 
 
-@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'broken tests in Studio for no reason')
+@skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'fails in open-release/juniper.master')
 class GroupConfigurationSearchMongo(CourseTestCase, MixedWithOptionsTestCase):
     """
     Tests indexing of content groups on course modules using mongo modulestore.

--- a/lms/djangoapps/instructor/tests/test_registration_codes.py
+++ b/lms/djangoapps/instructor/tests/test_registration_codes.py
@@ -34,7 +34,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @override_settings(REGISTRATION_CODE_LENGTH=8)
-@unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'TODO: fix in Juniper')
 class TestCourseRegistrationCodeStatus(SharedModuleStoreTestCase):
     """
     Test registration code status.


### PR DESCRIPTION
Squashes two more `MONKEYPATCH`.