### PR TITLE
Don't automatically activate the user when password is provided

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
@@ -72,7 +72,6 @@ class RegistrationApiViewTests(TestCase):
             res = self.client.post(self.url, params)
         self.assertContains(res, 'user_id', status_code=status.HTTP_200_OK)
 
-
     @ddt.data(True, False, 'True', 'False', 'true', 'false')
     def test_send_activation_email_with_password(self, send_activation_email):
         """
@@ -99,7 +98,6 @@ class RegistrationApiViewTests(TestCase):
             new_user = User.objects.get(username=params['username'])
             assert new_user.is_active != send_activation_email
 
-
     @ddt.data(True, False, 'True', 'False', 'true', 'false')
     def test_send_activation_email_without_password(self, send_activation_email):
         """
@@ -124,7 +122,6 @@ class RegistrationApiViewTests(TestCase):
                 self.assertContains(res, 'user_id', status_code=200)
                 new_user = User.objects.get(username=params['username'])
                 assert new_user.is_active == False
-
 
     @ddt.data('username', 'name')
     def test_missing_field(self, field):

--- a/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
@@ -7,6 +7,7 @@ These tests adapted from Appsembler enterprise `appsembler_api` tests
 from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 
@@ -71,8 +72,16 @@ class RegistrationApiViewTests(TestCase):
             res = self.client.post(self.url, params)
         self.assertContains(res, 'user_id', status_code=status.HTTP_200_OK)
 
+
     @ddt.data(True, False, 'True', 'False', 'true', 'false')
     def test_send_activation_email_with_password(self, send_activation_email):
+        """
+        This test makes sure when the API endpoint is called with a password,
+        the send_activation_email parameter is being used properly. Also makes
+        sure when the attribute is True the user remains inactive until the
+        activation is performed through the activation email. It also makes 
+        sure the user is automatically activate when the parameter is False.
+        """
         params = {
             'username': 'mr_potato_head',
             'email': 'mr_potato_head@example.com',
@@ -87,10 +96,16 @@ class RegistrationApiViewTests(TestCase):
         with patch('student.views.management.compose_and_send_activation_email', fake_send):
             res = self.client.post(self.url, params)
             self.assertContains(res, 'user_id', status_code=200)
+            new_user = User.objects.get(username=params['username'])
+            assert new_user.is_active != send_activation_email
+
 
     @ddt.data(True, False, 'True', 'False', 'true', 'false')
     def test_send_activation_email_without_password(self, send_activation_email):
-        """Should not send email. Ignores the `send_activation_email` param
+        """
+        Should not send email. Ignores the `send_activation_email` param. It
+        also makes sure the user remains inactive (is_active=False). The user
+        will be activated after the password is reseted.
         """
         params = {
             'username': 'mr_potato_head',
@@ -107,6 +122,9 @@ class RegistrationApiViewTests(TestCase):
             with patch('student.views.management.compose_and_send_activation_email', fake_send):
                 res = self.client.post(self.url, params)
                 self.assertContains(res, 'user_id', status_code=200)
+                new_user = User.objects.get(username=params['username'])
+                assert new_user.is_active == False
+
 
     @ddt.data('username', 'name')
     def test_missing_field(self, field):

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -193,8 +193,13 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
             # meaning we don't have to send a password reset email
             #user.is_active = password_provided
             if not password_provided:
+                # if the password is not provided, keep the user inactive until
+                # the password is set.
                 user.is_active = False
             else:
+                # if send_activation_email is True, we want to keep the user
+                # inactive until the email is properly validated. If the param
+                # is False, we activate it.
                 user.is_active = not data['send_activation_email']
             user.save()
             user_id = user.id

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -191,7 +191,11 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
             )
             # set the user as active if password is provided
             # meaning we don't have to send a password reset email
-            user.is_active = password_provided
+            #user.is_active = password_provided
+            if not password_provided:
+                user.is_active = False
+            else:
+                user.is_active = not data['send_activation_email']
             user.save()
             user_id = user.id
             if not password_provided:


### PR DESCRIPTION
Originally when we received the customer complain about this issue, we initially thought it was a design issue, and the original plan was to create a V2 of the API to address the issue. But it is actually a bug in the API endpoint.

In order to better understand the endpoint, please read our customer facing documentation: https://help.appsembler.com/article/438-tahoe-registration-api

The issue is that when a user is created through the endpoint, if the password is set, the endpoint automatically activates the user, despite if the `send_activation_email` parameter is `True` or `False`. This behaviour is wrong and it doesn't reflect what the customer facing docs describe. 

If the `send_activation_email` parameter is `True` the user must remain inactive until the email link is followed and the email address activated. We only need to auto activate the user when the endpoint is called with `send_activation_email=False`, because that means the API consumed is taking care of the email validation. 

This is causing pain points in the user workflow, because when users are created, they receive the activation email, but when they click it and land in the platform, a message saying the account is already activated is confusing.