### PR TITLE
Return exception if cannot get the site config in event in segment top level processor

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -31,6 +31,11 @@ def get_site_config_for_event(event_props):
                 # allow to fail if more than one Organization to avoid sharing data
                 orgcourse = models.OrganizationCourse.objects.get(course_id=args)
                 org = orgcourse.organization
+            else:
+                raise exceptions.EventProcessingError(
+                    "There isn't and org or course_id attribute set in the "
+                    "segment event, so we couldn't determine the site."
+                )
             site = utils.get_site_by_organization(org)
             site_configuration = site.configuration
         except (


### PR DESCRIPTION
Figures is hitting a lot of exceptions generated by this processor while running the pipeline:
```
2020-12-11 09:11:38,675 ERROR 22421 [eventtracking.backends.routing] routing.py:114 - Failed to execute processor: <openedx.core.djangoapps.appsembler.eventtracking.segment.SegmentTopLevelPropertiesProcessor object at 0x7efcba5b50d0>
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/eventtracking/backends/routing.py", line 107, in process_event
    modified_event = processor(processed_event)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/appsembler/eventtracking/segment.py", line 70, in __call__
    siteconfig = utils.get_site_config_for_event(event['data'])
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/appsembler/eventtracking/utils.py", line 34, in get_site_config_for_event
    site = utils.get_site_by_organization(org)
UnboundLocalError: local variable 'org' referenced before assignment
```
When there is not a site, the event should go main Appsembler segment destination only.