### PR TITLE
Juniper upgrade - Hack fix OAuth token deletion

### DIFF
--- a/openedx/core/djangolib/oauth2_retirement_utils.py
+++ b/openedx/core/djangolib/oauth2_retirement_utils.py
@@ -39,5 +39,8 @@ class ModelRetirer(object):
 
 
 def retire_dot_oauth2_models(user):
-    dot_models = [DOTAccessToken, DOTApplication, DOTGrant, DOTRefreshToken]
+    # Original order is [DOTAccessToken, DOTApplication, DOTGrant, DOTRefreshToken]
+    # This is a hack fix around the database. See this PR for additional info:
+    # https://github.com/appsembler/edx-platform/pull/886
+    dot_models = [DOTRefreshToken, DOTAccessToken, DOTApplication, DOTGrant]
     ModelRetirer(dot_models).retire_user_by_id(user.id)


### PR DESCRIPTION
This is basically the same fix as this PR:

https://github.com/appsembler/edx-platform/pull/886

What we're doing here is switching the order of deletion so that the
refresh token record is deleted before the access token record.

Once the database is fixed, we can revert this commit