### PR TITLE
Django 2 upgrade: LmsCurrentOrganizationMiddleware

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/middleware.py
+++ b/openedx/core/djangoapps/appsembler/sites/middleware.py
@@ -60,7 +60,7 @@ class RedirectMiddleware(MiddlewareMixin):
             pass
 
 
-class LmsCurrentOrganizationMiddleware(object):
+class LmsCurrentOrganizationMiddleware(RedirectMiddleware):
     """
     Get the current middleware for the LMS.
 


### PR DESCRIPTION
Closes #844 by fixing the root cause. Too bad it's almost outside the reach of our tests.