### PR TITLE
Add migration to add new Juniper SASS vars to sites

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/migrations/0003_add_juniper_new_sass_vars.py
+++ b/openedx/core/djangoapps/appsembler/sites/migrations/0003_add_juniper_new_sass_vars.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+
+import json
+from django.db import migrations, models
+
+
+def add_juniper_new_sass_vars(apps, schema_editor):
+    """
+    This migration adds all the new SASS variabled added during the initial
+    pass of the Tahoe Juniper release upgrade.
+    """
+    new_sass_var_keys = {
+        "$base-container-width": "calcRem(1200)",
+        "$base-learning-container-width": "calcRem(1000)",
+        "$courseware-content-container-side-padding": "calcRem(100)",
+        "$courseware-content-container-sidebar-width": "calcRem(240)",
+        "$courseware-content-container-width": "$base-learning-container-width",
+        "$site-nav-width": "$base-container-width",
+        "$inline-link-color": "$brand-primary-color",
+        "$light-border-color": "#dedede",
+        "$font-size-base-courseware": "calcRem(18)",
+        "$line-height-base-courseware": "200%",
+        "$in-app-container-border-radius": "calcRem(15)",
+        "$login-register-container-width": "calcRem(480)",
+    }
+    SiteConfiguration = apps.get_model('site_configuration', 'SiteConfiguration')
+    sites = SiteConfiguration.objects.all()
+    for site in sites:
+        for sass_var, sass_value in new_sass_var_keys.items():
+            exists = False
+            for key, val in site.sass_variables:
+                if key == sass_var:
+                    exists = True
+                    break
+
+            if not exists:
+                site.sass_variables.append([sass_var, [sass_value, sass_value]])
+
+        site.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('appsembler_sites', '0001_initial'),
+        ('appsembler_sites', '0002_add_hide_linked_accounts_sass_var'),
+        ('site_configuration', '0004_auto_20161120_2325'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_juniper_new_sass_vars),
+    ]


### PR DESCRIPTION
This new migration adds all the SASS variables added to the front end during the Juniper uprade. 

List here: https://github.com/appsembler/edx-theme-customers/commit/c66ac4ff0a63eddb9179c8c7099432f90b8d92e6#diff-9b11be80f6508b1ca0f220cdb2e1f41856bde0761f770cabfcb0b7273e5b4ed9R164-R176