### PR TITLE
Juniper upgrade TPA Admin update

### DIFF
--- a/openedx/core/djangoapps/appsembler/tpa_admin/api.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/api.py
@@ -1,3 +1,8 @@
+"""
+
+TODO: We should move the views here to the tpa_admin.views module to adhere to
+standard practices
+"""
 from rest_framework import generics, viewsets
 from rest_framework.permissions import IsAuthenticated
 from openedx.core.djangoapps.appsembler.sites.permissions import AMCAdminPermission
@@ -10,35 +15,59 @@ from openedx.core.djangoapps.appsembler.tpa_admin.serializers import (
     SAMLConfigurationSerializer,
     SAMLProviderConfigSerializer,
 )
+from openedx.core.djangoapps.appsembler.tpa_admin.filters import (
+    SAMLConfigurationFilter,
+    SAMLProviderConfigFilter,
+)
 
 
 class SAMLConfigurationViewSet(viewsets.ModelViewSet):
-    queryset = SAMLConfiguration.objects.current_set()
+    model = SAMLConfiguration
+    queryset = SAMLConfiguration.objects.current_set().order_by('id')
     serializer_class = SAMLConfigurationSerializer
     authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
     permission_classes = (IsAuthenticated, AMCAdminPermission)
+    filter_class = SAMLConfigurationFilter
 
 
 class SAMLConfigurationSiteDetail(generics.RetrieveAPIView):
+    """
+    We may not need this view as SAMLConfigurationViewSet provides filtering
+    by site id with following endpoint and query param
+
+    ```
+    saml-configurations/?site_id=<site_id>
+    ```
+    """
     serializer_class = SAMLConfigurationSerializer
     lookup_field = 'site_id'
 
     def get_queryset(self):
         site_id = self.kwargs['site_id']
-        return SAMLConfiguration.objects.current_set().filter(site__id=site_id)
+        return SAMLConfiguration.objects.current_set().filter(site_id=site_id)
 
 
 class SAMLProviderConfigViewSet(viewsets.ModelViewSet):
-    queryset = SAMLProviderConfig.objects.current_set()
+    queryset = SAMLProviderConfig.objects.current_set().order_by('id')
     serializer_class = SAMLProviderConfigSerializer
     authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
     permission_classes = (IsAuthenticated, AMCAdminPermission)
+    filter_class = SAMLProviderConfigFilter
 
 
 class SAMLProviderSiteDetail(generics.ListAPIView):
+    """
+    We may not need this view as SAMLProviderConfigViewSet provides filtering
+    by site id with following endpoint and query param
+
+    ```
+    saml-provider-config/?site_id=<site_id>
+    ```
+    """
     serializer_class = SAMLProviderConfigSerializer
     lookup_field = 'site_id'
 
     def get_queryset(self):
         site_id = self.kwargs['site_id']
-        return SAMLProviderConfig.objects.current_set().filter(site__id=site_id).order_by('-enabled')
+        return SAMLProviderConfig.objects.current_set().filter(
+            site__id=site_id).order_by('-enabled')

--- a/openedx/core/djangoapps/appsembler/tpa_admin/api.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/api.py
@@ -27,7 +27,7 @@ class SAMLConfigurationViewSet(viewsets.ModelViewSet):
     serializer_class = SAMLConfigurationSerializer
     authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
     permission_classes = (IsAuthenticated, AMCAdminPermission)
-    filter_class = SAMLConfigurationFilter
+    filterset_class = SAMLConfigurationFilter
 
 
 class SAMLConfigurationSiteDetail(generics.RetrieveAPIView):
@@ -52,7 +52,7 @@ class SAMLProviderConfigViewSet(viewsets.ModelViewSet):
     serializer_class = SAMLProviderConfigSerializer
     authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
     permission_classes = (IsAuthenticated, AMCAdminPermission)
-    filter_class = SAMLProviderConfigFilter
+    filterset_class = SAMLProviderConfigFilter
 
 
 class SAMLProviderSiteDetail(generics.ListAPIView):

--- a/openedx/core/djangoapps/appsembler/tpa_admin/filters.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/filters.py
@@ -1,0 +1,18 @@
+"""Filters for appsembler.tpa_admin viewsets
+"""
+import django_filters
+from third_party_auth.models import SAMLConfiguration, SAMLProviderConfig
+
+
+class SAMLConfigurationFilter(django_filters.FilterSet):
+
+    class Meta:
+        model = SAMLConfiguration
+        fields = ['site_id']
+
+
+class SAMLProviderConfigFilter(django_filters.FilterSet):
+
+    class Meta:
+        model = SAMLProviderConfig
+        fields = ['site_id']

--- a/openedx/core/djangoapps/appsembler/tpa_admin/models.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+# from django.db import models
 
 # Create your models here.

--- a/openedx/core/djangoapps/appsembler/tpa_admin/models.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/models.py
@@ -1,3 +1,3 @@
-# from django.db import models
-
-# Create your models here.
+"""
+TPA Admin currently doesn't have any models
+"""

--- a/openedx/core/djangoapps/appsembler/tpa_admin/serializers.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/serializers.py
@@ -1,9 +1,10 @@
-import json
-
-from third_party_auth.models import SAMLConfiguration, SAMLProviderConfig, SAMLProviderData
-from third_party_auth.models import clean_json
-
+"""Serializers for appsembler.tpa_admin
+"""
 from rest_framework import serializers
+from third_party_auth.models import (SAMLConfiguration,
+                                     SAMLProviderConfig,
+                                     SAMLProviderData)
+from third_party_auth.models import clean_json
 
 
 class SAMLConfigurationSerializer(serializers.ModelSerializer):
@@ -11,15 +12,19 @@ class SAMLConfigurationSerializer(serializers.ModelSerializer):
     class Meta:
         model = SAMLConfiguration
         fields = (
-            'id', 'site', 'enabled', 'entity_id', 'private_key', 'public_key', 'org_info_str', 'other_config_str'
+            'id', 'site', 'enabled', 'entity_id', 'private_key', 'public_key',
+            'org_info_str', 'other_config_str'
         )
 
     def validate_private_key(self, value):
-        return value.replace("-----BEGIN RSA PRIVATE KEY-----", "").replace("-----BEGIN PRIVATE KEY-----", "").replace(
-            "-----END RSA PRIVATE KEY-----", "").replace("-----END PRIVATE KEY-----", "").strip()
+        return value.replace("-----BEGIN RSA PRIVATE KEY-----", "").replace(
+            "-----BEGIN PRIVATE KEY-----", "").replace(
+            "-----END RSA PRIVATE KEY-----", "").replace(
+            "-----END PRIVATE KEY-----", "").strip()
 
     def validate_public_key(self, value):
-        return value.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").strip()
+        return value.replace("-----BEGIN CERTIFICATE-----", "").replace(
+            "-----END CERTIFICATE-----", "").strip()
 
     def validate_org_info_str(self, value):
         return clean_json(value, dict)
@@ -34,9 +39,11 @@ class SAMLProviderConfigSerializer(serializers.ModelSerializer):
     class Meta:
         model = SAMLProviderConfig
         fields = (
-            'id', 'site', 'enabled', 'name', 'icon_class', 'icon_image', 'secondary', 'skip_registration_form',
-            'visible', 'skip_email_verification', 'slug', 'entity_id', 'metadata_source', 'attr_user_permanent_id',
-            'attr_full_name', 'attr_first_name', 'attr_last_name', 'attr_username', 'attr_email', 'other_settings',
+            'id', 'site', 'enabled', 'name', 'icon_class', 'icon_image',
+            'secondary', 'skip_registration_form', 'visible',
+            'skip_email_verification', 'slug', 'entity_id', 'metadata_source',
+            'attr_user_permanent_id', 'attr_full_name', 'attr_first_name',
+            'attr_last_name', 'attr_username', 'attr_email', 'other_settings',
             'metadata_ready'
         )
 

--- a/openedx/core/djangoapps/appsembler/tpa_admin/tests.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/openedx/core/djangoapps/appsembler/tpa_admin/tests/test_views.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/tests/test_views.py
@@ -1,0 +1,167 @@
+"""
+Very basic testing for appsembler.tpa_admin
+"""
+
+import pytest
+from mock import patch
+from rest_framework.reverse import reverse
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.test import APITestCase
+
+from third_party_auth.models import SAMLProviderConfig
+from third_party_auth.tests.factories import SAMLConfigurationFactory
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
+from student.tests.factories import UserFactory
+
+
+VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.tpa_admin.api'
+
+
+class BaseViewTestCase(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.my_site = SiteFactory()
+        self.other_site = SiteFactory()
+        self.caller = UserFactory()
+        self.client.login(username=self.caller.username, password=self.caller.password)
+
+
+class BaseSAMLConfigurationTestCase(BaseViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.my_saml_config = SAMLConfigurationFactory(site=self.my_site)
+        self.other_saml_config = SAMLConfigurationFactory(site=self.other_site)
+        assert self.my_saml_config != self.other_saml_config
+
+
+@patch(VIEWS_MODULE + '.SAMLConfigurationViewSet.permission_classes', [AllowAny])
+class SAMLConfigurationViewSetTests(BaseSAMLConfigurationTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_list(self):
+        url = reverse('saml-configuration-list')
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_get_filtered_by_site_id(self):
+        url = reverse('saml-configuration-list')
+        url += '?site_id={}'.format(self.my_site.id)
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()['results']
+        found_site_ids = [rec['site'] for rec in results]
+        assert self.other_site not in found_site_ids
+
+    def test_get_detail(self):
+        url = reverse('saml-configuration-detail', args=[self.my_saml_config.id])
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+    @pytest.mark.skip('Test not implemented')
+    def test_create(self):
+        pass
+
+    @pytest.mark.skip('Test not implemented')
+    def test_destroy(self):
+        pass
+
+
+class SAMLConfigurationSiteDetailTests(BaseSAMLConfigurationTestCase):
+    """
+    The view, as tested does not have any permissions directly associated
+    The test is passing without patching permissions
+    """
+    def setUp(self):
+        super().setUp()
+
+    def test_get(self):
+        url = reverse('site-saml-configuration', args=[self.my_site.id])
+        response = self.client.get(url)
+        data = response.json()
+        assert response.status_code == status.HTTP_200_OK
+        assert data['id'] == self.my_saml_config.id
+        assert data['site'] == self.my_site.id
+
+
+class BaseSAMLProviderConfigTestCase(BaseViewTestCase):
+    def setUp(self):
+        """
+        We can't use SAMLProviderConfigFactory without modifying it because the
+        following is True:
+
+        ```
+        spc_1 = SAMLProviderConfigFactory(site=self.my_site)
+        spc_2 = SAMLProviderConfigFactory(site=self.other_site)
+        assert spc_1 == spc_2
+        ```
+        """
+        super().setUp()
+        self.my_spc = SAMLProviderConfig.objects.create(
+            site=self.my_site,
+            name='SAML Alpha',
+            slug='saml-alpha',
+            entity_id='https://alpha.com/foo',
+            metadata_source='https://alpha.com/foo-xml')
+        self.other_spc = SAMLProviderConfig.objects.create(
+            site=self.other_site,
+            name='SAML Bravo',
+            slug='saml-bravo',
+            entity_id='https://bravo.com/foo',
+            metadata_source='https://bravo.com/foo-xml')
+
+
+@patch(VIEWS_MODULE + '.SAMLProviderConfigViewSet.permission_classes', [AllowAny])
+class SAMLProviderConfigViewSetTests(BaseSAMLProviderConfigTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_get_list(self):
+        url = reverse('saml-providers-config-list')
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()['results']
+        found_site_ids = [rec['site'] for rec in results]
+        assert set([self.my_site.id, self.other_site.id]) == set(found_site_ids)
+
+    def test_get_filtered_by_site_id(self):
+        url = reverse('saml-providers-config-list')
+        url += '?site_id={}'.format(self.my_site.id)
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()['results']
+
+        found_site_ids = [rec['site'] for rec in results]
+        assert self.other_site not in found_site_ids
+
+    def test_get_detail(self):
+        url = reverse('saml-providers-config-detail',
+                      args=[self.my_spc.id])
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+    @pytest.mark.skip('Test not implemented')
+    def test_create(self):
+        pass
+
+    @pytest.mark.skip('Test not implemented')
+    def test_destroy(self):
+        pass
+
+
+class SAMLProviderSiteDetailTests(BaseSAMLProviderConfigTestCase):
+    """
+    The view, as tested does not have any permissions directly associated
+    The test is passing without patching permissions
+    """
+    def setUp(self):
+        super().setUp()
+
+    def test_get(self):
+        url = reverse('site-saml-provider', args=[self.my_site.id])
+        response = self.client.get(url)
+        results = response.json()['results']
+        assert response.status_code == status.HTTP_200_OK
+        found_site_ids = [rec['site'] for rec in results]
+        assert self.other_site not in found_site_ids

--- a/openedx/core/djangoapps/appsembler/tpa_admin/urls.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls import url
+"""
+"""
+from django.urls import include, path
+from rest_framework import routers
 
 from openedx.core.djangoapps.appsembler.tpa_admin.api import (
     SAMLConfigurationViewSet,
@@ -7,34 +10,24 @@ from openedx.core.djangoapps.appsembler.tpa_admin.api import (
     SAMLProviderSiteDetail
 )
 
-saml_configuration_list = SAMLConfigurationViewSet.as_view({
-    'get': 'list',
-    'post': 'create',
-})
+router = routers.DefaultRouter()
 
-saml_configuration_detail = SAMLConfigurationViewSet.as_view({
-    'get': 'retrieve',
-    'delete': 'destroy'
-})
+# Register SAML service providers configuration endpoint
+router.register(r'saml-configurations',
+                SAMLConfigurationViewSet,
+                basename='saml-configuration')
 
-saml_providers_config_list = SAMLProviderConfigViewSet.as_view({
-    'get': 'list',
-    'post': 'create',
-})
-
-saml_providers_config_detail = SAMLProviderConfigViewSet.as_view({
-    'get': 'retrieve',
-    'delete': 'destroy'
-})
+# Register SAML identity providers endpoint
+router.register(r'saml-providers-config',
+                SAMLProviderConfigViewSet,
+                basename='saml-providers-config')
 
 urlpatterns = [
-    # SAML Service Provider configuration
-    url(r'^saml-configurations/$', saml_configuration_list, name='saml-configuration-list'),
-    url(r'^saml-configurations/(?P<pk>[0-9]+)/$', saml_configuration_detail, name='saml-configuration-detail'),
-    url(r'^site-saml-configuration/(?P<site_id>.+)/$', SAMLConfigurationSiteDetail.as_view()),
-
-    # SAML Identity Providers
-    url(r'^saml-providers-config/$', saml_providers_config_list, name='saml-providers-config-list'),
-    url(r'^saml-providers-config/(?P<pk>[0-9]+)/$', saml_providers_config_detail, name='saml-providers-config-list'),
-    url(r'^site-saml-providers/(?P<site_id>.+)/$', SAMLProviderSiteDetail.as_view()),
+    path('site-saml-configuration/<int:site_id>/',
+         SAMLConfigurationSiteDetail.as_view(),
+         name='site-saml-configuration'),
+    path('site-saml-providers/<int:site_id>/',
+         SAMLProviderSiteDetail.as_view(),
+         name='site-saml-provider'),
+    path('', include(router.urls, )),
 ]

--- a/openedx/core/djangoapps/appsembler/tpa_admin/views.py
+++ b/openedx/core/djangoapps/appsembler/tpa_admin/views.py
@@ -1,3 +1,5 @@
-from django.shortcuts import render
+"""
 
-# Create your views here.
+TODO: Move the viess in appsembler_tpa_admin.api to here to adhere to standard
+practices
+"""


### PR DESCRIPTION
* Reworked this package for Django 2.2
* Now users DRF router for viewsets
* Added very minimal view tests, just to exercise the views

We may want or need to update AMC to use the new functionality. Mainly there is now a `site_id` query parameter for the `saml-configurations` and `saml-provider-config` list endpoints. If we do this, then we probably don't need the `SAMLConfigurationSiteDetail` or `SAMLProviderSiteDetail` classes anymore

https://appsembler.atlassian.net/browse/RED-1473
