### PR TITLE
Remove unneeded hr management related code

### DIFF
--- a/cms/envs/devstack_appsembler.py
+++ b/cms/envs/devstack_appsembler.py
@@ -3,6 +3,8 @@
 from .devstack_docker import *
 from .appsembler import *
 
+EMAIL_BACKEND = ENV_TOKENS.get('EMAIL_BACKEND', EMAIL_BACKEND)
+
 ENV_APPSEMBLER_FEATURES = ENV_TOKENS.get('APPSEMBLER_FEATURES', {})
 for feature, value in ENV_APPSEMBLER_FEATURES.items():
     APPSEMBLER_FEATURES[feature] = value

--- a/cms/envs/devstack_appsembler.py
+++ b/cms/envs/devstack_appsembler.py
@@ -1,6 +1,6 @@
 # devstack_appsembler.py
 
-from .devstack import *
+from .devstack_docker import *
 from .appsembler import *
 
 ENV_APPSEMBLER_FEATURES = ENV_TOKENS.get('APPSEMBLER_FEATURES', {})
@@ -22,58 +22,6 @@ EDX_ORG_COURSE_API_CLIENT_ID = AUTH_TOKENS.get('EDX_ORG_COURSE_API_CLIENT_ID', F
 EDX_ORG_COURSE_API_CLIENT_SECRET = AUTH_TOKENS.get('EDX_ORG_COURSE_API_CLIENT_SECRET', False)
 EDX_ORG_COURSE_API_TOKEN_TYPE = AUTH_TOKENS.get('EDX_ORG_COURSE_API_TOKEN_TYPE', False)
 EDX_ORG_COURSE_API_CATALOG_IDS = ENV_TOKENS.get('EDX_ORG_COURSE_API_CATALOG_IDS', False)
-
-if (APPSEMBLER_FEATURES.get('ENABLE_USAGE_TRACKING', False) or
-        APPSEMBLER_FEATURES.get('ENABLE_USAGE_AGGREGATION', False)):
-    # enable both apps for either feature flag, because
-    #
-    # * appsembler_usage depends on souvenirs models
-    #
-    # * appsembler_usage adds backfill_usage and email_usage management
-    #   commands even if the aggregation DB isn't available.
-    #
-    INSTALLED_APPS += (
-        'souvenirs',
-        'openedx.core.djangoapps.appsembler.usage',  # appsembler_usage
-    )
-
-    if APPSEMBLER_FEATURES.get('ENABLE_USAGE_TRACKING', False):
-        # enable live usage tracking via middleware
-        MIDDLEWARE_CLASSES += (
-            'souvenirs.middleware.SouvenirsMiddleware',
-        )
-
-    # router to send aggregation to cloud sql.
-    # this should be enabled even if the aggregation DB isn't available,
-    # to avoid trying to run migrations or store aggregation data in MySQL.
-    DATABASE_ROUTERS += [
-        'openedx.core.djangoapps.appsembler.usage.routers.AppsemblerUsageRouter',
-    ]
-
-    # appsembler devstack has dummy caches, but souvenirs needs a real cache
-    # for rate-limiting writes to DB.
-    SOUVENIRS_CACHE_NAME = 'souvenirs'
-    CACHES[SOUVENIRS_CACHE_NAME] = {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'souvenirs',
-    }
-
-    # operator can override DB auth for migrations
-    if ('appsembler_usage' in DATABASES and
-            os.environ.get('APPSEMBLER_USAGE_DB_AUTH')):
-        _user, _password = os.environ['APPSEMBLER_USAGE_DB_AUTH'].split(':', 1)
-        DATABASES['appsembler_usage'].update({
-            'USER': _user,
-            'PASSWORD': _password,
-        })
-
-    # custom reports function to count learners, staff, etc.
-    SOUVENIRS_USAGE_REPORTS_FUNCTION = 'openedx.core.djangoapps.appsembler.usage.reports.usage_for_periods'
-
-elif 'appsembler_usage' in DATABASES:
-    # if the AppsemblerUsageRouter isn't enabled, then avoid mistakes by
-    # removing the database alias
-    del DATABASES['appsembler_usage']
 
 # to allow to run python-saml with custom port
 SP_SAML_RESTRICT_MODE = False

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -68,14 +68,6 @@ DISABLE_UNENROLL_CERT_STATES = [
 USERNAME_EXISTS_MSG_FMT = _("An account with the Public Username '{username}' already exists.")
 
 
-# try to import appsembler fork of edx-organizations (if it's installed)
-try:
-    from organizations.models import Organization, UserOrganizationMapping
-    from hr_management.views import send_microsite_request_email_to_managers
-except ImportError:
-    pass
-
-
 log = logging.getLogger(__name__)
 
 
@@ -418,14 +410,6 @@ def create_or_set_user_attribute_created_on_site(user, site, request):
     """
     if site and site.id != settings.SITE_ID:
         UserAttribute.set_user_attribute(user, 'created_on_site', site.domain)
-
-    #if using custom Appsembler backend from edx-organizations
-    if u'organizations.backends.OrganizationMemberBackend' in settings.AUTHENTICATION_BACKENDS:
-        org = configuration_helpers.get_value('course_org_filter')
-        organization = Organization.objects.filter(name=org).first()
-        if organization:
-            UserOrganizationMapping.objects.get_or_create(user=user, organization=organization, is_active=False)
-            send_microsite_request_email_to_managers(request, user)
 
 
 # We want to allow inactive users to log in only when their account is first created

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -1,7 +1,7 @@
 # devstack_appsembler.py
 
 import os
-from .devstack import *
+from .devstack_docker import *
 from .appsembler import *
 
 ENV_APPSEMBLER_FEATURES = ENV_TOKENS.get('APPSEMBLER_FEATURES', {})

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -48,58 +48,6 @@ if APPSEMBLER_FEATURES.get('ENABLE_EXTERNAL_COURSES', False):
             ),
         }
 
-if (APPSEMBLER_FEATURES.get('ENABLE_USAGE_TRACKING', False) or
-        APPSEMBLER_FEATURES.get('ENABLE_USAGE_AGGREGATION', False)):
-    # enable both apps for either feature flag, because
-    #
-    # * appsembler_usage depends on souvenirs models
-    #
-    # * appsembler_usage adds backfill_usage and email_usage management
-    #   commands even if the aggregation DB isn't available.
-    #
-    INSTALLED_APPS += (
-        'souvenirs',
-        'openedx.core.djangoapps.appsembler.usage',  # appsembler_usage
-    )
-
-    if APPSEMBLER_FEATURES.get('ENABLE_USAGE_TRACKING', False):
-        # enable live usage tracking via middleware
-        MIDDLEWARE_CLASSES += (
-            'souvenirs.middleware.SouvenirsMiddleware',
-        )
-
-    # router to send aggregation to cloud sql.
-    # this should be enabled even if the aggregation DB isn't available,
-    # to avoid trying to run migrations or store aggregation data in MySQL.
-    DATABASE_ROUTERS += [
-        'openedx.core.djangoapps.appsembler.usage.routers.AppsemblerUsageRouter',
-    ]
-
-    # appsembler devstack has dummy caches, but souvenirs needs a real cache
-    # for rate-limiting writes to DB.
-    SOUVENIRS_CACHE_NAME = 'souvenirs'
-    CACHES[SOUVENIRS_CACHE_NAME] = {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'souvenirs',
-    }
-
-    # operator can override DB auth for migrations
-    if ('appsembler_usage' in DATABASES and
-            os.environ.get('APPSEMBLER_USAGE_DB_AUTH')):
-        _user, _password = os.environ['APPSEMBLER_USAGE_DB_AUTH'].split(':', 1)
-        DATABASES['appsembler_usage'].update({
-            'USER': _user,
-            'PASSWORD': _password,
-        })
-
-    # custom reports function to count learners, staff, etc.
-    SOUVENIRS_USAGE_REPORTS_FUNCTION = 'openedx.core.djangoapps.appsembler.usage.reports.usage_for_periods'
-
-elif 'appsembler_usage' in DATABASES:
-    # if the AppsemblerUsageRouter isn't enabled, then avoid mistakes by
-    # removing the database alias
-    del DATABASES['appsembler_usage']
-
 # to allow to run python-saml with custom port
 SP_SAML_RESTRICT_MODE = False
 

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -14,6 +14,8 @@ for cache_key in CACHES.keys():
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
+EMAIL_BACKEND = ENV_TOKENS.get('EMAIL_BACKEND', EMAIL_BACKEND)
+
 INSTALLED_APPS += (
     'appsembler',
     'appsembler_api'

--- a/lms/envs/devstack_appsembler.py
+++ b/lms/envs/devstack_appsembler.py
@@ -58,16 +58,6 @@ if 'LMS_AUTHENTICATION_BACKENDS' in APPSEMBLER_FEATURES.keys():
 
 EXCLUSIVE_SSO_LOGISTRATION_URL_MAP = ENV_TOKENS.get('EXCLUSIVE_SSO_LOGISTRATION_URL_MAP', {})
 
-#attempt to import model from our custom fork of edx-organizations
-# if it works, then also add the middleware
-try:
-    from organizations.models import UserOrganizationMapping
-    MIDDLEWARE_CLASSES += (
-        'organizations.middleware.OrganizationMiddleware',
-    )
-except ImportError:
-    pass
-
 # override devstack.py automatic enabling of courseware discovery
 FEATURES['ENABLE_COURSE_DISCOVERY'] = ENV_TOKENS['FEATURES'].get('ENABLE_COURSE_DISCOVERY', FEATURES['ENABLE_COURSE_DISCOVERY'])
 

--- a/lms/envs/devstack_docker.py
+++ b/lms/envs/devstack_docker.py
@@ -41,15 +41,16 @@ JWT_AUTH.update({
     ],
 })
 
-FEATURES.update({
-    'AUTOMATIC_AUTH_FOR_TESTING': True,
-    'ENABLE_COURSEWARE_SEARCH': False,
-    'ENABLE_COURSE_DISCOVERY': False,
-    'ENABLE_DASHBOARD_SEARCH': False,
-    'ENABLE_DISCUSSION_SERVICE': True,
-    'SHOW_HEADER_LANGUAGE_SELECTOR': True,
-    'ENABLE_ENTERPRISE_INTEGRATION': False,
-})
+# Appsembler: we often need to check these features. Don't override
+# FEATURES.update({
+#     'AUTOMATIC_AUTH_FOR_TESTING': True,
+#     'ENABLE_COURSEWARE_SEARCH': False,
+#     'ENABLE_COURSE_DISCOVERY': False,
+#     'ENABLE_DASHBOARD_SEARCH': False,
+#     'ENABLE_DISCUSSION_SERVICE': True,
+#     'SHOW_HEADER_LANGUAGE_SELECTOR': True,
+#     'ENABLE_ENTERPRISE_INTEGRATION': False,
+# })
 
 ENABLE_MKTG_SITE = os.environ.get('ENABLE_MARKETING_SITE', False)
 MARKETING_SITE_ROOT = os.environ.get('MARKETING_SITE_ROOT', 'http://localhost:8080')

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -7,7 +7,8 @@ from urlparse import urlparse, urlunparse
 
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models.fields import BooleanField, DateTimeField, DecimalField, TextField, FloatField, IntegerField
+from django.db.models import Q
+from django.db.models.fields import BooleanField, DateTimeField, DecimalField, FloatField, IntegerField, TextField
 from django.db.utils import IntegrityError
 from django.template import defaultfilters
 
@@ -576,7 +577,10 @@ class CourseOverview(TimeStampedModel):
             # In rare cases, courses belonging to the same org may be accidentally assigned
             # an org code with a different casing (e.g., Harvardx as opposed to HarvardX).
             # Case-insensitive matching allows us to deal with this kind of dirty data.
-            course_overviews = course_overviews.filter(org__iregex=r'(' + '|'.join(orgs) + ')')
+            org_filter = Q()  # Avoiding the `reduce()` for more readability, so a no-op filter starter is needed.
+            for org in orgs:
+                org_filter |= Q(org__iexact=org)
+            course_overviews = course_overviews.filter(org_filter)
 
         if filter_:
             course_overviews = course_overviews.filter(**filter_)


### PR DESCRIPTION
It's all been refactored over to hr_management nyif/hawthorn branch so we can keep edx-platform clean.

This is a little bit of a messy PR because it does some other things, too.

* use devstack_docker.py as base for devstack_appsembler.py (was importing from plain devstack.py before)
* cherry-pick a pick from Tahoe branch that fixes some organization name matching for Find Courses

