### PR TITLE
enable SSL on tiers postgres connection

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -61,7 +61,7 @@ def plugin_settings(settings):
         settings.TIERS_ORGANIZATION_TIER_GETTER_NAME = 'get_tier_for_org'
 
         settings.TIERS_DATABASE_URL = settings.AUTH_TOKENS.get('TIERS_DATABASE_URL')
-        settings.DATABASES['tiers'] = dj_database_url.parse(settings.TIERS_DATABASE_URL)
+        settings.DATABASES['tiers'] = dj_database_url.parse(settings.TIERS_DATABASE_URL, ssl_require=True)
         settings.DATABASE_ROUTERS += ['openedx.core.djangoapps.appsembler.sites.routers.TiersDbRouter']
 
         settings.MIDDLEWARE += (


### PR DESCRIPTION
This should allow us to re-enable "Allow only SSL connections" on our Postgres instance. We also ought to use a client certificate but `dj-database-url` doesn't support those arguments so it will be trickier to configure. This should at least eliminate one plaintext communication channel.