### PR TITLE
Triage all TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS marks

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/tests/test_proctoring.py
@@ -100,7 +100,10 @@ class TestProctoredExams(ModuleStoreTestCase):
 
         self._verify_exam_data(sequence, True)
 
-    @unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'IntegrityError due to UserID.test')
+    @unittest.skipIf(
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage IntegrityError in RED-1877
+        'IntegrityError due to UserID.test'
+    )
     @ddt.data(
         (True, False, True, False, False),
         (False, False, True, False, False),
@@ -253,7 +256,8 @@ class TestProctoredExams(ModuleStoreTestCase):
         #
         # The fix is probably to see if there's some missing user creation for
         # Special user IDs such as xmodule.modulestore.ModuleStoreEnum.UserID.test
-        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fails due to IntegrityError'
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage IntegrityError in RED-1877
+        'fails due to IntegrityError'
     )
     def test_advanced_settings(self, enable_timed_exams, enable_proctored_exams, expected_count):
         """

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -16,7 +16,7 @@ from testfixtures import LogCapture
 
 from student.tests.factories import UserFactory
 
-if not settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:
+if not settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS:  # TODO: Refactor or fix in RED-1674
     # TODO: Fix broken imports See https://openedx.atlassian.net/browse/DEPR-47
     from edx_oauth2_provider.models import TrustedClient
     from edx_oauth2_provider.tests.factories import (
@@ -176,7 +176,7 @@ class TestLoginHelper(TestCase):
 
 
 @unittest.skipIf(
-    settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
+    settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Refactor or fix in RED-1674
     'edX removed TrustedClient See https://openedx.atlassian.net/browse/DEPR-47'
 )
 class TestDestroyOAuthTokensHelper(TestCase):

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -205,8 +205,10 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
             }
         )
 
-    @unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
-                     'Failing tests for unclear reasons, disabling temporarily.')
+    @unittest.skipIf(
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage and fix in RED-1599
+        'Failing tests for unclear reasons, disabling temporarily.'
+    )
     @ddt.data(
         (False, timedelta(days=2), False),
         (False, -timedelta(days=2), True),

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -645,8 +645,10 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         self.assertContains(response, '<html class="no-js" lang="ar">')
 
-    @unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
-                     'Test fails. Investigated. Disabling for now.')
+    @unittest.skipIf(
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage and fix in RED-1599
+        'Test fails. Investigated. Disabling for now.'
+    )
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_html_view_for_non_viewable_certificate_and_for_student_user(self):
         """
@@ -1561,8 +1563,10 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
     """
     Test events emitted by certificate handling.
     """
-    @unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
-                     'Test fails. Investigated. Disabling for now.')
+    @unittest.skipIf(
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage and fix in RED-1599
+        'Test fails. Investigated. Disabling for now.'
+    )
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_certificate_evidence_event_emitted(self):
         self.client.logout()
@@ -1589,8 +1593,10 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
             actual_event['data']
         )
 
-    @unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
-                     'Test fails. Investigated. Disabling for now.')
+    @unittest.skipIf(
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage and fix in RED-1599
+        'Test fails. Investigated. Disabling for now.'
+    )
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_evidence_event_sent(self):
         self._add_course_certificates(count=1, signatory_count=2)

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -225,7 +225,10 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         )
 
     @ddt.data(True, False)
-    @unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'Fails due to missing html element')
+    @unittest.skipIf(
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage and fix in RED-1878
+        'Fails due to missing html element'
+    )
     def test_membership_reason_field_visibility(self, enbale_reason_field):
         """
         Verify that reason field is enabled by site configuration flag 'ENABLE_MANUAL_ENROLLMENT_REASON_FIELD'
@@ -255,7 +258,10 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         else:
             self.assertNotContains(response, reason_field)
 
-    @unittest.skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'Fails due to missing html element')
+    @unittest.skipIf(
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage and fix in RED-1878
+        'Fails due to missing html element'
+    )
     def test_membership_site_configuration_role(self):
         """
         Verify that the role choices set via site configuration are loaded in the membership tab
@@ -607,7 +613,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
 
 
 @unittest.skipIf(
-    settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
+    settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage and fix in RED-1879
     'This should be re-examined later see https://github.com/appsembler/edx-platform/pull/706. '
     'It may not be needed because we may not have performance problems anymore. '
 )

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_course_enrollment_allowed.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_course_enrollment_allowed.py
@@ -25,7 +25,6 @@ from openedx.core.djangoapps.appsembler.api.tests.factories import (
 
 @lms_multi_tenant_test
 @patch.dict('django.conf.settings.FEATURES', {'SKIP_EMAIL_VALIDATION': True})
-@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix in after Tahoe Customer APIs have been migrated')
 class TestCourseEnrollmentAllowedMultitenant(ModuleStoreTestCase):
     """
     Unit tests for the CourseEnrollmentAllowed model and related features.

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_tahoe_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_tahoe_registration_api.py
@@ -22,7 +22,6 @@ APPSEMBLER_API_VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.api.v1.views'
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.permission_classes', [])
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.throttle_classes', [])
 @skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This only tests multi-tenancy')
-@skipIf(settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS, 'fix in Juniper')
 class MultiTenantRegistrationAPITest(APITestCase):
     """
     Tests to ensure the Tahoe Registration API end-point allow multi-tenant emails.

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1571,7 +1571,7 @@ class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
         return response
 
     @unittest.skipIf(
-        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage IntegrityError in RED-1877
         'IntegrityError in wiki_articleplugin needs devstack/staging to test before marking as perm. failure.'
     )
     def test_retire_user(self):
@@ -1611,7 +1611,7 @@ class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
         self.assertEqual(retired_api_access_request.reason, '')
 
     @unittest.skipIf(
-        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,
+        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage IntegrityError in RED-1877
         'IntegrityError in wiki_articleplugin needs devstack/staging to test before marking as perm. failure.'
     )
     def test_retire_user_twice_idempotent(self):


### PR DESCRIPTION
This effectively moves the [RED-1595: [Juniper] Address failed tests](https://appsembler.atlassian.net/browse/RED-1595) Epic to done by creating corresponding [RED-1503: [Juniper] Tahoe production blockers](https://appsembler.atlassian.net/browse/RED-1503) tasks.