### PR TITLE
    unskip, refactor and fix cert tests

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -505,7 +505,8 @@ def _certificate_download_url(user_id, course_id, user_certificate=None):
 
 
 def has_html_certificates_enabled(course):
-    if not configuration_helpers.get_value("CERTIFICATES_HTML_VIEW", False):
+    if not configuration_helpers.get_value('CERTIFICATES_HTML_VIEW',
+                                           settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False)):
         return False
     return course.cert_html_view_enabled
 

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -499,7 +499,8 @@ def render_html_view(request, course_id, certificate=None):
     configuration = CertificateHtmlViewConfiguration.get_config()
 
     # Kick the user back to the "Invalid" screen if the feature is disabled globally
-    if not configuration_helpers.get_value('CERTIFICATES_HTML_VIEW', settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False)):
+    if not configuration_helpers.get_value('CERTIFICATES_HTML_VIEW',
+                                           settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False)):
         return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
     # Load the course and user objects

--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -30,10 +30,10 @@ RESCORE_EXAMS = 'instructor.rescore_exams'
 VIEW_REGISTRATION = 'instructor.view_registration'
 VIEW_DASHBOARD = 'instructor.dashboard'
 
-TAHOE_CERTIFICATE_ADMIN = 'instructor.tahoe_certificates'  # Custom rule so Tahoe customers can control certificates
+TAHOE_CERTIFICATE_ADMIN = 'instructor.tahoe_certificates_admin'  # Custom rule so Tahoe customers can control certs
 
 
-perms[TAHOE_CERTIFICATE_ADMIN] = HasAccessRule('staff')
+perms[TAHOE_CERTIFICATE_ADMIN] = HasAccessRule('staff') | HasAccessRule('instructor')
 perms[ALLOW_STUDENT_TO_BYPASS_ENTRANCE_EXAM] = HasAccessRule('staff')
 perms[ASSIGN_TO_COHORTS] = HasAccessRule('staff')
 perms[EDIT_COURSE_ACCESS] = HasAccessRule('instructor')

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -608,7 +608,8 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
 
 @unittest.skipIf(
     settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
-    'this should be re-examined later see https://github.com/appsembler/edx-platform/pull/706'
+    'This should be re-examined later see https://github.com/appsembler/edx-platform/pull/706. '
+    'It may not be needed because we may not have performance problems anymore. '
 )
 class TestInstructorDashboardMenuForDueDates(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -657,7 +658,8 @@ class TestInstructorDashboardMenuForDueDates(ModuleStoreTestCase, LoginEnrollmen
         )
 
         response = self.client.get(url)
-        self.assertNotIn('data-section="extensions"', response.content)
+        content = response.content.decode('utf-8')
+        self.assertNotIn('data-section="extensions"', content)
 
     @with_site_configuration(configuration={
         'INDIVIDUAL_DUE_DATES': True,  # site configuration override
@@ -676,7 +678,8 @@ class TestInstructorDashboardMenuForDueDates(ModuleStoreTestCase, LoginEnrollmen
         )
 
         response = self.client.get(url)
-        self.assertIn('data-section="extensions"', response.content)
+        content = response.content.decode('utf-8')
+        self.assertIn('data-section="extensions"', content)
 
 
 @ddt.ddt

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -202,7 +202,9 @@ def instructor_dashboard_2(request, course_id):
     # and enable self-generated certificates for a course.
     # Note: This is hidden for all CCXs
     certs_enabled = CertificateGenerationConfiguration.current().enabled and not hasattr(course_key, 'ccx')
-    if certs_enabled and (access['admin'] or access['staff']) and configuration_helpers.get_value('CERTIFICATES_HTML_VIEW', False):
+    site_has_cert_enabled = configuration_helpers.get_value('CERTIFICATES_HTML_VIEW',
+                                                            settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False))
+    if certs_enabled and (access['admin'] or access['staff']) and site_has_cert_enabled:
         sections.append(_section_certificates(course))
 
     openassessment_blocks = modulestore().get_items(


### PR DESCRIPTION
Certificates in Tahoe has some differences:
    
   - No PDF certificates, just HTML
   - Site admins can disable HTML certificates via AMC
   - Course admin and staff can control certs without extra perms
