### PR TITLE
Fixes and refactor for Studio login settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -406,7 +406,7 @@ FEATURES = {
     # .. toggle_tickets: https://openedx.atlassian.net/browse/DEPR-58
     # .. toggle_status: supported
     'DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO': True,
-    'STUDIO_LOCAL_LOGIN': False,
+    'TAHOE_STUDIO_LOCAL_LOGIN': False,
 }
 
 ENABLE_JASMINE = False

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -533,7 +533,7 @@ SYSTEM_WIDE_ROLE_CLASSES = ENV_TOKENS.get('SYSTEM_WIDE_ROLE_CLASSES') or SYSTEM_
 
 
 ### Appsembler customization - Studio local login ###
-if FEATURES.get('STUDIO_LOCAL_LOGIN'):
+if FEATURES.get('TAHOE_STUDIO_LOCAL_LOGIN'):
     CMS_ROOT_URL = '//localhost:18010'
     LOGIN_URL = reverse_lazy('login')
     FRONTEND_LOGIN_URL = lambda settings: settings.CMS_ROOT_URL + '/login'

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -534,11 +534,10 @@ SYSTEM_WIDE_ROLE_CLASSES = ENV_TOKENS.get('SYSTEM_WIDE_ROLE_CLASSES') or SYSTEM_
 
 ### Appsembler customization - Studio local login ###
 if FEATURES.get('TAHOE_STUDIO_LOCAL_LOGIN'):
-    CMS_ROOT_URL = '//localhost:18010'
     LOGIN_URL = reverse_lazy('login')
-    FRONTEND_LOGIN_URL = lambda settings: settings.CMS_ROOT_URL + '/login'
+    FRONTEND_LOGIN_URL = lambda settings: '/login/'
     derived('FRONTEND_LOGIN_URL')
-    FRONTEND_LOGOUT_URL = lambda settings: settings.CMS_ROOT_URL + '/logout/'
+    FRONTEND_LOGOUT_URL = lambda settings: '/logout/'
     derived('FRONTEND_LOGOUT_URL')
     LOGOUT_REDIRECT_URL = reverse_lazy('home')
 

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -301,7 +301,7 @@ urlpatterns += (
     url(r'^hijack/', include('hijack.urls')),
 )
 
-if settings.FEATURES.get('STUDIO_LOCAL_LOGIN'):
+if settings.FEATURES.get('TAHOE_STUDIO_LOCAL_LOGIN'):
     urlpatterns += [
         url(r'', include('cms.djangoapps.appsembler.urls'))
     ]


### PR DESCRIPTION
- Using the `TAHOE_` prefix makes the feature easier to distinguish from other Open edX features especially when used in theme.
- Studio login URL was resolving to `https://localhost:18010/login?next=https%3A%2F%2Fstudio.tahoe-us-juniper-staging.appsembler.com%2Fhome%2F`, the settings fixes should address this issue.

  ```
  >>> from django.conf import settings
  >>> settings.FRONTEND_LOGIN_URL
  '/login/'
  ```