### PR TITLE
Juniper upgrade - Apply RefreshToken.revoke() on `destroy_oauth_tokens`

### DIFF
--- a/openedx/core/djangoapps/appsembler/auth/oauth.py
+++ b/openedx/core/djangoapps/appsembler/auth/oauth.py
@@ -4,9 +4,7 @@
 from django.conf import settings
 from django.db.models import Subquery
 
-from oauth2_provider.models import (get_application_model,
-                                    AccessToken,
-                                    RefreshToken)
+from oauth2_provider.models import get_application_model, RefreshToken
 
 from .models import TrustedApplication
 
@@ -20,23 +18,21 @@ def destroy_oauth_tokens(user):
     trusted application tokens should be preserved. These are tracked in the
     `openedx.core.djangoapps.appsembler.auth.models.TrustedApplication` model
     """
-    dot_access_query = AccessToken.objects.filter(user=user.id)
     dot_refresh_query = RefreshToken.objects.filter(user=user.id)
-
-    Application = get_application_model()
 
     if settings.FEATURES.get('KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS', False):
         # Appsembler: Avoid deleting the trusted confidential applications such
         # as the Appsembler Management Console
-        trusted_applications = Application.objects.filter(
+        trusted_applications = get_application_model().objects.filter(
             client_type=Application.CLIENT_CONFIDENTIAL,
             pk__in=Subquery(TrustedApplication.objects.all().values('id')),
         )
-
-        dot_access_query = dot_access_query.exclude(
-            application__in=trusted_applications)
+        # We could just merge the `trusted_application` into the following,
+        # but keeping them apart makes it a bit easier for future debugging
         dot_refresh_query = dot_refresh_query.exclude(
             application__in=trusted_applications)
 
-    dot_access_query.delete()
-    dot_refresh_query.delete()
+    # The following revokes each token found. The revoke() call deletes the
+    # related access token and marks the refresh token as revoked and marked for
+    # deletion the next time oauth2_provider.models.clear_expired() is called
+    [refresh_token.revoke() for refresh_token in dot_refresh_query]


### PR DESCRIPTION
This commit calls the RefreshToken.revoke() method instead of explicitly deleting access tokens and refresh tokens.

The `.revoke()` call deletes the related `AccessToken` record should it exist. Therefore, our custom `destroy_oauth_tokens` function does not need to query the `AccessToken` model.

This fix should work more in line with how Django OAuth Toolkit was designed.
For this fix to work, we need to fix the database table `oauth2_provider_refreshtoken` so that the `access_token_id` field is correct (able to have NULL value for this field). This is a change in the `oauth2_provider` package versions between Hawthorn (version 0.12.0) and Juniper (version 1.3.2) that appears not to have been updated in the migrations

For the hack fix to prevent the error:

```
django.db.utils.IntegrityError: (1048, "Column 'access_token_id' cannot be null")
```
We would simply swap the order of deletions:

```
dot_refresh_query.delete()
dot_access_query.delete()
```


https://appsembler.atlassian.net/browse/RED-1865

Write-up: https://appsembler.atlassian.net/wiki/spaces/JUP/pages/1663762477/Oauth2+Provider+access+token+id+error
