### PR TITLE
Install appsembler.txt requirements files during devstack provisioning

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -37,6 +37,11 @@ PRIVATE_REQS = 'requirements/private.txt'
 if os.path.exists(PRIVATE_REQS):
     PYTHON_REQ_FILES.append(PRIVATE_REQS)
 
+# Appsembler: Install appsembler.txt requirements files during devstack provisioning.
+APPSEMBLER_REQS = 'requirements/edx/appsembler.txt'
+if os.path.exists(APPSEMBLER_REQS):
+    PYTHON_REQ_FILES.append(APPSEMBLER_REQS)
+
 
 def str2bool(s):
     s = str(s)


### PR DESCRIPTION
Provisioning devstack fails on `xmodule_assets common/static/xmodule` as `honeycomb-beeline` cannot be found. This PR allows appsembler requirements to be installed during provisioning.