### PR TITLE
Refactor course.certificates_display_behavior to add a setting

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -569,9 +569,9 @@ class CourseFields(object):
             "soon as certificates are generated, enter early_no_info."
         ),
         scope=Scope.settings,
-        # Appsembler: Defaulting to "early_with_info" rather than edX's "end" to match customers needs
-        # More info on: https://trello.com/c/bi7J0a4z
-        default="early_with_info",
+        # Tahoe: RED-1599: Customize the default value to 'early_with_info' instead of edX's 'end'
+        # RED-1599: Defaulting to "early_with_info" rather than edX's "end" to match customers needs
+        default=getattr(settings, "TAHOE_CERTIFICATE_DISPLAY_BEHAVIOUR", "early_with_info"),
     )
     course_image = String(
         display_name=_("Course About Page Image"),

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -148,6 +148,21 @@ class HasEndedMayCertifyTestCase(unittest.TestCase):
         self.assertFalse(self.future_noshow_certs.may_certify())
 
 
+def test_tahoe_customized_certificate_behaviour_setting():
+    """
+    Test for the `TAHOE_CERTIFICATE_DISPLAY_BEHAVIOUR` setting to customize certificates_display_behavior.
+    """
+    course_xml = """
+         <course org="{org}" course="{course}" url_name="test">
+            <chapter url="hi" url_name="ch" display_name="CH"></chapter>
+         </course>
+    """.format(org=ORG, course=COURSE)
+
+    system = DummySystem(load_error_modules=True)
+    course = system.process_xml(course_xml)
+    assert course.certificates_display_behavior == 'early_with_info'
+
+
 class CourseSummaryHasEnded(unittest.TestCase):
     """ Test for has_ended method when end date is missing timezone information. """
 


### PR DESCRIPTION
This pull request mostly pay a minor tech-debt without noticeable changes. It paves the way for customizing the value for Tahoe Clusters.

- `TAHOE_CERTIFICATE_DISPLAY_BEHAVIOUR` allows customizing the default value. This changes the default from `end` to `early_with_info`
- Full details are both in https://github.com/appsembler/edx-platform/pull/381 and the Jira issue RED-1599


### Tests

This PR does _not_ enable tests for `test_course_module.py` but adds a test case for future reference.

The tests will be enabled (low priority) in another PR: https://github.com/appsembler/edx-platform/pull/860
