### PR TITLE
 stop auto-activating the user when password is provided (3rd attempt)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: edx-platform tests
+
+on:
+  push:
+    branches:
+      - "appsembler/tahoe/develop"
+      - "appsembler/tahoe/master"
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+    strategy:
+      matrix:
+        python-version: [2.7]
+        tox-env:
+          - pep8
+          - py-common
+          - py-lms-1
+          - py-lms-2
+          - py-mte
+          - py-studio
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }} ${{ matrix.tox-env }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      # TODO: Remove tox-pip-version once we upgrade to Koa+, or whenever we have addressed pip 20.3 strict issues.
+      run: |
+        sudo apt-get install -y python-dev libxml2-dev libxmlsec1-dev
+        pip install tox tox-pip-version
+    - name: Run tox
+      run: |
+        tox -e ${{ matrix.tox-env }}

--- a/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
@@ -117,7 +117,7 @@ class RegistrationApiViewTests(TestCase):
                 res = self.client.post(self.url, params)
                 self.assertContains(res, 'user_id', status_code=200)
                 new_user = User.objects.get(username=params['username'])
-                assert new_user.is_active == False
+                assert not new_user.is_active
 
     @ddt.data('username', 'name')
     def test_missing_field(self, field):

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -213,14 +213,14 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
                 params=data,
             )
             if not password_provided:
-                # if the password is not provided, keep the user inactive until
-                # the password is set.
-                user.is_active = False
-            else:
                 # if send_activation_email is True, we want to keep the user
                 # inactive until the email is properly validated. If the param
                 # is False, we activate it.
                 user.is_active = not data['send_activation_email']
+            else:
+                # if the password is not provided, keep the user inactive until
+                # the password is set.
+                user.is_active = False
             user.save()
             user_id = user.id
             if not password_provided:

--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -212,9 +212,15 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
                 request=request,
                 params=data,
             )
-            # set the user as active if password is provided
-            # meaning we don't have to send a password reset email
-            user.is_active = password_provided
+            if not password_provided:
+                # if the password is not provided, keep the user inactive until
+                # the password is set.
+                user.is_active = False
+            else:
+                # if send_activation_email is True, we want to keep the user
+                # inactive until the email is properly validated. If the param
+                # is False, we activate it.
+                user.is_active = not data['send_activation_email']
             user.save()
             user_id = user.id
             if not password_provided:

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -112,7 +112,6 @@ PyContracts==1.7.1
 pycountry==1.20
 pycryptodomex==3.4.7
 pygments==2.2.0                     # Used to support colors in paver command output
-pygraphviz==1.1                     # No longer in use?  Optional dependency of networkx, from edx-sandbox/shared.in
 pyjwkest==1.3.2
 # TODO Replace PyJWT usage with pyjwkest
 PyJWT==1.5.2

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -30,7 +30,7 @@ git+https://github.com/edx/edx-ora2.git@2.1.18#egg=ora2==2.1.18
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
-git+https://github.com/edx/RecommenderXBlock.git@1.3.3#egg=recommender-xblock==1.3.3
+recommender-xblock==1.3.3
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
 -e common/lib/symmath

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -189,7 +189,6 @@ pycountry==1.20
 pycparser==2.18
 pycryptodomex==3.4.7
 pygments==2.2.0
-pygraphviz==1.1
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pymongo==3.9.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -33,7 +33,7 @@ git+https://github.com/edx/edx-ora2.git@2.1.18#egg=ora2==2.1.18
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
-git+https://github.com/edx/RecommenderXBlock.git@1.3.3#egg=recommender-xblock==1.3.3
+recommender-xblock==1.3.3
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
 -e common/lib/symmath

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -250,7 +250,6 @@ pycryptodomex==3.4.7
 pydispatcher==2.0.5
 pyflakes==1.6.0
 pygments==2.2.0
-pygraphviz==1.1
 pyinotify==0.9.6
 pyjwkest==1.3.2
 pyjwt==1.5.2

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -91,7 +91,7 @@
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/edx/edx-ora2.git@2.1.18#egg=ora2==2.1.18
--e git+https://github.com/edx/RecommenderXBlock.git@1.3.3#egg=recommender-xblock==1.3.3
+recommender-xblock==1.3.3
 -e git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -31,7 +31,7 @@ git+https://github.com/edx/edx-ora2.git@2.1.18#egg=ora2==2.1.18
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
-git+https://github.com/edx/RecommenderXBlock.git@1.3.3#egg=recommender-xblock==1.3.3
+recommender-xblock==1.3.3
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
 -e common/lib/symmath

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -240,7 +240,6 @@ pycryptodomex==3.4.7
 pydispatcher==2.0.5       # via scrapy
 pyflakes==1.6.0           # via flake8
 pygments==2.2.0
-pygraphviz==1.1
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pylint-celery==0.3        # via edx-lint


### PR DESCRIPTION
(reopen Maxi's https://github.com/appsembler/edx-platform/pull/876 to fix pip issues)

Originally when we received the customer complain about this issue, we initially thought it was a design issue, and the original plan was to create a V2 of the API to address the issue. But it is actually a bug in the API endpoint.

In order to better understand the endpoint, please read our customer facing documentation: https://help.appsembler.com/article/438-tahoe-registration-api

The issue is that when a user is created through the endpoint, if the password is set, the endpoint automatically activates the user, despite if the `send_activation_email` parameter is `True` or `False`. This behaviour is wrong and it doesn't reflect what the customer facing docs describe. 

If the `send_activation_email` parameter is `True` the user must remain inactive until the email link is followed and the email address activated. We only need to auto activate the user when the endpoint is called with `send_activation_email=False`, because that means the API consumed is taking care of the email validation. 

This is causing pain points in the user workflow, because when users are created, they receive the activation email, but when they click it and land in the platform, a message saying the account is already activated is confusing.