### PR TITLE
Build Tahoe devstack image

### DIFF
--- a/Dockerfile.devstack
+++ b/Dockerfile.devstack
@@ -1,0 +1,8 @@
+FROM edxops/edxapp:juniper.master
+
+RUN cd /edx/app/edxapp \
+    && git clone https://github.com/appsembler/edx-platform.git --branch main \
+    && bash -c 'cd edx-platform && source ../edxapp_env && paver install_prereqs' \
+    && rm -rf edx-platform
+
+WORKDIR /edx/app/edxapp/edx-platform


### PR DESCRIPTION
This file deprecates: https://github.com/appsembler/configuration/blob/appsembler/juniper/master/docker/build/edxapp/Dockerfile

The docker images have already been pushed to `appsembler/edxapp:juniper.master`. We could use GitHub Actions to automate this but we're not in hurry to do that.

This is a better approach since it removes Ansible from the docker build workflow. We still depend on `edxops/edxapp` which uses Ansible, but that's transparent to us.

This pull request will enable us to provide a better docker images for devstack by making them pre-installed with Tahoe pip packages and perhaps ready with configurations.