### PR TITLE
Allow auto-generation of certs (e.g., on passing grade) for Honor mode

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -3,6 +3,7 @@ Signal handler for enabling/disabling self-generated certificates based on the c
 """
 import logging
 
+from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -126,6 +127,12 @@ def fire_ungenerated_certificate_task(user, course_key, expected_verification_st
         CourseMode.PROFESSIONAL,
         CourseMode.NO_ID_PROFESSIONAL_MODE,
     ]
+    if settings.FEATURES.get('TAHOE_AUTO_GENERATE_HONOR_CERTS', False):
+        # Appsembler change: allow for Honor mode
+        allowed_enrollment_modes_list += [
+            CourseMode.HONOR
+        ]
+
     enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
     cert = GeneratedCertificate.certificate_for_student(user, course_key)
 

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -5,6 +5,8 @@ and disabling for instructor-paced courses.
 import ddt
 import mock
 
+from django.conf import settings
+
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -311,9 +313,10 @@ class CertificateGenerationTaskTest(ModuleStoreTestCase):
         ('no-id-professional', True),
         ('credit', True),
         ('audit', False),
-        ('honor', False),
+        ('honor', True),  # TAHOE_AUTO_GENERATE_HONOR_CERTS feature: allows for honor
     )
     @ddt.unpack
+    @mock.patch.dict(settings.FEATURES, {'TAHOE_AUTO_GENERATE_HONOR_CERTS': True})
     def test_fire_ungenerated_certificate_task_allowed_modes(self, enrollment_mode, should_create):
         """
         Test that certificate generation task is fired for only modes that are

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -46,3 +46,6 @@ def plugin_settings(settings):
     settings.CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX = 'custom_domains_redirects'
 
     settings.COPY_SEGMENT_EVENT_PROPERTIES_TO_TOP_LEVEL = False
+
+    # Appsembler allows generating honor certs
+    settings.FEATURES['TAHOE_AUTO_GENERATE_HONOR_CERTS'] = True


### PR DESCRIPTION
Even as of Koa, auto-generation of certs is not allowed for Audit or Honor.   It is allowed for Verified, Credit, Professional, and No ID Professional.  https://github.com/edx/edx-platform/blob/151bd136667d27bf85256e382ed5b5ea0144e00f/lms/djangoapps/certificates/signals.py#L145 

None of the allowed modes work for Tahoe because:

* A payment workflow is enforced for enrollment with mode Verified, Professional, and No ID Professional
* Credit is meant to a purchased add-on mode after course completion and expects a credit provider id.  Also Credit mode will block Certificates page from showing up in Studio (at least as of Hawthorn)... why, I do not know.

So, we should just allow auto-certs for Honor.  This PR does that.