### PR TITLE
Data research role to include course staff and instructor

### DIFF
--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -46,7 +46,8 @@ perms[GIVE_STUDENT_EXTENSION] = HasAccessRule('staff')
 perms[VIEW_ISSUED_CERTIFICATES] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 # only global staff or those with the data_researcher role can access the data download tab
 # HasAccessRule('staff') also includes course staff
-perms[CAN_RESEARCH] = is_staff | HasRolesRule('data_researcher')
+# Tahoe: We need to add `instructor` and `staff` for Tahoe multi-tenancy.
+perms[CAN_RESEARCH] = is_staff | HasRolesRule('data_researcher') | HasAccessRule('instructor') | HasAccessRule('staff')
 perms[CAN_ENROLL] = HasAccessRule('staff')
 perms[CAN_BETATEST] = HasAccessRule('instructor')
 perms[ENROLLMENT_REPORT] = HasAccessRule('staff') | HasRolesRule('data_researcher')

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -139,8 +139,8 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         self.assertTrue(has_instructor_tab(org_researcher, self.course))
 
     @ddt.data(
-        ('staff', False),
-        ('instructor', False),
+        ('staff', True),  # Tahoe: Enable staff data download so non user.is_staff customers can access data (RED-1505)
+        ('instructor', True),  # Tahoe: Enable instructor data download (same as above RED-1505)
         ('data_researcher', True),
         ('global_staff', True),
     )


### PR DESCRIPTION
RED-1505. This allows Tahoe customers (non global staff) to download grade reports in instructor dashboard.