### PR TITLE
Raise upload limit to 25MB

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1173,10 +1173,10 @@ SHIBBOLETH_DOMAIN_PREFIX = 'shib:'
 OPENID_DOMAIN_PREFIX = 'openid:'
 
 ### Size of chunks into which asset uploads will be divided
-UPLOAD_CHUNK_SIZE_IN_MB = 10
+UPLOAD_CHUNK_SIZE_IN_MB = 25
 
 ### Max size of asset uploads to GridFS
-MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = 10
+MAX_ASSET_UPLOAD_FILE_SIZE_IN_MB = 25
 
 # FAQ url to direct users to if they upload
 # a file that exceeds the above size


### PR DESCRIPTION
Raising upload size limit to 25MB.
No other customer is using Ginkgo version of edx-platform, So instead of creating a branch for PSU and doing this there I picked the easy path to raise the file upload on Ginkgo master branch since no other customer is using this branch