### PR TITLE
(wip) test appsembler api urls

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1016,13 +1016,11 @@ urlpatterns += (
 )
 
 # Tahoe API
-if not settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-    # TODO: This URL import is broken in Juniper and needs upgrade
-    urlpatterns += (
-        url(r'^tahoe/api/',
-            include('openedx.core.djangoapps.appsembler.api.urls',
-                    namespace='tahoe-api')),
-    )
+urlpatterns += (
+    url(r'^tahoe/api/',
+        include('openedx.core.djangoapps.appsembler.api.urls',
+                namespace='tahoe-api')),
+)
 
 urlpatterns.extend(plugin_urls.get_patterns(plugin_constants.ProjectType.LMS))
 


### PR DESCRIPTION
RED-1476

This error shows up when attempting to include the `appsembler.api.urls` app. I don't know how to fix it.

```
_____ ERROR collecting common/djangoapps/student/tests/test_admin_views.py _____
common/djangoapps/student/tests/test_admin_views.py:206: in <module>
    class CourseEnrollmentAdminTest(SharedModuleStoreTestCase):
common/djangoapps/student/tests/test_admin_views.py:211: in CourseEnrollmentAdminTest
    ('get', reverse('admin:student_courseenrollment_add')),
../../../edxapp_toxenv/common/src/django-wiki/wiki/models/__init__.py:91: in reverse
    url = original_django_reverse(*args, **kwargs)
../../../edxapp_toxenv/common/lib/python3.5/site-packages/django/urls/base.py:58: in reverse
    app_list = resolver.app_dict[ns]
../../../edxapp_toxenv/common/lib/python3.5/site-packages/django/urls/resolvers.py:513: in app_dict
    self._populate()
../../../edxapp_toxenv/common/lib/python3.5/site-packages/django/urls/resolvers.py:447: in _populate
    for url_pattern in reversed(self.url_patterns):
../../../edxapp_toxenv/common/lib/python3.5/site-packages/django/utils/functional.py:80: in __get__
    res = instance.__dict__[self.name] = self.func(instance)
../../../edxapp_toxenv/common/lib/python3.5/site-packages/django/urls/resolvers.py:584: in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
../../../edxapp_toxenv/common/lib/python3.5/site-packages/django/utils/functional.py:80: in __get__
    res = instance.__dict__[self.name] = self.func(instance)
../../../edxapp_toxenv/common/lib/python3.5/site-packages/django/urls/resolvers.py:577: in urlconf_module
    return import_module(self.urlconf_name)
/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
lms/urls.py:1022: in <module>
    namespace='tahoe-api')),
../../../edxapp_toxenv/common/lib/python3.5/site-packages/django/urls/conf.py:34: in include
    urlconf_module = import_module(urlconf_module)
/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
openedx/core/djangoapps/appsembler/api/urls.py:12: in <module>
    url(r'^v1/', include(v1_urls, namespace='v1')),
../../../edxapp_toxenv/common/lib/python3.5/site-packages/django/urls/conf.py:39: in include
    'Specifying a namespace in include() without providing an app_name '
E   django.core.exceptions.ImproperlyConfigured: Specifying a namespace in include() without providing an app_name is not supported. Set the app_name attribute in the included module, or pass a 2-tuple containing the list of patterns and app_name instead.
```