### PR TITLE
fix merge noise: duplicate tox version broke tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ pip_version=pip==20.2.4
 # directory without hacking sys.path, but they will inherit the tox virtualenv
 # and look in site-packages.
 usedevelop=True
-pip_version=pip<20
 setenv =
     PYTHONHASHSEED=0
     TOXENV={envname}


### PR DESCRIPTION
fix the following error which I made in manually merging #758 due to conflicts. I will make another PR next time.

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.5.10/x64/bin/tox", line 8, in <module>
    sys.exit(cmdline())
  File "/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/site-packages/tox/session/__init__.py", line 44, in cmdline
    main(args)
  File "/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/site-packages/tox/session/__init__.py", line 65, in main
    config = load_config(args)
  File "/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/site-packages/tox/session/__init__.py", line 81, in load_config
    config = parseconfig(args)
  File "/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/site-packages/tox/config/__init__.py", line 278, in parseconfig
    ParseIni(config, config_file, content)
  File "/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/site-packages/tox/config/__init__.py", line 1097, in __init__
    self._cfg = py.iniconfig.IniConfig(config.toxinipath, ini_data)
  File "/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/site-packages/py/_vendored_packages/iniconfig.py", line 73, in __init__
    self._raise(lineno, 'duplicate name %r' % (name, ))
  File "/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/site-packages/py/_vendored_packages/iniconfig.py", line 77, in _raise
    raise ParseError(self.path, lineno, msg)
py._vendored_packages.iniconfig.ParseError: /home/runner/work/edx-platform/edx-platform/tox.ini:28: duplicate name 'pip_version'
Error: The operation was canceled.
```