### PR TITLE
Juniper upgrade - Adds LMS_ROOT_URL assignment to SiteConfiguration.save

### DIFF
--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -6,6 +6,7 @@ Django models for site configurations.
 import collections
 from logging import getLogger
 import os
+from urllib.parse import urlsplit
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -88,6 +89,15 @@ class SiteConfiguration(models.Model):
         # Set the default language code for new sites if missing
         # TODO: Move it to somewhere else like in AMC
         self.site_values['LANGUAGE_CODE'] = self.site_values.get('LANGUAGE_CODE', 'en')
+
+        # We cannot simply use a protocol-relative URL for LMS_ROOT_URL
+        # This is because the URL here will be used by such activities as
+        # sending activation links to new users. The activation link needs the
+        # scheme address verfication emails. The callers using this variable
+        # expect the scheme in the URL
+        self.site_values['LMS_ROOT_URL'] = '{scheme}://{domain}'.format(
+            scheme=urlsplit(settings.LMS_ROOT_URL).scheme,
+            domain=self.site.domain)
 
         super(SiteConfiguration, self).save(**kwargs)
 

--- a/openedx/core/djangoapps/site_configuration/tests/test_models.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_models.py
@@ -2,10 +2,8 @@
 Tests for site configuration's django models.
 """
 import six
-from urllib.parse import urlsplit
 import unittest
 
-from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import IntegrityError, transaction
 from django.test import TestCase
@@ -162,19 +160,14 @@ class SiteConfigurationTests(TestCase):
             site_values=self.test_config1
         )
 
-        scheme = urlsplit(settings.LMS_ROOT_URL).scheme
-        expected_site_root_url = '{scheme}://{domain}'.format(scheme=scheme, domain=self.domain)
         # Make sure entry is saved and retrieved correctly
         self.assertEqual(site_configuration.get_value("university"), self.test_config1['university'])
         self.assertEqual(site_configuration.get_value("platform_name"), self.test_config1['platform_name'])
-        self.assertEqual(site_configuration.get_value("PLATFORM_NAME"), self.test_config1['platform_name'])
         self.assertEqual(site_configuration.get_value("SITE_NAME"), self.test_config1['SITE_NAME'])
         self.assertEqual(site_configuration.get_value("course_org_filter"), self.test_config1['course_org_filter'])
         self.assertEqual(site_configuration.get_value("css_overrides_file"), self.test_config1['css_overrides_file'])
         self.assertEqual(site_configuration.get_value("ENABLE_MKTG_SITE"), self.test_config1['ENABLE_MKTG_SITE'])
         self.assertEqual(site_configuration.get_value("favicon_path"), self.test_config1['favicon_path'])
-        self.assertEqual(site_configuration.get_value("LMS_ROOT_URL"), expected_site_root_url)
-
         self.assertEqual(
             site_configuration.get_value("ENABLE_THIRD_PARTY_AUTH"),
             self.test_config1['ENABLE_THIRD_PARTY_AUTH'],
@@ -310,15 +303,6 @@ class SiteConfigurationTests(TestCase):
                 "platform_name",
                 "dummy-default-value"),
             "dummy-default-value",
-        )
-        # Test that LMS_ROOT_URL is assigned to the SiteConfiguration on creation
-        scheme = urlsplit(settings.LMS_ROOT_URL).scheme
-        expected_site_root_url = '{scheme}://{domain}'.format(scheme=scheme,
-                                                              domain=self.domain)
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(
-                self.test_config1['course_org_filter'], 'LMS_ROOT_URL'),
-            expected_site_root_url
         )
 
     def test_get_site_for_org(self):

--- a/openedx/core/djangoapps/site_configuration/tests/test_models.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_models.py
@@ -2,8 +2,10 @@
 Tests for site configuration's django models.
 """
 import six
+from urllib.parse import urlsplit
 import unittest
 
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import IntegrityError, transaction
 from django.test import TestCase
@@ -160,14 +162,19 @@ class SiteConfigurationTests(TestCase):
             site_values=self.test_config1
         )
 
+        scheme = urlsplit(settings.LMS_ROOT_URL).scheme
+        expected_site_root_url = '{scheme}://{domain}'.format(scheme=scheme, domain=self.domain)
         # Make sure entry is saved and retrieved correctly
         self.assertEqual(site_configuration.get_value("university"), self.test_config1['university'])
         self.assertEqual(site_configuration.get_value("platform_name"), self.test_config1['platform_name'])
+        self.assertEqual(site_configuration.get_value("PLATFORM_NAME"), self.test_config1['platform_name'])
         self.assertEqual(site_configuration.get_value("SITE_NAME"), self.test_config1['SITE_NAME'])
         self.assertEqual(site_configuration.get_value("course_org_filter"), self.test_config1['course_org_filter'])
         self.assertEqual(site_configuration.get_value("css_overrides_file"), self.test_config1['css_overrides_file'])
         self.assertEqual(site_configuration.get_value("ENABLE_MKTG_SITE"), self.test_config1['ENABLE_MKTG_SITE'])
         self.assertEqual(site_configuration.get_value("favicon_path"), self.test_config1['favicon_path'])
+        self.assertEqual(site_configuration.get_value("LMS_ROOT_URL"), expected_site_root_url)
+
         self.assertEqual(
             site_configuration.get_value("ENABLE_THIRD_PARTY_AUTH"),
             self.test_config1['ENABLE_THIRD_PARTY_AUTH'],
@@ -303,6 +310,15 @@ class SiteConfigurationTests(TestCase):
                 "platform_name",
                 "dummy-default-value"),
             "dummy-default-value",
+        )
+        # Test that LMS_ROOT_URL is assigned to the SiteConfiguration on creation
+        scheme = urlsplit(settings.LMS_ROOT_URL).scheme
+        expected_site_root_url = '{scheme}://{domain}'.format(scheme=scheme,
+                                                              domain=self.domain)
+        self.assertEqual(
+            SiteConfiguration.get_value_for_org(
+                self.test_config1['course_org_filter'], 'LMS_ROOT_URL'),
+            expected_site_root_url
         )
 
     def test_get_site_for_org(self):

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -1,13 +1,13 @@
 """
 Tests for site configuration's Tahoe customizations.
 """
-from os import getenv
-
+from urllib.parse import urlsplit
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
 
 
@@ -41,6 +41,10 @@ class SiteConfigurationTests(TestCase):
             name=cls.test_config['SITE_NAME'],
         )
 
+        cls.scheme = urlsplit(settings.LMS_ROOT_URL).scheme
+        cls.expected_site_root_url = '{scheme}://{domain}'.format(
+            scheme=cls.scheme, domain=cls.domain)
+
     def test_site_configuration_compile_sass(self):
         """
         Test that and entry is added to SiteConfigurationHistory model each time a new
@@ -52,3 +56,36 @@ class SiteConfigurationTests(TestCase):
         )
 
         site_configuration.save()
+
+    def test_get_value(self):
+        """
+        Test that get_value returns correct value for Tahoe custom keys.
+        """
+        # add SiteConfiguration to database
+        site_configuration = SiteConfigurationFactory.create(
+            site=self.site,
+            site_values=self.test_config
+        )
+
+        # Make sure entry is saved and retrieved correctly
+        self.assertEqual(site_configuration.get_value("PLATFORM_NAME"),
+                         self.test_config['platform_name'])
+        self.assertEqual(site_configuration.get_value("LMS_ROOT_URL"),
+                         self.expected_site_root_url)
+
+    def test_get_value_for_org(self):
+        """
+        Test that get_value_for_org returns correct value for Tahoe custom keys.
+        """
+        # add SiteConfiguration to database
+        SiteConfigurationFactory.create(
+            site=self.site,
+            site_values=self.test_config
+        )
+
+        # Test that LMS_ROOT_URL is assigned to the SiteConfiguration on creation
+        self.assertEqual(
+            SiteConfiguration.get_value_for_org(
+                self.test_config['course_org_filter'], 'LMS_ROOT_URL'),
+            self.expected_site_root_url
+        )


### PR DESCRIPTION
Now when SiteConfiguration.save is called, it's 'site_values['LMS_ROOT_URL'] field variable will be assigned with the scheme from `django.conf.settings.LMS_ROOT_URL and the domain name from the site record associated with the site configuration record.


https://appsembler.atlassian.net/browse/RED-1863