### PR TITLE
Juniper upgrade boto to boto3

### DIFF
--- a/cms/djangoapps/cms_user_tasks/tasks.py
+++ b/cms/djangoapps/cms_user_tasks/tasks.py
@@ -3,7 +3,8 @@ Celery tasks used by cms_user_tasks
 """
 
 
-from boto.exception import NoAuthHandlerFound
+# was from boto.exception import NoAuthHandlerFound
+from botocore.exceptions import NoCredentialsError
 from celery.exceptions import MaxRetriesExceededError
 from celery.task import task
 from celery.utils.log import get_task_logger
@@ -44,7 +45,12 @@ def send_task_complete_email(self, task_name, task_state_text, dest_addr, detail
     try:
         mail.send_mail(subject, message, from_address, [dest_addr], fail_silently=False)
         LOGGER.info(u"Task complete email has been sent to User %s", dest_addr)
-    except NoAuthHandlerFound:
+    except NoCredentialsError:
+        # JLB what sense does it make to retry when there's a credentials error?
+
+        # boto.exception.NoAuthHandlerFound was the previous exception
+        # Readings on the web indicate this can happen when Boto cannot find
+        # credentials
         LOGGER.info(
             u'Retrying sending email to user %s, attempt # %s of %s',
             dest_addr,

--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -7,7 +7,7 @@ import logging
 from uuid import uuid4
 
 import mock
-from boto.exception import NoAuthHandlerFound
+from botocore.exceptions import NoCredentialsError
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
@@ -219,7 +219,7 @@ class TestUserTaskStopped(APITestCase):
         Make sure we can succeed on retries
         """
         with mock.patch('django.core.mail.send_mail') as mock_exception:
-            mock_exception.side_effect = NoAuthHandlerFound()
+            mock_exception.side_effect = NoCredentialsError()
 
             with mock.patch('cms_user_tasks.tasks.send_task_complete_email.retry') as mock_retry:
                 user_task_stopped.send(sender=UserTaskStatus, status=self.status)
@@ -231,7 +231,7 @@ class TestUserTaskStopped(APITestCase):
         logger.addHandler(hdlr)
 
         with mock.patch('cms_user_tasks.tasks.send_task_complete_email.delay') as mock_delay:
-            mock_delay.side_effect = NoAuthHandlerFound()
+            mock_delay.side_effect = NoCredentialsError()
             user_task_stopped.send(sender=UserTaskStatus, status=self.status)
             self.assertTrue(mock_delay.called)
             self.assertEqual(hdlr.messages['error'][0], u'Unable to queue send_task_complete_email')

--- a/cms/djangoapps/contentstore/storage.py
+++ b/cms/djangoapps/contentstore/storage.py
@@ -5,11 +5,11 @@ Storage backend for course import and export.
 
 from django.conf import settings
 from django.core.files.storage import get_storage_class
-from storages.backends.s3boto import S3BotoStorage
+from storages.backends.s3boto3 import S3Boto3Storage
 from storages.utils import setting
 
 
-class ImportExportS3Storage(S3BotoStorage):  # pylint: disable=abstract-method
+class ImportExportS3Storage(S3Boto3Storage):  # pylint: disable=abstract-method
     """
     S3 backend for course import and export OLX files.
     """

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -26,7 +26,7 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
 from path import Path as path
 from six import text_type
-from storages.backends.s3boto import S3BotoStorage
+from storages.backends.s3boto3 import S3Boto3Storage
 from user_tasks.conf import settings as user_tasks_settings
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 
@@ -373,7 +373,7 @@ def export_status_handler(request, course_key_string):
         artifact = UserTaskArtifact.objects.get(status=task_status, name='Output')
         if isinstance(artifact.file.storage, FileSystemStorage):
             output_url = reverse_course_url('export_output_handler', course_key)
-        elif isinstance(artifact.file.storage, S3BotoStorage):
+        elif isinstance(artifact.file.storage, S3Boto3Storage):
             filename = os.path.basename(artifact.file.name)
             disposition = u'attachment; filename="{}"'.format(filename)
             output_url = artifact.file.storage.url(artifact.file.name, response_headers={

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -23,7 +23,7 @@ from mock import Mock, patch
 from opaque_keys.edx.locator import LibraryLocator
 from path import Path as path
 from six.moves import zip
-from storages.backends.s3boto import S3BotoStorage
+from storages.backends.s3boto3 import S3Boto3Storage
 from user_tasks.models import UserTaskStatus
 
 from contentstore.tests.test_libraries import LibraryTestCase
@@ -796,7 +796,7 @@ class ExportTestCase(CourseTestCase):
         """
         Verify that the export status handler generates the correct export path
         for storage providers other than ``FileSystemStorage`` and
-        ``S3BotoStorage``
+        ``S3Boto3Storage``
         """
         mock_latest_task_status.return_value = Mock(state=UserTaskStatus.SUCCEEDED)
         mock_get_user_task_artifact.return_value = self._mock_artifact(
@@ -815,11 +815,11 @@ class ExportTestCase(CourseTestCase):
     ):
         """
         Verify that the export status handler generates the correct export path
-        for the ``S3BotoStorage`` storage provider
+        for the ``S3Boto3Storage`` storage provider
         """
         mock_latest_task_status.return_value = Mock(state=UserTaskStatus.SUCCEEDED)
         mock_get_user_task_artifact.return_value = self._mock_artifact(
-            spec=S3BotoStorage,
+            spec=S3Boto3Storage,
             file_url='/s3/file/path/testfile.tar.gz',
         )
         resp = self.client.get(self.status_url)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2090,7 +2090,7 @@ VIDEO_IMAGE_SETTINGS = dict(
     VIDEO_IMAGE_MAX_BYTES=2 * 1024 * 1024,    # 2 MB
     VIDEO_IMAGE_MIN_BYTES=2 * 1024,       # 2 KB
     # Backend storage
-    # STORAGE_CLASS='storages.backends.s3boto.S3BotoStorage',
+    # STORAGE_CLASS='storages.backends.s3boto3.S3Boto3Storage',
     # STORAGE_KWARGS=dict(bucket='video-image-bucket'),
     STORAGE_KWARGS=dict(
         location=MEDIA_ROOT,
@@ -2105,7 +2105,7 @@ VIDEO_IMAGE_MAX_AGE = 31536000
 VIDEO_TRANSCRIPTS_SETTINGS = dict(
     VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,    # 3 MB
     # Backend storage
-    # STORAGE_CLASS='storages.backends.s3boto.S3BotoStorage',
+    # STORAGE_CLASS='storages.backends.s3boto3.S3Boto3Storage',
     # STORAGE_KWARGS=dict(bucket='video-transcripts-bucket'),
     STORAGE_KWARGS=dict(
         location=MEDIA_ROOT,

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -332,7 +332,7 @@ AWS_S3_CUSTOM_DOMAIN = AUTH_TOKENS.get('AWS_S3_CUSTOM_DOMAIN', 'edxuploads.s3.am
 if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
     DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
 elif AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 else:
     DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 

--- a/common/test/utils.py
+++ b/common/test/utils.py
@@ -116,22 +116,24 @@ def skip_signal(signal, **kwargs):
         signal.connect(**kwargs)
 
 
-class MockS3BotoMixin(object):
+class MockS3Boto3Mixin(object):
     """
-    TestCase mixin that mocks the S3BotoStorage save method and s3 connection.
+    TestCase mixin that mocks the S3Boto3Storage save method and s3 connection.
     """
     def setUp(self):
-        super(MockS3BotoMixin, self).setUp()
-        self._mocked_connection = patch('boto.connect_s3', return_value=Mock())
+        super(MockS3Boto3Mixin, self).setUp()
+        # Original boto was 'boto.connect_s3'
+        # This will probably need to be fixed, but trying this initially
+        self._mocked_connection = patch('boto3.resource', return_value=Mock())
         self.mocked_connection = self._mocked_connection.start()
 
-        self.patcher = patch('storages.backends.s3boto.S3BotoStorage.save')
+        self.patcher = patch('storages.backends.s3boto3.S3Boto3Storage.save')
         self.patcher.start()
 
     def tearDown(self):
         self._mocked_connection.stop()
         self.patcher.stop()
-        super(MockS3BotoMixin, self).tearDown()
+        super(MockS3Boto3Mixin, self).tearDown()
 
 
 class reprwrapper(object):

--- a/lms/djangoapps/instructor_task/tests/test_models.py
+++ b/lms/djangoapps/instructor_task/tests/test_models.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.test import SimpleTestCase, TestCase, override_settings
 from opaque_keys.edx.locator import CourseLocator
 
-from common.test.utils import MockS3BotoMixin
+from common.test.utils import MockS3Boto3Mixin
 from lms.djangoapps.instructor_task.models import InstructorTask, ReportStore, TASK_INPUT_LENGTH
 from lms.djangoapps.instructor_task.tests.test_base import TestReportMixin
 
@@ -98,7 +98,7 @@ class DjangoStorageReportStoreLocalTestCase(ReportStoreTestMixin, TestReportMixi
             return ReportStore.from_config(config_name='GRADES_DOWNLOAD')
 
 
-class DjangoStorageReportStoreS3TestCase(MockS3BotoMixin, ReportStoreTestMixin, TestReportMixin, SimpleTestCase):
+class DjangoStorageReportStoreS3TestCase(MockS3Boto3Mixin, ReportStoreTestMixin, TestReportMixin, SimpleTestCase):
     """
     Test the DjangoStorageReportStore implementation using S3 stubs.
     """
@@ -108,7 +108,7 @@ class DjangoStorageReportStoreS3TestCase(MockS3BotoMixin, ReportStoreTestMixin, 
         storage.
         """
         test_settings = copy.deepcopy(settings.GRADES_DOWNLOAD)
-        test_settings['STORAGE_CLASS'] = 'storages.backends.s3boto.S3BotoStorage'
+        test_settings['STORAGE_CLASS'] = 'storages.backends.s3boto3.S3Boto3Storage'
         test_settings['STORAGE_KWARGS'] = {
             'bucket': settings.GRADES_DOWNLOAD['BUCKET'],
             'location': settings.GRADES_DOWNLOAD['ROOT_PATH'],

--- a/lms/djangoapps/verify_student/management/commands/tests/test_populate_expiry_date.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_populate_expiry_date.py
@@ -11,7 +11,7 @@ from django.test import TestCase
 from mock import patch
 from testfixtures import LogCapture
 
-from common.test.utils import MockS3BotoMixin
+from common.test.utils import MockS3Boto3Mixin
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from lms.djangoapps.verify_student.tests.test_models import FAKE_SETTINGS, mock_software_secure_post
 from student.tests.factories import UserFactory
@@ -21,7 +21,7 @@ LOGGER_NAME = 'lms.djangoapps.verify_student.management.commands.populate_expiry
 
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
-class TestPopulateExpiryDate(MockS3BotoMixin, TestCase):
+class TestPopulateExpiryDate(MockS3Boto3Mixin, TestCase):
     """ Tests for django admin command `populate_expiry_date` in the verify_student module """
 
     def create_and_submit(self, user):

--- a/lms/djangoapps/verify_student/management/commands/tests/test_send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_send_verification_expiry_email.py
@@ -16,7 +16,7 @@ from mock import patch
 from student.tests.factories import UserFactory
 from testfixtures import LogCapture
 
-from common.test.utils import MockS3BotoMixin
+from common.test.utils import MockS3Boto3Mixin
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from lms.djangoapps.verify_student.tests.test_models import FAKE_SETTINGS, mock_software_secure_post
 
@@ -25,7 +25,7 @@ LOGGER_NAME = 'lms.djangoapps.verify_student.management.commands.send_verificati
 
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
-class TestSendVerificationExpiryEmail(MockS3BotoMixin, TestCase):
+class TestSendVerificationExpiryEmail(MockS3Boto3Mixin, TestCase):
     """ Tests for django admin command `send_verification_expiry_email` in the verify_student module """
 
     def setUp(self):

--- a/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
@@ -9,7 +9,7 @@ from django.core.management import call_command
 from mock import patch
 from testfixtures import LogCapture
 
-from common.test.utils import MockS3BotoMixin
+from common.test.utils import MockS3Boto3Mixin
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, SSPVerificationRetryConfig
 from lms.djangoapps.verify_student.tests import TestVerificationBase
 from lms.djangoapps.verify_student.tests.test_models import (
@@ -25,7 +25,7 @@ LOGGER_NAME = 'retry_photo_verification'
 # Lots of patching to stub in our own settings, and HTTP posting
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
-class TestVerifyStudentCommand(MockS3BotoMixin, TestVerificationBase):
+class TestVerifyStudentCommand(MockS3Boto3Mixin, TestVerificationBase):
     """
     Tests for django admin commands in the verify_student module
     """

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -843,7 +843,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         config = settings.VERIFY_STUDENT["SOFTWARE_SECURE"]
 
         # Default to the S3 backend for backward compatibility
-        storage_class = config.get("STORAGE_CLASS", "storages.backends.s3boto.S3BotoStorage")
+        storage_class = config.get("STORAGE_CLASS", "storages.backends.s3boto3.S3Boto3Storage")
         storage_kwargs = config.get("STORAGE_KWARGS", {})
 
         # Map old settings to the parameters expected by the storage backend

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -13,7 +13,7 @@ from freezegun import freeze_time
 from mock import patch
 from six.moves import range
 
-from common.test.utils import MockS3BotoMixin
+from common.test.utils import MockS3Boto3Mixin
 from lms.djangoapps.verify_student.models import (
     ManualVerification,
     PhotoVerification,
@@ -94,7 +94,7 @@ def mock_software_secure_post_unavailable(url, headers=None, data=None, **kwargs
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
 @ddt.ddt
-class TestPhotoVerification(TestVerificationBase, MockS3BotoMixin, ModuleStoreTestCase):
+class TestPhotoVerification(TestVerificationBase, MockS3Boto3Mixin, ModuleStoreTestCase):
 
     def test_state_transitions(self):
         """

--- a/lms/djangoapps/verify_student/tests/test_tasks.py
+++ b/lms/djangoapps/verify_student/tests/test_tasks.py
@@ -4,7 +4,7 @@ import mock
 from django.conf import settings
 from mock import patch
 
-from common.test.utils import MockS3BotoMixin
+from common.test.utils import MockS3Boto3Mixin
 from verify_student.tests import TestVerificationBase
 from verify_student.tests.test_models import FAKE_SETTINGS, mock_software_secure_post_unavailable
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -14,7 +14,7 @@ LOGGER_NAME = 'lms.djangoapps.verify_student.tasks'
 
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @ddt.ddt
-class TestPhotoVerificationTasks(TestVerificationBase, MockS3BotoMixin, ModuleStoreTestCase):
+class TestPhotoVerificationTasks(TestVerificationBase, MockS3Boto3Mixin, ModuleStoreTestCase):
 
     @mock.patch('lms.djangoapps.verify_student.tasks.log')
     def test_logs_for_retry_until_failure(self, mock_log):

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -26,7 +26,7 @@ from opaque_keys.edx.locator import CourseLocator
 from six.moves import zip
 from waffle.testutils import override_switch
 
-from common.test.utils import MockS3BotoMixin, XssTestMixin
+from common.test.utils import MockS3Boto3Mixin, XssTestMixin
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
 from lms.djangoapps.commerce.models import CommerceConfiguration
@@ -1413,7 +1413,7 @@ class TestCreateOrderView(ModuleStoreTestCase):
 
 @ddt.ddt
 @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
-class TestSubmitPhotosForVerification(MockS3BotoMixin, TestVerificationBase):
+class TestSubmitPhotosForVerification(MockS3Boto3Mixin, TestVerificationBase):
     """
     Tests for submitting photos for verification.
     """

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2932,7 +2932,7 @@ VIDEO_IMAGE_SETTINGS = dict(
     VIDEO_IMAGE_MAX_BYTES=2 * 1024 * 1024,    # 2 MB
     VIDEO_IMAGE_MIN_BYTES=2 * 1024,       # 2 KB
     # Backend storage
-    # STORAGE_CLASS='storages.backends.s3boto.S3BotoStorage',
+    # STORAGE_CLASS='storages.backends.s3boto3.S3Boto3Storage',
     # STORAGE_KWARGS=dict(bucket='video-image-bucket'),
     STORAGE_KWARGS=dict(
         location=MEDIA_ROOT,
@@ -2948,7 +2948,7 @@ VIDEO_IMAGE_MAX_AGE = 31536000
 VIDEO_TRANSCRIPTS_SETTINGS = dict(
     VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,    # 3 MB
     # Backend storage
-    # STORAGE_CLASS='storages.backends.s3boto.S3BotoStorage',
+    # STORAGE_CLASS='storages.backends.s3boto3.S3Boto3Storage',
     # STORAGE_KWARGS=dict(bucket='video-transcripts-bucket'),
     STORAGE_KWARGS=dict(
         location=MEDIA_ROOT,

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -473,7 +473,7 @@ AWS_S3_CUSTOM_DOMAIN = AUTH_TOKENS.get('AWS_S3_CUSTOM_DOMAIN', 'edxuploads.s3.am
 if AUTH_TOKENS.get('DEFAULT_FILE_STORAGE'):
     DEFAULT_FILE_STORAGE = AUTH_TOKENS.get('DEFAULT_FILE_STORAGE')
 elif AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 else:
     DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 


### PR DESCRIPTION
    - Initial pass at Boto3 upgrade. Mostly import object changes and object name substitution
    - Had to rework a test in lms/djangoapps/instructor/tests/test_api.py
    - Did not update any of the paverlib code

https://appsembler.atlassian.net/browse/RED-1528