### PR TITLE
devstack: use edxapp-envs always

### DIFF
--- a/Dockerfile.devstack
+++ b/Dockerfile.devstack
@@ -1,8 +1,21 @@
+# Release upgrade note: Change the release name below to build for another release
 FROM edxops/edxapp:juniper.master
 
+# This Docker image will be pushed to DockerHub with `appsembler/edxapp`
+#
+# This Docker image is similar to the `edxops/edxapp` devstack image except for the
+# following differences:
+#
+#   1. Install appsembler.txt requirements
+#   2. Use the https://github.com/appsembler/edxapp-envs environment files
+#
+
 RUN cd /edx/app/edxapp \
-    && git clone https://github.com/appsembler/edx-platform.git --branch main \
+    && git clone https://github.com/appsembler/edx-platform.git --branch main --single-branch --depth 1 \
     && bash -c 'cd edx-platform && source ../edxapp_env && paver install_prereqs' \
-    && rm -rf edx-platform
+    && rm -rf edx-platform \
+    && rm -f /edx/etc/lms.yml /edx/etc/studio.yml \
+    && ln -s /edx/src/edxapp-envs/lms.yml /edx/etc/ \
+    && ln -s /edx/src/edxapp-envs/studio.yml /edx/etc/
 
 WORKDIR /edx/app/edxapp/edx-platform


### PR DESCRIPTION
RED-2047 This will fix issues with the `make dev.reset` being broken to due to missing edxapp-envs links.

This helps to use the checked out https://github.com/appsembler/edxapp-envs repo in devsack.

### TODO

 - [x] Push the manually built image: `appsembler/edxapp:juniper.manual` and try `make dev.reset` locally
 - [x] Push the docker image `appsembler/edxapp:juniper.master`
 - [x] Get this PR merged

### Related

 - https://github.com/appsembler/devstack/pull/67 