### PR TITLE
Comment Appsembler changes to provision the devstack

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -399,7 +399,9 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 from .common import _make_mako_template_dirs
 ENABLE_COMPREHENSIVE_THEMING = True
 COMPREHENSIVE_THEME_DIRS = [
-    "/edx/var/edxapp/themes",
+    "/edx/app/edxapp/edx-platform/common/test/appsembler",
 ]
 TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
 derive_settings(__name__)
+
+DEFAULT_SITE_THEME = 'edx-theme-codebase'

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -79,8 +79,10 @@ class SiteConfiguration(models.Model):
     def save(self, **kwargs):
         # When creating a new object, save default microsite values. Not implemented as a default method on the field
         # because it depends on other fields that should be already filled.
-        if not self.site_values:
-            self.site_values = self.get_initial_microsite_values()
+
+        # TODO: provisioning keeps breaking
+        # if not self.site_values:
+        self.site_values = self.get_initial_microsite_values()
 
         # fix for a bug with some pages requiring uppercase platform_name variable
         self.site_values['PLATFORM_NAME'] = self.site_values.get('platform_name', '')


### PR DESCRIPTION
This is not meant to be merged, but it's a hack to make sure the `make dev.provision` command works on our branches.

### What's hacked?
- Devstack to use `ENABLE_COMPREHENSIVE_THEMING`.
- `get_initial_sass_variables` to return an empty list (Most of the files it's relying on are no longer available in edX themes).
- `self.compile_microsite_sass()` is not being called for the same reason above.

### What's fixed?
- Appsembler's `storage_class` call.

If you have any advice on how to make these calls work that'd be great, but for now and until @grozdanowski comes back I think this is a good start to provision the devstack.