### PR TITLE
fix: instructor dashboard broken BridgeKeeper permissions

### DIFF
--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_login_view.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_login_view.py
@@ -14,17 +14,11 @@ from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from .test_utils import with_organization_context, create_org_user
+from ...settings.helpers import get_tahoe_multitenant_auth_backends
 
 
 @skip_unless_lms
-@override_settings(
-    AUTHENTICATION_BACKENDS=(
-        # Match the Appsembler configuration in appsembler.settings..production_common
-        'organizations.backends.DefaultSiteBackend',
-        'organizations.backends.SiteMemberBackend',
-        'organizations.backends.OrganizationMemberBackend',
-    )
-)
+@override_settings(AUTHENTICATION_BACKENDS=get_tahoe_multitenant_auth_backends(settings))
 @skipUnless(settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'], 'This only tests multi-tenancy')
 class MultiTenantLoginTest(CacheIsolationTestCase):
     """
@@ -49,16 +43,6 @@ class MultiTenantLoginTest(CacheIsolationTestCase):
         cache.clear()
         # Store the login url
         self.url = reverse('login_api')
-
-    def test_auth_backends(self):
-        """
-        Ensure the correct authentication backends are enabled for this test case.
-        """
-        assert settings.AUTHENTICATION_BACKENDS == (
-            'organizations.backends.DefaultSiteBackend',
-            'organizations.backends.SiteMemberBackend',
-            'organizations.backends.OrganizationMemberBackend',
-        )
 
     def create_user(self, org, email=EMAIL, password=PASSWORD):
         """

--- a/openedx/core/djangoapps/appsembler/settings/helpers.py
+++ b/openedx/core/djangoapps/appsembler/settings/helpers.py
@@ -1,0 +1,80 @@
+"""
+Helpers for the settings.
+"""
+
+from os import path
+
+
+def get_tahoe_theme_static_dirs(settings):
+    """
+    Get STATICFILES_DIRS for Tahoe to enable Appsembler Themes static files customizations.
+
+    :param settings (Django settings module).
+    :return STATICFILES_DIRS for Tahoe.
+    """
+    from openedx.core.djangoapps.theming.helpers_dirs import (
+        get_themes_unchecked,
+        get_theme_base_dirs_from_settings
+    )
+
+    if settings.ENABLE_COMPREHENSIVE_THEMING:
+        themes_dirs = get_theme_base_dirs_from_settings(settings.COMPREHENSIVE_THEME_DIRS)
+        themes = get_themes_unchecked(themes_dirs, settings.PROJECT_ROOT)
+
+        assert len(themes), 'Customer themes enabled, but it seems that there is no Tahoe theme.'
+        assert len(themes) == 1, (
+            'Customer themes enabled, but it looks like there is more than one theme, '
+            'however Tahoe does only supports having a single instance of `edx-theme-codebase`'
+            'and no other theme should be installed.'
+        )
+
+        theme = themes[0]
+
+        # Allow the theme to override the platform files transparently
+        # without having to change the Open edX code.
+        theme_static = theme.path / 'static'
+        static_files_dir_setting = settings.STATICFILES_DIRS
+        if path.isdir(theme_static):
+            static_files_dir_setting += [theme_static]
+        return static_files_dir_setting
+
+
+def get_tahoe_multitenant_auth_backends(settings):
+    """
+    Support Multi-Tenancy via OrganizationMemberBackend and DefaultSiteBackend instead of the edX's backend.
+
+    :param settings (Django settings module).
+    :return AUTHENTICATION_BACKENDS for Tahoe.
+
+    Release upgrade note: This function modifies the AUTHENTICATION_BACKENDS by removing unwanted backends and adding
+                          Tahoe-needed multi-tenant backends. Without this function Tahoe won't function properly
+                          and there will be either silently missing features such as hidden Instructor
+                          Dashboard (RED-1924) or silently breaking Tahoe security.
+    """
+
+    upstream_user_model_backend = \
+        'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend'
+
+    if upstream_user_model_backend not in settings.AUTHENTICATION_BACKENDS:
+        # EdxRateLimitedAllowAllUsersModelBackend is missing from the settings.
+        # It helps to compare AUTHENTICATION_BACKENDS before and after this exception was raised.
+        raise Exception(
+            'Tahoe Security: settings.AUTHENTICATION_BACKENDS have changes by either upstream release upgrade or a '
+            'configuration change. '
+            'This means that the `use_tahoe_multitenant_auth_backends` function should be updated accordingly. '
+            'While there is no clear path to address this change, it is safer to avoid breaking authentication '
+            'silently.'
+        )
+
+    authentication_backends = settings.AUTHENTICATION_BACKENDS
+
+    if settings.APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_AUTH_BACKENDS', True):
+        upstream_backend_index = authentication_backends.index(upstream_user_model_backend)
+
+        # Use multi-tenant Tahoe backends instead of the upstream EdxRateLimitedAllowAllUsersModelBackend backend.
+        authentication_backends = settings.AUTHENTICATION_BACKENDS[:upstream_backend_index] + [
+            'organizations.backends.DefaultSiteBackend',
+            'organizations.backends.OrganizationMemberBackend',
+        ] + settings.AUTHENTICATION_BACKENDS[upstream_backend_index + 1:]
+
+    return authentication_backends

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -12,14 +12,14 @@ def plugin_settings(settings):
     """
     settings.APPSEMBLER_FEATURES = {}
 
-    settings.INSTALLED_APPS += (
+    settings.INSTALLED_APPS += [
         'hijack',
         'hijack_admin',
 
         'openedx.core.djangoapps.appsembler.sites',
         'openedx.core.djangoapps.appsembler.html_certificates',
         'openedx.core.djangoapps.appsembler.api',
-    )
+    ]
 
     # insert at beginning because it needs to be earlier in the list than various
     # redirect middleware which will cause later `process_request()` methods to be skipped

--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
@@ -27,9 +27,11 @@ def plugin_settings(settings):
             if cache_key != 'celery':  # NOTE: Disabling cache breaks things like Celery subtasks
                 settings.CACHES[cache_key]['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'
 
-    settings.INSTALLED_APPS += (
-        'django_extensions',
-    )
+    django_extensions_app_name = 'django_extensions'
+    if django_extensions_app_name not in settings.INSTALLED_APPS:
+        settings.INSTALLED_APPS += [
+            django_extensions_app_name,
+        ]
 
     settings.CUSTOMER_THEMES_BACKEND_OPTIONS = {}
 

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -40,7 +40,7 @@ def plugin_settings(settings):
         settings.ANYMAIL = {
             "MANDRILL_API_KEY": settings.MANDRILL_API_KEY,
         }
-        settings.INSTALLED_APPS += ("anymail",)
+        settings.INSTALLED_APPS += ['anymail']
 
     # Sentry
     settings.SENTRY_DSN = settings.AUTH_TOKENS.get('SENTRY_DSN', False)
@@ -54,7 +54,7 @@ def plugin_settings(settings):
             'dsn': settings.SENTRY_DSN,
         }
 
-        settings.INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
+        settings.INSTALLED_APPS += ['raven.contrib.django.raven_compat']
 
     if settings.FEATURES.get('ENABLE_TIERS_APP', False):
         settings.TIERS_ORGANIZATION_MODEL = 'organizations.Organization'
@@ -65,17 +65,17 @@ def plugin_settings(settings):
         settings.DATABASES['tiers'] = dj_database_url.parse(settings.TIERS_DATABASE_URL, ssl_require=True)
         settings.DATABASE_ROUTERS.insert(0, 'openedx.core.djangoapps.appsembler.sites.routers.TiersDbRouter')
 
-        settings.MIDDLEWARE += (
+        settings.MIDDLEWARE += [
             'tiers.middleware.TierMiddleware',
-        )
-        settings.INSTALLED_APPS += (
+        ]
+        settings.INSTALLED_APPS += [
             'tiers',
-        )
+        ]
 
     if settings.FEATURES.get('APPSEMBLER_MULTI_TENANT_EMAILS', False):
-        settings.INSTALLED_APPS += (
+        settings.INSTALLED_APPS += [
             'openedx.core.djangoapps.appsembler.multi_tenant_emails',
-        )
+        ]
 
     settings.TAHOE_DEFAULT_COURSE_NAME = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_NAME', '')
     settings.TAHOE_DEFAULT_COURSE_GITHUB_ORG = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_GITHUB_ORG', '')

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
@@ -1,42 +1,13 @@
 """
 Settings for Appsembler on LMS in Production.
 """
-from os import path
 
 from openedx.core.djangoapps.appsembler.settings.settings import production_common
+from ..helpers import get_tahoe_theme_static_dirs, get_tahoe_multitenant_auth_backends
 
 
 EDX_SITE_REDIRECT_MIDDLEWARE = "django_sites_extensions.middleware.RedirectMiddleware"
 TAHOE_MARKETING_SITE_URL = "https://appsembler.com/tahoe"
-
-
-def _add_theme_static_dirs(settings):
-    """
-    Appsembler Themes static files customizations.
-    """
-    from openedx.core.djangoapps.theming.helpers_dirs import (
-        get_themes_unchecked,
-        get_theme_base_dirs_from_settings
-    )
-
-    if settings.ENABLE_COMPREHENSIVE_THEMING:
-        themes_dirs = get_theme_base_dirs_from_settings(settings.COMPREHENSIVE_THEME_DIRS)
-        themes = get_themes_unchecked(themes_dirs, settings.PROJECT_ROOT)
-
-        assert len(themes), 'Customer themes enabled, but it seems that there is no Tahoe theme.'
-        assert len(themes) == 1, (
-            'Customer themes enabled, but it looks like there is more than one theme, '
-            'however Tahoe does only supports having a single instance of `edx-theme-codebase`'
-            'and no other theme should be installed.'
-        )
-
-        theme = themes[0]
-
-        # Allow the theme to override the platform files transparently
-        # without having to change the Open edX code.
-        theme_static = theme.path / 'static'
-        if path.isdir(theme_static):
-            settings.STATICFILES_DIRS.append(theme_static)
 
 
 def plugin_settings(settings):
@@ -107,25 +78,6 @@ def plugin_settings(settings):
     settings.COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_about_page'
     settings.SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING = True
 
-    if settings.APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_AUTH_BACKENDS', True):
-        settings.AUTHENTICATION_BACKENDS = (
-            'organizations.backends.DefaultSiteBackend',
-            'organizations.backends.SiteMemberBackend',
-            'organizations.backends.OrganizationMemberBackend',
-        )
-
-    if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
-        settings.AUTHENTICATION_BACKENDS = list(settings.AUTHENTICATION_BACKENDS) + (
-            settings.ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
-                'social_core.backends.google.GoogleOAuth2',
-                'social_core.backends.linkedin.LinkedinOAuth2',
-                'social_core.backends.facebook.FacebookOAuth2',
-                'social_core.backends.azuread.AzureADOAuth2',
-                'third_party_auth.saml.SAMLAuthBackend',
-                'third_party_auth.lti.LTIAuthBackend',
-            ])
-        )
-
     if settings.FEATURES.get('TAHOE_YEARLY_AMC_TOKENS', True):
         # TODO: RED-1901 Remove this feature and reduce the time back to one hour.
         #       Extending AMC tokens from an hour to a year is _not_ a good idea but needed for AMC to work and
@@ -140,4 +92,5 @@ def plugin_settings(settings):
     settings.ACCESS_CONTROL_BACKENDS = settings.ENV_TOKENS.get('ACCESS_CONTROL_BACKENDS', {})
     settings.LMS_SEGMENT_SITE = settings.AUTH_TOKENS.get('SEGMENT_SITE')
 
-    _add_theme_static_dirs(settings)
+    settings.STATICFILES_DIRS = get_tahoe_theme_static_dirs(settings)
+    settings.AUTHENTICATION_BACKENDS = get_tahoe_multitenant_auth_backends(settings)

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
@@ -53,9 +53,11 @@ def plugin_settings(settings):
 
     settings.LMS_BASE = settings.ENV_TOKENS.get('LMS_BASE')
 
-    settings.INSTALLED_APPS += (
-        'openedx.core.djangoapps.appsembler.tpa_admin',
-    )
+    tpa_admin_app_name = 'openedx.core.djangoapps.appsembler.tpa_admin'
+    if tpa_admin_app_name not in settings.INSTALLED_APPS:
+        settings.INSTALLED_APPS += [
+            tpa_admin_app_name,
+        ]
 
     settings.CORS_ORIGIN_ALLOW_ALL = True
 

--- a/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
@@ -29,6 +29,6 @@ def plugin_settings(settings):
     settings.TAHOE_ALWAYS_SKIP_TEST = True
 
     if settings.FEATURES.get('APPSEMBLER_MULTI_TENANT_EMAILS', False):
-        settings.INSTALLED_APPS += (
+        settings.INSTALLED_APPS += [
             'openedx.core.djangoapps.appsembler.multi_tenant_emails',
-        )
+        ]

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
@@ -3,7 +3,6 @@
 
 import pytest
 from mock import patch
-from path import Path
 
 from openedx.core.djangoapps.theming.helpers_dirs import Theme
 
@@ -15,30 +14,12 @@ from openedx.core.djangoapps.appsembler.settings.settings import (
 )
 
 
-class FakeSettings:
-    pass
-
-
-def get_faked_settings():
-    settings = FakeSettings()
-
-    settings.INSTALLED_APPS = []
-    settings.FEATURES = {}
-    settings.AMC_APP_URL = ''
-    settings.AMC_APP_OAUTH2_CLIENT_ID = ''
-    settings.APPSEMBLER_FEATURES = {}
-    settings.OAUTH2_PROVIDER = {}
-    settings.MIDDLEWARE = [
-        'django.contrib.sites.middleware.CurrentSiteMiddleware',
-        'django_sites_extensions.middleware.RedirectMiddleware',
-    ]
-    settings.STATICFILES_DIRS = []
-    settings.CACHES = {}
-    settings.ENABLE_COMPREHENSIVE_THEMING = True
-    settings.PROJECT_ROOT = Path('/tmp/')
-
+@pytest.fixture(scope='function')
+def fake_production_settings(settings):
+    """
+    Pytest fixture to fake production settings such as AUTH_TOKENS that are otherwise missing in tests.
+    """
     settings.AUTH_TOKENS = {}
-    settings.QUEUE_VARIANT = 'fake-queue-variant'
     settings.CELERY_QUEUES = {}
     settings.ALTERNATE_QUEUE_ENVS = []
     settings.ENV_TOKENS = {
@@ -47,30 +28,26 @@ def get_faked_settings():
         'EMAIL_BACKEND': 'fake-email-backend',
         'FEATURES': {}
     }
-    settings.COMPREHENSIVE_THEME_DIRS = ['/path/to/nowhere']
     settings.MAIN_SITE_REDIRECT_WHITELIST = []
     return settings
 
 
-def test_devstack_cms():
-    settings = get_faked_settings()
-    devstack_cms.plugin_settings(settings)
+def test_devstack_cms(fake_production_settings):
+    devstack_cms.plugin_settings(fake_production_settings)
 
 
-def test_devstack_lms():
-    settings = get_faked_settings()
-    devstack_lms.plugin_settings(settings)
+def test_devstack_lms(fake_production_settings):
+    devstack_lms.plugin_settings(fake_production_settings)
 
 
-def test_production_cms():
-    settings = get_faked_settings()
-    production_cms.plugin_settings(settings)
+def test_production_cms(fake_production_settings):
+    production_cms.plugin_settings(fake_production_settings)
 
 
 @pytest.mark.parametrize('retval, additional_count', [(False, 0), (True, 1)])
-def test_production_lms(retval, additional_count):
-    settings = get_faked_settings()
-    with patch('openedx.core.djangoapps.appsembler.settings.settings.production_lms.path.isdir',
+def test_production_lms(fake_production_settings, retval, additional_count):
+    settings = fake_production_settings
+    with patch('openedx.core.djangoapps.appsembler.settings.helpers.path.isdir',
                return_value=retval):
         with patch(
             'openedx.core.djangoapps.theming.helpers_dirs.get_themes_unchecked',

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_tahoe_auth_backends_bridgekeeper.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_tahoe_auth_backends_bridgekeeper.py
@@ -1,0 +1,53 @@
+"""
+Tests for BridgeKeeper auth backend with get_tahoe_multitenant_auth_backends() in-use.
+"""
+from django.test import override_settings
+from django.conf import settings
+
+from lms.djangoapps.instructor import permissions
+from lms.djangoapps.instructor.access import allow_access
+from lms.djangoapps.courseware.access import has_access
+
+from openedx.core.djangoapps.appsembler.settings.helpers import get_tahoe_multitenant_auth_backends
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from student.tests.factories import UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+@override_settings(AUTHENTICATION_BACKENDS=get_tahoe_multitenant_auth_backends(settings))
+@skip_unless_lms
+class TestInstructorAccessWithTahoeAuthBackends(ModuleStoreTestCase):
+    """
+    Ensure BridgeKeeper don't break when get_tahoe_multitenant_auth_backends() is used.
+
+    This fixes RED-1924 in which permissions.VIEW_DASHBOARD was broken due to get_tahoe_multitenant_auth_backends().
+    """
+
+    def setUp(self):
+        super(TestInstructorAccessWithTahoeAuthBackends, self).setUp()
+        self.course = CourseFactory.create()
+        self.instructor = UserFactory.create()
+        self.staff = UserFactory.create()
+        allow_access(self.course, self.instructor, 'instructor')
+        allow_access(self.course, self.staff, 'staff')
+
+    def test_tahoe_backends(self):
+        """
+        Ensure get_tahoe_multitenant_auth_backends adds Tahoe backends to AUTHENTICATION_BACKENDS.
+        """
+        assert 'organizations.backends.DefaultSiteBackend' in settings.AUTHENTICATION_BACKENDS
+        assert 'organizations.backends.OrganizationMemberBackend' in settings.AUTHENTICATION_BACKENDS
+
+    def test_instructors_has_access(self):
+        """
+        Sanity check for `has_access` without using BridgeKeeper's `user.has_perm()`.
+        """
+        assert has_access(self.staff, 'staff', self.course.id)
+        assert has_access(self.instructor, 'instructor', self.course.id)
+
+    def test_instructor_dashboard_view_perm(self):
+        """
+        Ensure has_perm (via BridgeKeeper) works with get_tahoe_multitenant_auth_backends() used.
+        """
+        assert self.staff.has_perm(permissions.VIEW_DASHBOARD, self.course.id)


### PR DESCRIPTION
### Bug fixes
RED-1924: This fix allows the Instructor Dashboard to function properly.
RED-1954: Show back the "View as student" bar for instructors.

Fixed it by removing hard-coded Hawthorn authentication backends in the `appsembler.settings` module and enabling Tahoe `AUTHENTICATION_BACKENDS` defensively via `get_tahoe_multitenant_auth_backends()`.

#### Refactoring: Removing `FakeSettings`
FakeSettings has been added to help test production settings but in tests. Which is an oxymoron, but it helped. The problem with `FakeSettings` is that it requires regular maintenance and breaks often with errors like:

```
AttributeError: 'FakeSettings' object has no attribute 'ENV_TOKENS'
```

To reduce maintaiance and add most settings, I've used the `fake_production_settings` pytest fixture to copy all `lms/env/test.py` and add production-only settings only when needed.

#### Refactoring: Replacing tuples with lists
Mostly to be consistent with the `lms/envs/common.py` settings to avoid nasty errors in the future.

### Screenshot

It's back!

<kbd>![image](https://user-images.githubusercontent.com/645156/113159663-76e43c80-9245-11eb-8a39-675c097083f0.png)</kbd>
