### PR TITLE
Move RedirectMiddleware to appsembler.settings plugin

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1242,8 +1242,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
 
     # Allows us to define redirects via Django admin
-    'openedx.core.djangoapps.appsembler.sites.middleware.CustomDomainsRedirectMiddleware',
-    'openedx.core.djangoapps.appsembler.sites.middleware.RedirectMiddleware',
+    'django_sites_extensions.middleware.RedirectMiddleware',
 
     # Instead of SessionMiddleware, we use a more secure version
     # 'django.contrib.sessions.middleware.SessionMiddleware',

--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
@@ -7,6 +7,7 @@ from openedx.core.djangoapps.appsembler.settings.settings import aws_common
 
 
 EDX_SITE_REDIRECT_MIDDLEWARE = "django_sites_extensions.middleware.RedirectMiddleware"
+TAHOE_MARKETING_SITE_URL = "https://appsembler.com/tahoe"
 
 
 def _add_theme_static_dirs(settings):
@@ -62,7 +63,7 @@ def plugin_settings(settings):
             settings.MIDDLEWARE_CLASSES.insert(redir_middleware, tahoe_redir_middleware)
 
         settings.TAHOE_MAIN_SITE_REDIRECT_URL = settings.ENV_TOKENS.get(
-            'TAHOE_MAIN_SITE_REDIRECT_URL', 'https://appsembler.com/tahoe/'
+            'TAHOE_MAIN_SITE_REDIRECT_URL', TAHOE_MARKETING_SITE_URL
         )
         # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
         # from the redirect mechanics.

--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
@@ -60,6 +60,10 @@ def plugin_settings(settings):
             'openedx.core.djangoapps.appsembler.sites.middleware.RedirectMiddleware'
         ):
             settings.MIDDLEWARE_CLASSES.insert(redir_middleware, tahoe_redir_middleware)
+
+        settings.TAHOE_MAIN_SITE_REDIRECT_URL = settings.ENV_TOKENS.get(
+            'TAHOE_MAIN_SITE_REDIRECT_URL', 'https://appsembler.com/tahoe/'
+        )
         # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
         # from the redirect mechanics.
         settings.MAIN_SITE_REDIRECT_WHITELIST = [

--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_lms.py
@@ -55,12 +55,15 @@ def plugin_settings(settings):
     aws_common.plugin_settings(settings)
 
     if settings.APPSEMBLER_FEATURES.get("TAHOE_ENABLE_DOMAIN_REDIRECT_MIDDLEWARE", True):
-        redir_middleware = settings.MIDDLEWARE_CLASSES.index(EDX_SITE_REDIRECT_MIDDLEWARE)
-        for tahoe_redir_middleware in (
-            'openedx.core.djangoapps.appsembler.sites.middleware.CustomDomainsRedirectMiddleware',
+        redir_middleware_index = settings.MIDDLEWARE_CLASSES.index(EDX_SITE_REDIRECT_MIDDLEWARE)
+        settings.MIDDLEWARE_CLASSES.insert(
+            redir_middleware_index,  # Insert after Django RedirectMiddleware
+            'openedx.core.djangoapps.appsembler.sites.middleware.CustomDomainsRedirectMiddleware'
+        )
+        settings.MIDDLEWARE_CLASSES.insert(
+            redir_middleware_index + 1,  # Insert after CustomDomainsRedirectMiddleware
             'openedx.core.djangoapps.appsembler.sites.middleware.RedirectMiddleware'
-        ):
-            settings.MIDDLEWARE_CLASSES.insert(redir_middleware, tahoe_redir_middleware)
+        )
 
         settings.TAHOE_MAIN_SITE_REDIRECT_URL = settings.ENV_TOKENS.get(
             'TAHOE_MAIN_SITE_REDIRECT_URL', TAHOE_MARKETING_SITE_URL

--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_lms.py
@@ -35,4 +35,5 @@ def plugin_settings(settings):
 
     # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
     # from the redirect mechanics.
-    settings.MAIN_SITE_REDIRECT_WHITELIST += ['/media/']
+    if settings.APPSEMBLER_FEATURES.get("TAHOE_ENABLE_DOMAIN_REDIRECT_MIDDLEWARE", True):
+        settings.MAIN_SITE_REDIRECT_WHITELIST += ['/media/']

--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -54,7 +54,7 @@ class RedirectMiddleware(object):
                 lambda p: p in request.path,
                 settings.MAIN_SITE_REDIRECT_WHITELIST))
             if (site.id == settings.SITE_ID) and not in_whitelist:
-                return redirect("https://appsembler.com/tahoe/")
+                return redirect(settings.TAHOE_MAIN_SITE_REDIRECT_URL)
         except Exception:
             # I'm not entirely sure this middleware get's called only in LMS or in other apps as well.
             # Soooo just in case

--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -2,8 +2,7 @@ import beeline
 import logging
 
 from django.conf import settings
-from django.core.cache import cache, caches
-from django.contrib.redirects.models import Redirect
+from django.core.cache import caches
 from django.shortcuts import redirect
 
 from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain

--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -40,8 +40,7 @@ class CustomDomainsRedirectMiddleware(object):
 
 class RedirectMiddleware(object):
     """
-    Redirects requests for URLs persisted using the django.contrib.redirects.models.Redirect model.
-    With the exception of the main site.
+    Redirects requests for main site to Tahoe marketing page, except whitelisted.
     """
     def process_request(self, request):
         """
@@ -61,17 +60,6 @@ class RedirectMiddleware(object):
             # Soooo just in case
             beeline.add_trace_field("redirect_middleware_exception", True)
             pass
-        cache_key = '{prefix}-{site}'.format(prefix=settings.REDIRECT_CACHE_KEY_PREFIX, site=site.domain)
-        redirects = cache.get(cache_key)
-        if redirects is None:
-            redirects = {
-                django_redirect.old_path: django_redirect.new_path
-                for django_redirect in Redirect.objects.filter(site=site)
-            }
-            cache.set(cache_key, redirects, settings.REDIRECT_CACHE_TIMEOUT)
-        redirect_to = redirects.get(request.path)
-        if redirect_to:
-            return redirect(redirect_to, permanent=True)
 
 
 class LmsCurrentOrganizationMiddleware(object):

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_middlewares.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_middlewares.py
@@ -3,7 +3,7 @@ Tests for the sites.middlewares module.
 """
 
 from mock import patch, Mock
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
 from openedx.core.djangoapps.appsembler.sites.middleware import LmsCurrentOrganizationMiddleware, RedirectMiddleware
@@ -30,36 +30,37 @@ class LmsCurrentOrganizationMiddlewareTests(TestCase):
         assert request.session['organization'] is None
 
 
-@patch('settings.TAHOE_MAIN_SITE_REDIRECT_URL', 'https://foo.bar')
+@override_settings(TAHOE_MAIN_SITE_REDIRECT_URL='https://foo.bar')
+@override_settings(MAIN_SITE_REDIRECT_WHITELIST=['/baz'])
 class RedirectMiddlewareTests(TestCase):
-    def setup(self):
+    def setUp(self):
+        super(RedirectMiddlewareTests, self).setUp()
         self.default_site = SiteFactory.create()
         self.other_site = SiteFactory.create()
-        patcher = patch("settings.SITE_ID", self.default_site.id)
+        patcher = patch("django.conf.settings.SITE_ID", self.default_site.id)
         patcher.start()
         self.addCleanup(patcher.stop)
 
     def test_redirects_default_site(self):
-        request = RequestFactory().get(self.default_site.domain)
+        request = RequestFactory().get('/path', HTTP_HOST=self.default_site.domain)
         request.site = self.default_site
         processed = RedirectMiddleware().process_request(request)
-        self.assertRedirects(processed, 'https://foo.bar')
+        self.assertEquals(processed.url, 'https://foo.bar')  # middleware drops the path
 
     def test_with_no_site_found(self):
-        request = RequestFactory().get("/")
+        request = RequestFactory().get('/')
         request.site = None
         processed = RedirectMiddleware().process_request(request)
-        self.assertEquals(processed, None)
+        self.assertIsNone(processed)
 
     def test_no_redirect_other_site(self):
-        request = RequestFactory().get(self.other_site.domain)
+        request = RequestFactory().get('/', HTTP_HOST=self.other_site.domain)
         request.site = self.other_site
         processed = RedirectMiddleware().process_request(request)
-        self.assertEquals(processed, None)
+        self.assertIsNone(processed)
 
-    @patch('settings.MAIN_SITE_REDIRECT_WHITELIST', ['/baz'])
     def test_url_in_whitelist(self):
-        request = RequestFactory().get('{}/baz'.format(self.default_site.domain))
+        request = RequestFactory().get('/baz', HTTP_HOST=self.default_site.domain)
         request.site = self.default_site
         processed = RedirectMiddleware().process_request(request)
-        self.assertEquals(processed, None)
+        self.assertIsNone(processed)

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_middlewares.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_middlewares.py
@@ -4,8 +4,10 @@ Tests for the sites.middlewares module.
 
 from mock import patch, Mock
 from django.test import TestCase
+from django.test.client import RequestFactory
 
-from openedx.core.djangoapps.appsembler.sites.middleware import LmsCurrentOrganizationMiddleware
+from openedx.core.djangoapps.appsembler.sites.middleware import LmsCurrentOrganizationMiddleware, RedirectMiddleware
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 
 
 @patch('openedx.core.djangoapps.appsembler.sites.middleware.get_current_organization')
@@ -26,3 +28,38 @@ class LmsCurrentOrganizationMiddlewareTests(TestCase):
 
         middleware.process_request(request)
         assert request.session['organization'] is None
+
+
+@patch('settings.TAHOE_MAIN_SITE_REDIRECT_URL', 'https://foo.bar')
+class RedirectMiddlewareTests(TestCase):
+    def setup(self):
+        self.default_site = SiteFactory.create()
+        self.other_site = SiteFactory.create()
+        patcher = patch("settings.SITE_ID", self.default_site.id)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_redirects_default_site(self):
+        request = RequestFactory().get(self.default_site.domain)
+        request.site = self.default_site
+        processed = RedirectMiddleware().process_request(request)
+        self.assertRedirects(processed, 'https://foo.bar')
+
+    def test_with_no_site_found(self):
+        request = RequestFactory().get("/")
+        request.site = None
+        processed = RedirectMiddleware().process_request(request)
+        self.assertEquals(processed, None)
+
+    def test_no_redirect_other_site(self):
+        request = RequestFactory().get(self.other_site.domain)
+        request.site = self.other_site
+        processed = RedirectMiddleware().process_request(request)
+        self.assertEquals(processed, None)
+
+    @patch('settings.MAIN_SITE_REDIRECT_WHITELIST', ['/baz'])
+    def test_url_in_whitelist(self):
+        request = RequestFactory().get('{}/baz'.format(self.default_site.domain))
+        request.site = self.default_site
+        processed = RedirectMiddleware().process_request(request)
+        self.assertEquals(processed, None)


### PR DESCRIPTION
Split out original edX Django Extensions RedirectMiddleware (Redirect model-based 302s) from Tahoe-specific redirect middleware for default site minus whitelisted paths.  Use appsembler.sites.middleware.RedirectMiddleware when enabled via settings.  Default to enabled.

This change allows us to skip this behavior on standalone installs.

Add the first tests for this feature, too!