### PR TITLE
lms organization middleware to make tiers expiration work in lms

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_cms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_cms.py
@@ -33,6 +33,7 @@ def plugin_settings(settings):
         settings.RAVEN_CONFIG['tags']['app'] = 'cms'
 
     settings.MIDDLEWARE_CLASSES += (
+        # TODO: OrganizationMiddleware should be added before Tiers middleware in `aws_common.plugin_settings()`
         'organizations.middleware.OrganizationMiddleware',
     )
 

--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
@@ -43,6 +43,11 @@ def plugin_settings(settings):
 
     This file, however, won't run in test environments.
     """
+    settings.MIDDLEWARE_CLASSES += (
+        # LmsCurrentOrganizationMiddleware needs to go before `TiersMiddleware` in aws_common.plugin_settings()
+        'openedx.core.djangoapps.appsembler.sites.middleware.LmsCurrentOrganizationMiddleware',
+    )
+
     aws_common.plugin_settings(settings)
 
     settings.LMS_BASE = settings.ENV_TOKENS.get('LMS_BASE')

--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -1,12 +1,15 @@
+import beeline
+import logging
+
 from django.conf import settings
 from django.core.cache import cache, caches
 from django.contrib.redirects.models import Redirect
 from django.shortcuts import redirect
 
 from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
+from openedx.core.djangoapps.appsembler.sites.utils import get_current_organization
 
-import beeline
-import logging
+
 log = logging.getLogger(__name__)
 
 
@@ -66,3 +69,17 @@ class RedirectMiddleware(object):
         redirect_to = redirects.get(request.path)
         if redirect_to:
             return redirect(redirect_to, permanent=True)
+
+
+class LmsCurrentOrganizationMiddleware(object):
+    """
+    Get the current middleware for the LMS.
+
+    This middleware replaces the default `organizations.OrganizationMiddleware` to
+    use a better get_current_organization() helper.
+    """
+    def process_request(self, request):
+        # Note: This does _not_ support multiple organizations per user.
+        organization = get_current_organization(failure_return_none=True)
+        beeline.add_trace_field('session_current_organization', organization)
+        request.session['organization'] = organization

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_middlewares.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_middlewares.py
@@ -1,0 +1,28 @@
+"""
+Tests for the sites.middlewares module.
+"""
+
+from mock import patch, Mock
+from django.test import TestCase
+
+from openedx.core.djangoapps.appsembler.sites.middleware import LmsCurrentOrganizationMiddleware
+
+
+@patch('openedx.core.djangoapps.appsembler.sites.middleware.get_current_organization')
+class LmsCurrentOrganizationMiddlewareTests(TestCase):
+    def test_with_organization(self, get_current_organization):
+        middleware = LmsCurrentOrganizationMiddleware()
+        request = Mock(session={})
+        fake_org = Mock()
+        get_current_organization.return_value = fake_org
+
+        middleware.process_request(request)
+        assert request.session['organization'] is fake_org
+
+    def test_with_no_organization(self, get_current_organization):
+        middleware = LmsCurrentOrganizationMiddleware()
+        request = Mock(session={})
+        get_current_organization.return_value = None
+
+        middleware.process_request(request)
+        assert request.session['organization'] is None


### PR DESCRIPTION
### Summary
RED-1431. Tiers app never worked in the LMS (as far as I know). This PR will activate it.

This PR will help us to disable expired sites in the LMS after the following `tiers` update: https://github.com/appsembler/django-tiers/pull/22.

### Performance implications
This PR makes use of sessions on every request on the LMS. LMS already initialize sessions on _every_ request, so this PR should not make a performance hit.

However, if there's an issue we probably want to revert this PR.

### Tiers interaction

The [`TiersMiddleware` was short-circuited](https://github.com/appsembler/django-tiers/blob/364fc7cbe1000d213fc3622163cd5f536bdcd1c9/tiers/middleware.py#L49-L53) due to _not_ having the `organization` in the session. If something breaks or we get weird redirects, we should also revert this PR.

### Staging deployment
To test the safety of both we'll rely on testing in staging more than anything else due to the complex interactions between the different components.