### PR TITLE
Update Django Extensions version from 1.5.9 to 3.1.0

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -1,4 +1,4 @@
-django-extensions==1.5.9
+django-extensions==3.1.0
 python-intercom==3.1.0
 raven==6.10.0
 django-anymail==5.0


### PR DESCRIPTION
Django Extensions 1.5.9 breaks on at least some functionality in Django
2.2. Specifically when you run `./manage.py cms show_urls`, you get:

```
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django_extensions/management/commands/show_urls.py", line 9, in <module>
    from django.core.urlresolvers import RegexURLPattern, RegexURLResolver, LocaleRegexURLResolver
ImportError: No module named 'django.core.urlresolvers'
```

This PR upgrades to the latest version that supports Python 3.5