### PR TITLE
get_lms_link_from_course_key fallback to LMS base if no Site found

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -37,12 +37,12 @@ def get_lms_link_from_course_key(base_lms_url, course_key):
     """
     beeline.add_context_field("base_lms_url", base_lms_url)
     beeline.add_context_field("course_key", course_key)
-    try:
-        site_domain = Site.objects.get(name=course_key.org).domain
-    except Site.DoesNotExist:
-        site_domain = "{}.{}".format(course_key.org, base_lms_url)
-
-    return site_domain
+    # avoid circular import
+    from openedx.core.djangoapps.appsembler.api.sites import get_site_for_course
+    course_site = get_site_for_course(course_key)
+    if course_site:
+        return course_site.domain
+    return base_lms_url
 
 
 @beeline.traced(name="get_site_by_organization")


### PR DESCRIPTION
The way this is written now is adding a lot of complexity for standalone deployments.  There, we have a single Site with multiple course orgs.  As far as I can tell, there's no need within Tahoe SaaS multitenant to fall back to {course_org}.LMS_BASE if no Site with the name of the course org is found.  There are many other points of the system that enforce or will break unless that Site is named 'chef' or whatever.  

As it is, for a single-site standalone, the Site not found fallback then means we have to support wildcard subdomains, as all of our preview and jump_to links will end up going to {course_org}.lms_base.customer_domain.com.  That gets complicated, as wildcard LE certs require DNS TXT record validation, etc.

So, putting this together as a Draft for initial feedback.  If it looks good to go ahead I'll write tests (there are none yet anyhow). 