### PR TITLE
RED-1877: always skip upstream failing tests in Juniper/Koa

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_proctoring.py
+++ b/cms/djangoapps/contentstore/tests/test_proctoring.py
@@ -100,10 +100,7 @@ class TestProctoredExams(ModuleStoreTestCase):
 
         self._verify_exam_data(sequence, True)
 
-    @unittest.skipIf(
-        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage IntegrityError in RED-1877
-        'IntegrityError due to UserID.test'
-    )
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Skipping until Lilac OSPR edx#27002 of BOM-2453')
     @ddt.data(
         (True, False, True, False, False),
         (False, False, True, False, False),
@@ -245,20 +242,7 @@ class TestProctoredExams(ModuleStoreTestCase):
         (False, False, 0),
     )
     @ddt.unpack
-    @unittest.skipIf(
-        # This test expects a user ID with the ID `-3` which is
-        # Therefore the error below is thrown:
-        #
-        #   django.db.utils.IntegrityError: The row in table 'proctoring_proctoredexamreviewpolicy'
-        #   with primary key '1' has an invalid foreign key:
-        #   proctoring_proctoredexamreviewpolicy.set_by_user_id contains a value '-3'
-        #   that does not have a corresponding value in auth_user.id.
-        #
-        # The fix is probably to see if there's some missing user creation for
-        # Special user IDs such as xmodule.modulestore.ModuleStoreEnum.UserID.test
-        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage IntegrityError in RED-1877
-        'fails due to IntegrityError'
-    )
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Skipping until Lilac OSPR edx#27002 of BOM-2453')
     def test_advanced_settings(self, enable_timed_exams, enable_proctored_exams, expected_count):
         """
         Make sure the feature flag is honored

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1570,10 +1570,7 @@ class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
         self.assertEqual(response.status_code, expected_status)
         return response
 
-    @unittest.skipIf(
-        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage IntegrityError in RED-1877
-        'IntegrityError in wiki_articleplugin needs devstack/staging to test before marking as perm. failure.'
-    )
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Skipping until Lilac OSPR edx#27002 of BOM-2453')
     def test_retire_user(self):
         # check that rows that will not exist after retirement exist now
         self.assertTrue(CreditRequest.objects.filter(username=self.test_user.username).exists())
@@ -1610,10 +1607,7 @@ class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
         self.assertEqual(retired_api_access_request.company_name, '')
         self.assertEqual(retired_api_access_request.reason, '')
 
-    @unittest.skipIf(
-        settings.TAHOE_TEMP_MONKEYPATCHING_JUNIPER_TESTS,  # TODO: Triage IntegrityError in RED-1877
-        'IntegrityError in wiki_articleplugin needs devstack/staging to test before marking as perm. failure.'
-    )
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Skipping until Lilac OSPR edx#27002 of BOM-2453')
     def test_retire_user_twice_idempotent(self):
         # check that a second call to the retire_misc endpoint will work
         data = {'username': self.original_username}


### PR DESCRIPTION
The failed upstream tests appear to need a decent investment to be fixed. Not worth it unfortunately.

I've checked it in Koa.master and it failed as well. It could have to do with my SQLite version `3.31.1`, but I don't want to push more time in it.

Those tests are to be fixed in Lilac https://github.com/edx/edx-platform/pull/27002 but the commits are not cleanly cherry-pickable.

RED-1877