### PR TITLE
pin pip for tox to avoid strict checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     services:
       mongodb:
         image: mongo
@@ -34,9 +34,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      # TODO: Remove tox-pip-version once we upgrade to Koa+, or whenever we have addressed pip 20.3 strict issues.
       run: |
         sudo apt-get install -y python-dev libxml2-dev libxmlsec1-dev
-        pip install tox
+        pip install tox tox-pip-version
     - name: Run tox
       run: |
         tox -e ${{ matrix.tox-env }}

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ toxworkdir={env:TOX_WORKDIR:{homedir}/edxapp_toxenv}
 
 [testenv]
 basepython=python3.5
+# TODO: Remove tox-pip-version once we upgrade to Koa+, or whenever we have addressed pip 20.3 strict issues.
+pip_version=pip==20.2.4
 # This ensures "-e ." is installed, so that a link back to the top-level
 # edx-platform source directory is installed in site-packages, making
 # edx-platform source code importable from python subprocesses.  Child
@@ -174,7 +176,7 @@ commands =
     pytest {posargs:openedx/core/djangoapps/appsembler/multi_tenant_emails}
 
 [testenv:common-minimal]
-# Minimal test case just to see tox in Travis
+# Minimal test case just to see tox on the CI. Useful for CI debugging.
 # TODO: Remove after Juniper is in production since this duplicates the `common` env
 commands =
     pytest common/djangoapps/student/tests/test_helpers.py


### PR DESCRIPTION
`tox`'s `virtualenv` automatically downloads the latest pip (now pip 20.3) which has strict checks and prevents a couple of requirements from being installed due to issues in upstream.

This patches the issues by pinning pip at `20.2.4` so it does't have strict checks.