### PR TITLE
get_active_sites() to return QuerySet

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -54,6 +54,26 @@ def get_site_by_organization(org):
     return org.sites.all()[0]
 
 
+def _get_active_tiers_uuids():
+    """
+    Get active Tier organiation UUIDs from the Tiers (AMC Postgres) database.
+
+    Note: This mostly a hack that's needed for improving the performance of
+          batch operations by excluding dead sites.
+
+    TODO: This helper should live in a future Tahoe Sites package.
+    """
+    from tiers.models import Tier
+    # This queries the AMC Postgres database
+    active_tiers_uuids = Tier.objects.filter(
+        Q(tier_enforcement_exempt=True) |
+        Q(tier_expires_at__gte=timezone.now())
+    ).annotate(
+        organization_edx_uuid=F('organization__edx_uuid')
+    ).values_list('organization_edx_uuid', flat=True)
+    return active_tiers_uuids
+
+
 def get_active_organizations():
     """
     Get active organizations based on Tiers information.
@@ -63,22 +83,15 @@ def get_active_organizations():
 
     TODO: This helper should live in a future Tahoe Sites package.
     """
-    from tiers.models import Tier
-    # This queries the AMC Postgres database
-    active_tiers = Tier.objects.filter(
-        Q(tier_enforcement_exempt=True) |
-        Q(tier_expires_at__gte=timezone.now())
-    ).annotate(
-        organization_edx_uuid=F('organization__edx_uuid')
-    ).values_list('organization_edx_uuid', flat=True)
+    active_tiers_uuids = _get_active_tiers_uuids()
 
     # Now back to the LMS MySQL database
     return Organization.objects.filter(
-        edx_uuid__in=[str(edx_uuid) for edx_uuid in active_tiers],
+        edx_uuid__in=[str(edx_uuid) for edx_uuid in active_tiers_uuids],
     )
 
 
-def get_active_sites():
+def get_active_sites(order_by='domain'):
     """
     Get active sites based on Tiers information.
 
@@ -87,10 +100,9 @@ def get_active_sites():
 
     TODO: This helper should live in a future Tahoe Sites package.
     """
-    sites = []
-    for organization in get_active_organizations():
-        sites.extend(organization.sites.all())
-    return sites
+    return Site.objects.filter(
+        organizations__in=get_active_organizations()
+    ).order_by(order_by)
 
 
 @beeline.traced(name="get_amc_oauth_client")


### PR DESCRIPTION
 - added tests
 - added order_by parameter
 - refactored `_get_active_tiers_uuids` to isolate the Tiers import

This PR addresses an indirect bug in which Figures expects a QuerySet:

 - https://sentry.io/organizations/appsembler/issues/2198232186/?project=145493&query=is%3Aunresolved

```
do_update_enrollment_data = False if date_for < today else True
    sites = get_sites()
    sites_count = sites.count()
    ^

TypeError: count() takes exactly one argument (0 given)
```