### PR TITLE
remove backports library: was needed in python 2

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/tasks.py
+++ b/openedx/core/djangoapps/appsembler/sites/tasks.py
@@ -7,8 +7,7 @@ import os
 import tarfile
 import datetime
 
-from backports.tempfile import TemporaryDirectory
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from celery.task import task
 from celery.utils.log import get_task_logger

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -7,5 +7,4 @@ dj-database-url==0.5.0
 psycopg2-binary==2.8.3
 django-hijack==2.1.10
 django-hijack-admin==2.1.10
-backports.tempfile==1.0
 honeycomb-beeline==2.12.1


### PR DESCRIPTION
The library was added in https://github.com/appsembler/edx-platform/pull/546 for Python 2 compatibility. Now it's not needed in Juniper.