### PR TITLE
Juniper upgrade hack fix for destroying oauth tokens

### DIFF
--- a/openedx/core/djangoapps/appsembler/auth/oauth.py
+++ b/openedx/core/djangoapps/appsembler/auth/oauth.py
@@ -38,5 +38,10 @@ def destroy_oauth_tokens(user):
         dot_refresh_query = dot_refresh_query.exclude(
             application__in=trusted_applications)
 
-    dot_access_query.delete()
+    # This is a quick hack fix to work around the oauth2_provider migrations
+    # problem where refresh token has a non-nullable foreign key field to the
+    # access token table
+    # For more details see the PR:
+    # https://github.com/appsembler/edx-platform/pull/883
     dot_refresh_query.delete()
+    dot_access_query.delete()


### PR DESCRIPTION
This PR is intended as a temporary fix for server 500 errors occurring when `destroy_oauth_tokens` is called. When the database has been repaired, we can then merge the PR here instead: 

https://github.com/appsembler/edx-platform/pull/883


##  commit message
This commit works around the problem that oauth2_provider migrations got squashed and not properly applied when oauth2_provider was upgraded from version 0.12.0 to 1.3.2

In the old version refrsh token has a non-nullable migrations problem where refresh token has a non-nullable foreign key field to the access token table. For more details see the PR:

    https://github.com/appsembler/edx-platform/pull/883