### PR TITLE
Put default site redirect behind a FEATURE flag, defaulting enabled

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
@@ -113,4 +113,8 @@ def plugin_settings(settings):
 
     settings.USE_S3_FOR_CUSTOMER_THEMES = True
 
+    settings.FEATURES['TAHOE_ENABLE_DEFAULT_SITE_REDIRECT'] = settings.ENV_TOKENS['FEATURES'].get(
+        'TAHOE_ENABLE_DEFAULT_SITE_REDIRECT', True
+    )
+
     _add_theme_static_dirs(settings)

--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
@@ -33,6 +33,10 @@ def plugin_settings(settings):
         if path.isdir(customer_themes_dir):
             settings.STATICFILES_DIRS.insert(0, ('customer_themes', customer_themes_dir))
 
+    settings.FEATURES['TAHOE_ENABLE_DEFAULT_SITE_REDIRECT'] = settings.ENV_TOKENS['FEATURES'].get(
+        'TAHOE_ENABLE_DEFAULT_SITE_REDIRECT', True
+    )
+
     # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
     # from the redirect mechanics.
     settings.MAIN_SITE_REDIRECT_WHITELIST += ['/media/']

--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -48,19 +48,20 @@ class RedirectMiddleware(object):
         Redirects the current request if there is a matching Redirect model
         with the current request URL as the old_path field.
         """
-        site = request.site
-        try:
-            beeline.add_trace_field("site_id", site.id)
-            in_whitelist = any(map(
-                lambda p: p in request.path,
-                settings.MAIN_SITE_REDIRECT_WHITELIST))
-            if (site.id == settings.SITE_ID) and not in_whitelist:
-                return redirect("https://appsembler.com/tahoe/")
-        except Exception:
-            # I'm not entirely sure this middleware get's called only in LMS or in other apps as well.
-            # Soooo just in case
-            beeline.add_trace_field("redirect_middleware_exception", True)
-            pass
+        if settings.FEATURES.get("TAHOE_ENABLE_DEFAULT_SITE_REDIRECT", True):
+            site = request.site
+            try:
+                beeline.add_trace_field("site_id", site.id)
+                in_whitelist = any(map(
+                    lambda p: p in request.path,
+                    settings.MAIN_SITE_REDIRECT_WHITELIST))
+                if (site.id == settings.SITE_ID) and not in_whitelist:
+                    return redirect("https://appsembler.com/tahoe/")
+            except Exception:
+                # I'm not entirely sure this middleware get's called only in LMS or in other apps as well.
+                # Soooo just in case
+                beeline.add_trace_field("redirect_middleware_exception", True)
+                pass
         cache_key = '{prefix}-{site}'.format(prefix=settings.REDIRECT_CACHE_KEY_PREFIX, site=site.domain)
         redirects = cache.get(cache_key)
         if redirects is None:


### PR DESCRIPTION
Let's not assume the tahoe edx-platform branches are running on Tahoe SaaS.  For a standalone site we don't want to assume that the default Site is not the Site we want.  

This puts a feature flag in front of the Redirect middleware that checks for the request host matching no defined Site, and if not, redirecting to appsembler.com/tahoe

I needed to put this in place to get some kind of Preview functionality working on DHIS2 standalone.  