### PR TITLE
Hide "View My Records" button in profile page

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -18,6 +18,9 @@ def plugin_settings(settings):
     settings.APPSEMBLER_AMC_API_BASE = settings.AUTH_TOKENS.get('APPSEMBLER_AMC_API_BASE')
     settings.APPSEMBLER_FIRST_LOGIN_API = '/logged_into_edx'
 
+    # Tahoe: RED-1909 - Credentials should be disabled on all sites.
+    settings.FEATURES['TAHOE_ENABLE_CREDENTIALS'] = False
+
     settings.AMC_APP_URL = settings.ENV_TOKENS.get('AMC_APP_URL')
     settings.AMC_APP_OAUTH2_CLIENT_ID = settings.ENV_TOKENS.get('AMC_APP_OAUTH2_CLIENT_ID')
 

--- a/openedx/core/djangoapps/credentials/models.py
+++ b/openedx/core/djangoapps/credentials/models.py
@@ -96,8 +96,13 @@ class CredentialsApiConfig(ConfigurationModel):
         """
         Publicly-accessible Records URL root.
         """
+        # Tahoe: Credentials can be turned off on all sites by default.
+        #        The feature is set to `False` but only in `production_common.py`, so it stays `True` during test
+        #        to avoid massively breaking upstream tests.
+        default_credentials_enabled = settings.FEATURES.get('TAHOE_ENABLE_CREDENTIALS', True)
+
         # Not every site wants the Learner Records feature, so we allow opting out.
-        if not helpers.get_value('ENABLE_LEARNER_RECORDS', True):
+        if not helpers.get_value('ENABLE_LEARNER_RECORDS', default_credentials_enabled):
             return None
         root = helpers.get_value('CREDENTIALS_PUBLIC_SERVICE_URL', settings.CREDENTIALS_PUBLIC_SERVICE_URL)
         return urljoin(root, '/records/')

--- a/openedx/core/djangoapps/credentials/tests/test_tahoe_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_tahoe_utils.py
@@ -1,0 +1,18 @@
+"""Tests covering Credentials utilities with Tahoe customizations."""
+
+import pytest
+
+from openedx.core.djangoapps.credentials.utils import get_credentials_records_url
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+
+@skip_unless_lms
+@pytest.mark.django_db
+def test_tahoe_credentials_records_url(settings):
+    """
+    Credentials is disabled in Tahoe, so get_credentials_records_url() return `None`.
+    """
+    assert get_credentials_records_url(), 'By default a URL should be returned, otherwise upstream tests will break'
+
+    settings.FEATURES = {'TAHOE_ENABLE_CREDENTIALS': False}
+    assert not get_credentials_records_url(), 'In Tahoe production credentials can be disabled'


### PR DESCRIPTION
RED-1909. Introduce new `FEATURES['TAHOE_ENABLE_CREDENTIALS']` which should be set to `False` on production.



### Button's gone:

before
![image](https://user-images.githubusercontent.com/645156/113577651-424bf880-962a-11eb-935f-cb2b4b9e172a.png)

after

![image](https://user-images.githubusercontent.com/645156/113577677-4bd56080-962a-11eb-8f26-b34fc901b171.png)
