### PR TITLE
stop auto-activating the user when password is provided

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: edx-platform tests
+
+on:
+  push:
+    branches:
+      - "appsembler/tahoe/develop"
+      - "appsembler/tahoe/master"
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+    strategy:
+      matrix:
+        python-version: [2.7]
+        tox-env:
+          - pep8
+          - py-common
+          - py-lms-1
+          - py-lms-2
+          - py-mte
+          - py-studio
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }} ${{ matrix.tox-env }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      # TODO: Remove tox-pip-version once we upgrade to Koa+, or whenever we have addressed pip 20.3 strict issues.
+      run: |
+        sudo apt-get install -y python-dev libxml2-dev libxmlsec1-dev
+        pip install tox tox-pip-version
+    - name: Run tox
+      run: |
+        tox -e ${{ matrix.tox-env }}

--- a/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
@@ -117,7 +117,7 @@ class RegistrationApiViewTests(TestCase):
                 res = self.client.post(self.url, params)
                 self.assertContains(res, 'user_id', status_code=200)
                 new_user = User.objects.get(username=params['username'])
-                assert new_user.is_active == False
+                assert not new_user.is_active
 
     @ddt.data('username', 'name')
     def test_missing_field(self, field):

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -213,14 +213,14 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
                 params=data,
             )
             if not password_provided:
-                # if the password is not provided, keep the user inactive until
-                # the password is set.
-                user.is_active = False
-            else:
                 # if send_activation_email is True, we want to keep the user
                 # inactive until the email is properly validated. If the param
                 # is False, we activate it.
                 user.is_active = not data['send_activation_email']
+            else:
+                # if the password is not provided, keep the user inactive until
+                # the password is set.
+                user.is_active = False
             user.save()
             user_id = user.id
             if not password_provided:

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -212,9 +212,15 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
                 request=request,
                 params=data,
             )
-            # set the user as active if password is provided
-            # meaning we don't have to send a password reset email
-            user.is_active = password_provided
+            if not password_provided:
+                # if the password is not provided, keep the user inactive until
+                # the password is set.
+                user.is_active = False
+            else:
+                # if send_activation_email is True, we want to keep the user
+                # inactive until the email is properly validated. If the param
+                # is False, we activate it.
+                user.is_active = not data['send_activation_email']
             user.save()
             user_id = user.id
             if not password_provided:

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -112,7 +112,6 @@ PyContracts==1.7.1
 pycountry==1.20
 pycryptodomex==3.4.7
 pygments==2.2.0                     # Used to support colors in paver command output
-pygraphviz==1.1                     # No longer in use?  Optional dependency of networkx, from edx-sandbox/shared.in
 pyjwkest==1.3.2
 # TODO Replace PyJWT usage with pyjwkest
 PyJWT==1.5.2

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -189,7 +189,6 @@ pycountry==1.20
 pycparser==2.18
 pycryptodomex==3.4.7
 pygments==2.2.0
-pygraphviz==1.1
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pymongo==3.9.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -250,7 +250,6 @@ pycryptodomex==3.4.7
 pydispatcher==2.0.5
 pyflakes==1.6.0
 pygments==2.2.0
-pygraphviz==1.1
 pyinotify==0.9.6
 pyjwkest==1.3.2
 pyjwt==1.5.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -240,7 +240,6 @@ pycryptodomex==3.4.7
 pydispatcher==2.0.5       # via scrapy
 pyflakes==1.6.0           # via flake8
 pygments==2.2.0
-pygraphviz==1.1
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pylint-celery==0.3        # via edx-lint


### PR DESCRIPTION
(Originally opened against main but closed by @OmarIthawi https://github.com/appsembler/edx-platform/pull/876)

Originally when we received the customer complain about this issue, we initially thought it was a design issue, and the original plan was to create a V2 of the API to address the issue. But it is actually a bug in the API endpoint.

In order to better understand the endpoint, please read our customer facing documentation: https://help.appsembler.com/article/438-tahoe-registration-api

The issue is that when a user is created through the endpoint, if the password is set, the endpoint automatically activates the user, despite if the `send_activation_email` parameter is `True` or `False`. This behaviour is wrong and it doesn't reflect what the customer facing docs describe. 

If the `send_activation_email` parameter is `True` the user must remain inactive until the email link is followed and the email address activated. We only need to auto activate the user when the endpoint is called with `send_activation_email=False`, because that means the API consumed is taking care of the email validation. 

This is causing pain points in the user workflow, because when users are created, they receive the activation email, but when they click it and land in the platform, a message saying the account is already activated is confusing.