### PR TITLE
upgrade dj-database-url to 0.5.0

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -3,7 +3,7 @@ python-intercom==3.1.0
 raven==6.10.0
 django-anymail==5.0
 django-tiers==0.2.2
-dj-database-url==0.4.2
+dj-database-url==0.5.0
 psycopg2-binary==2.8.3
 django-hijack==2.1.10
 django-hijack-admin==2.1.10


### PR DESCRIPTION
it adds testing/support for python 3.5, which is what we use now.

hopefully this fixes an issue I've run into with `dj-database-url`
complaining about wanting bytes instead of a string for the tiers
database URL.
