### PR TITLE
Remove TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS from production code

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -58,16 +58,6 @@ def plugin_settings(settings):
         'location': 'customer_themes',
     }
 
-    if not settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
-        # TODO: Fix middlewares
-        _middleware_list = list(settings.MIDDLEWARE)
-        _after_site_mdlwr = _middleware_list.index('django.contrib.sites.middleware.CurrentSiteMiddleware') + 1
-        settings.MIDDLEWARE = tuple(_middleware_list[:_after_site_mdlwr]) + (
-            # Allows us to define redirects via Django admin
-            'openedx.core.djangoapps.appsembler.sites.middleware.CustomDomainsRedirectMiddleware',
-            'openedx.core.djangoapps.appsembler.sites.middleware.RedirectMiddleware',
-        ) + tuple(_middleware_list[_after_site_mdlwr:])
-
     settings.CUSTOM_DOMAINS_REDIRECT_CACHE_TIMEOUT = None  # The length of time we cache Redirect model data
     settings.CUSTOM_DOMAINS_REDIRECT_CACHE_KEY_PREFIX = 'custom_domains_redirects'
 

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -51,7 +51,7 @@ def plugin_settings(settings):
     # This flag should be removed when we fully migrate all of Tahoe fork to Juniper
     # until then, instead of commenting out code, this flag should be used so we can easily find
     # and fix test issues
-    settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS = True
+    settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS = False
 
     settings.TAHOE_ENABLE_CUSTOM_ERROR_VIEW = True  # Use the Django default error page during testing
     settings.CUSTOMER_THEMES_BACKEND_OPTIONS = {

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
@@ -104,7 +104,6 @@ def plugin_settings(settings):
         'openedx.core.djangoapps.appsembler.sites.middleware.RedirectMiddleware',
     ] + settings.MIDDLEWARE[_after_site_mdlwr:]
 
-
     # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
     # from the redirect mechanics.
     settings.MAIN_SITE_REDIRECT_WHITELIST = [

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
@@ -97,6 +97,14 @@ def plugin_settings(settings):
     settings.ACCESS_CONTROL_BACKENDS = settings.ENV_TOKENS.get('ACCESS_CONTROL_BACKENDS', {})
     settings.LMS_SEGMENT_SITE = settings.AUTH_TOKENS.get('SEGMENT_SITE')
 
+    _after_site_mdlwr = settings.MIDDLEWARE.index('django.contrib.sites.middleware.CurrentSiteMiddleware') + 1
+    settings.MIDDLEWARE = settings.MIDDLEWARE[:_after_site_mdlwr] + [
+        # Allows us to define redirects via Django admin
+        'openedx.core.djangoapps.appsembler.sites.middleware.CustomDomainsRedirectMiddleware',
+        'openedx.core.djangoapps.appsembler.sites.middleware.RedirectMiddleware',
+    ] + settings.MIDDLEWARE[_after_site_mdlwr:]
+
+
     # This is used in the appsembler_sites.middleware.RedirectMiddleware to exclude certain paths
     # from the redirect mechanics.
     settings.MAIN_SITE_REDIRECT_WHITELIST = [

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
@@ -27,6 +27,9 @@ def get_faked_settings():
     settings.AMC_APP_URL = ''
     settings.AMC_APP_OAUTH2_CLIENT_ID = ''
     settings.APPSEMBLER_FEATURES = {}
+    settings.MIDDLEWARE = [
+        'django.contrib.sites.middleware.CurrentSiteMiddleware',
+    ]
     settings.STATICFILES_DIRS = []
     settings.CACHES = {}
     settings.ENABLE_COMPREHENSIVE_THEMING = True

--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.core.cache import cache, caches
 from django.contrib.redirects.models import Redirect
 from django.shortcuts import redirect
+from django.utils.deprecation import MiddlewareMixin
 
 from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
 
@@ -10,7 +11,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class CustomDomainsRedirectMiddleware(object):
+class CustomDomainsRedirectMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         cache_general = caches['default']
@@ -35,7 +36,7 @@ class CustomDomainsRedirectMiddleware(object):
             return
 
 
-class RedirectMiddleware(object):
+class RedirectMiddleware(MiddlewareMixin):
     """
     Redirects requests for URLs persisted using the django.contrib.redirects.models.Redirect model.
     With the exception of the main site.


### PR DESCRIPTION
 - removing `TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS` from production code since the `main` branch should not be fully migrated
 -  enable CustomDomainsRedirectMiddleware and RedirectMiddleware always on production and devstack