### PR TITLE
get_lms_link_for_course_key return base URL if AssertionError w/ Org

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/tests/test_utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_utils.py
@@ -154,6 +154,12 @@ class LMSLinkByCourseOrgTestCase(TestCase):
         url = get_lms_link_from_course_key(self.base_lms_url, self.courseKey)
         self.assertEqual(url, self.base_lms_url)
 
+    @patch('openedx.core.djangoapps.appsembler.api.sites.get_site_for_course')
+    def test_lms_link_with_error_getting_site(self, mocked_get_site_for_course):
+        mocked_get_site_for_course.side_effect = AssertionError
+        url = get_lms_link_from_course_key(self.base_lms_url, self.courseKey)
+        self.assertEqual(url, self.base_lms_url)
+
     @patch.dict('django.conf.settings.FEATURES', {
         'PREVIEW_LMS_BASE': 'preview.lms_base.domain'
     })

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -39,7 +39,11 @@ def get_lms_link_from_course_key(base_lms_url, course_key):
     beeline.add_context_field("course_key", course_key)
     # avoid circular import
     from openedx.core.djangoapps.appsembler.api.sites import get_site_for_course
-    course_site = get_site_for_course(course_key)
+    try:
+        course_site = get_site_for_course(course_key)
+    except AssertionError:
+        # catch problems like Org w/ 0 or >=1 Sites w/o breaking whole views like Studio courses list
+        course_site = None
     if course_site:
         return course_site.domain
     return base_lms_url


### PR DESCRIPTION
if an Organization is related to 0 or more than 1 Sites, then
get_site_for_course will raise an AssertionError.  We don't want that
to break views, esp. like Studio courses list