### PR TITLE
Revert "get_lms_link_from_course_key fallback to LMS base if no Site found"

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/tests/test_utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_utils.py
@@ -12,10 +12,8 @@ from openedx.core.djangoapps.appsembler.sites.utils import (
     get_current_organization,
     get_initial_page_elements,
     get_active_sites,
-    get_lms_link_from_course_key
 )
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
-
 from organizations.models import Organization
 
 
@@ -128,36 +126,3 @@ class OrganizationByRequestTestCase(TestCase):
         self.request.site = self.siteFoo
         with self.assertRaises(ImproperlyConfigured):
             get_current_organization()
-
-
-class LMSLinkByCourseOrgTestCase(TestCase):
-    """
-    Exercise getting the appropriate LMS Link for Studio "View in LMS"
-    based on the organization value set on the course that is being viewed.
-    (note we don't test with custom domains since that is handled by middleware)
-    """
-    def setUp(self):
-        super(LMSLinkByCourseOrgTestCase, self).setUp()
-        self.siteFoo = SiteFactory.create(domain='foo.dev', name='foo.dev')
-        self.courseKey = "course-v1:org+course+run"
-        self.base_lms_url = "lms_base.domain"
-
-    @patch('openedx.core.djangoapps.appsembler.api.sites.get_site_for_course')
-    def test_lms_link_happy_path(self, mocked_get_site_for_course):
-        mocked_get_site_for_course.return_value = self.siteFoo
-        url = get_lms_link_from_course_key(self.base_lms_url, self.courseKey)
-        self.assertEqual(url, "foo.dev")
-
-    @patch('openedx.core.djangoapps.appsembler.api.sites.get_site_for_course')
-    def test_lms_link_no_site_matching_course(self, mocked_get_site_for_course):
-        mocked_get_site_for_course.return_value = None
-        url = get_lms_link_from_course_key(self.base_lms_url, self.courseKey)
-        self.assertEqual(url, self.base_lms_url)
-
-    @patch.dict('django.conf.settings.FEATURES', {
-        'PREVIEW_LMS_BASE': 'preview.lms_base.domain'
-    })
-    def test_lms_link_for_preview_always_return_preview_domain(self):
-        preview_url = "preview.lms_base.domain"
-        url = get_lms_link_from_course_key(preview_url, self.courseKey)
-        self.assertEqual(url, preview_url)

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -37,12 +37,12 @@ def get_lms_link_from_course_key(base_lms_url, course_key):
     """
     beeline.add_context_field("base_lms_url", base_lms_url)
     beeline.add_context_field("course_key", course_key)
-    # avoid circular import
-    from openedx.core.djangoapps.appsembler.api.sites import get_site_for_course
-    course_site = get_site_for_course(course_key)
-    if course_site:
-        return course_site.domain
-    return base_lms_url
+    try:
+        site_domain = Site.objects.get(name=course_key.org).domain
+    except Site.DoesNotExist:
+        site_domain = "{}.{}".format(course_key.org, base_lms_url)
+
+    return site_domain
 
 
 @beeline.traced(name="get_site_by_organization")


### PR DESCRIPTION
Studio load has been very slow for superusers after appsembler/edx-platform#813 has been deployed (see RED-2055).

We have a couple of options:

  - A) Use a different logic for both multi-tenant and standalone via feature flags
  - B) Revert this fix and do it later
  - C) Optimize the `get_site_for_course` function to handle a 1000 course in Studio