### PR TITLE
Appsembler Apps Sites - Upgraded OAuth2

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
@@ -17,6 +17,9 @@ def plugin_settings(settings):
     if not settings.AMC_APP_URL:
         settings.AMC_APP_URL = 'http://localhost:13000'
 
+    if not settings.AMC_APP_OAUTH2_CLIENT_ID:
+        settings.AMC_APP_OAUTH2_CLIENT_ID = 'dev-amc-app-oauth2-client-id'
+
     # Disable caching in dev environment
     if not settings.FEATURES.get('ENABLE_DEVSTACK_CACHES', False):
         print('\nAppsembler: disabling devstack caches\n', file=sys.stderr)

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -19,6 +19,7 @@ def plugin_settings(settings):
     settings.APPSEMBLER_FIRST_LOGIN_API = '/logged_into_edx'
 
     settings.AMC_APP_URL = settings.ENV_TOKENS.get('AMC_APP_URL')
+    settings.AMC_APP_OAUTH2_CLIENT_ID = settings.ENV_TOKENS.get('AMC_APP_OAUTH2_CLIENT_ID')
 
     settings.DEFAULT_COURSE_MODE_SLUG = settings.ENV_TOKENS.get('EDXAPP_DEFAULT_COURSE_MODE_SLUG', 'audit')
     settings.DEFAULT_MODE_NAME_FROM_SLUG = _(settings.DEFAULT_COURSE_MODE_SLUG.capitalize())

--- a/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
@@ -11,6 +11,7 @@ def plugin_settings(settings):
     settings.USE_S3_FOR_CUSTOMER_THEMES = False
 
     settings.AMC_APP_URL = 'http://localhost:13000'  # Tests needs this URL.
+    settings.AMC_APP_OAUTH2_CLIENT_ID = 'test-amc-app-oauth2-client-id'
 
     # Allow enabling the APPSEMBLER_MULTI_TENANT_EMAILS when running unit tests via environment variables,
     # because it's disabled by default.

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 import pkg_resources
-import uuid
 from mock import patch, mock_open
 from io import StringIO
 
@@ -47,9 +46,7 @@ from student.tests.factories import (
 
 from organizations.models import Organization, OrganizationCourse
 
-if not settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    from provider.constants import CONFIDENTIAL
-    from oauth2_provider.models import AccessToken, RefreshToken, Client
+from oauth2_provider.models import AccessToken, RefreshToken, Application
 
 from student.roles import CourseCreatorRole
 
@@ -71,7 +68,8 @@ class CreateDevstackSiteCommandTestCase(TestCase):
 
     def setUp(self):
         assert settings.ENABLE_COMPREHENSIVE_THEMING
-        Client.objects.create(url=settings.AMC_APP_URL, client_type=CONFIDENTIAL)
+        Application.objects.create(client_id=settings.AMC_APP_OAUTH2_CLIENT_ID,
+                                   client_type=Application.CONFIDENTIAL)
 
     def test_no_sites(self):
         """
@@ -122,7 +120,8 @@ class RemoveSiteCommandTestCase(TestCase):
     """
     def setUp(self):
         assert settings.ENABLE_COMPREHENSIVE_THEMING
-        Client.objects.create(url=settings.AMC_APP_URL, client_type=CONFIDENTIAL)
+        Application.objects.create(client_id=settings.AMC_APP_OAUTH2_CLIENT_ID,
+                                   client_type=Application.CONFIDENTIAL)
 
         self.to_be_deleted = 'delete'
         self.shall_remain = 'keep'
@@ -438,7 +437,7 @@ class TestOffboardSiteCommand(ModuleStoreTestCase):
         new_user_count = 3
 
         assert organization.userorganizationmapping_set.count() == 0
-        users = self.create_org_users(org=organization, new_user_count=new_user_count)
+        self.create_org_users(org=organization, new_user_count=new_user_count)
         assert organization.userorganizationmapping_set.count() == new_user_count
 
         data = self.command.process_organization_users(organization)

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -12,9 +12,7 @@ from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.db.models.query import Q
 
-if not settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    # TODO: Fix broken imports
-    from provider.oauth2.models import AccessToken, RefreshToken, Client
+from oauth2_provider.models import AccessToken, RefreshToken, Application
 
 from django.utils.text import slugify
 
@@ -59,7 +57,7 @@ def get_amc_oauth_client():
     """
     Return the AMC OAuth2 Client model instance.
     """
-    return Client.objects.get(url=settings.AMC_APP_URL)
+    return Application.objects.get(client_id=settings.AMC_APP_OAUTH2_CLIENT_ID)
 
 
 @beeline.traced(name="get_amc_tokens")


### PR DESCRIPTION
This commit replaces the Hawthorn call to
`provider.oauth2.models.Client` with
`oauth2_provider.models.Application`

The `Application` model replaces the `Client` model. There are field
changes. The `Client` model field `url` is gone and the `client_id`
field is now unique. Therefore this commit replaces use of `Client.url`
with `Application.client_id` to create the new record and to retrieve
the record for the AMC client

The `appsembler_settings` settings have been updated to use a new
setting value `AMC_APP_OAUTH2_CLIENT_ID` to identify the AMC app's OAuth
client.

https://appsembler.atlassian.net/browse/RED-1668