### PR TITLE
Fix bug related to order in dict vars

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/migrations/0003_add_juniper_new_sass_vars.py
+++ b/openedx/core/djangoapps/appsembler/sites/migrations/0003_add_juniper_new_sass_vars.py
@@ -2,6 +2,8 @@
 
 
 import json
+from collections import OrderedDict
+
 from django.db import migrations, models
 
 
@@ -10,20 +12,23 @@ def add_juniper_new_sass_vars(apps, schema_editor):
     This migration adds all the new SASS variabled added during the initial
     pass of the Tahoe Juniper release upgrade.
     """
-    new_sass_var_keys = {
-        "$base-container-width": "calcRem(1200)",
-        "$base-learning-container-width": "calcRem(1000)",
-        "$courseware-content-container-side-padding": "calcRem(100)",
-        "$courseware-content-container-sidebar-width": "calcRem(240)",
-        "$courseware-content-container-width": "$base-learning-container-width",
-        "$site-nav-width": "$base-container-width",
-        "$inline-link-color": "$brand-primary-color",
-        "$light-border-color": "#dedede",
-        "$font-size-base-courseware": "calcRem(18)",
-        "$line-height-base-courseware": "200%",
-        "$in-app-container-border-radius": "calcRem(15)",
-        "$login-register-container-width": "calcRem(480)",
-    }
+    new_sass_var_keys = OrderedDict(
+        [
+            ("$base-container-width", "calcRem(1200)"),
+            ("$base-learning-container-width", "calcRem(1000)"),
+            ("$courseware-content-container-side-padding", "calcRem(100)"),
+            ("$courseware-content-container-sidebar-width", "calcRem(240)"),
+            ("$courseware-content-container-width", "$base-learning-container-width"),
+            ("$site-nav-width", "$base-container-width"),
+            ("$inline-link-color", "$brand-primary-color"),
+            ("$light-border-color", "#dedede"),
+            ("$font-size-base-courseware", "calcRem(18)"),
+            ("$line-height-base-courseware", "200%"),
+            ("$in-app-container-border-radius", "calcRem(15)"),
+            ("$login-register-container-width", "calcRem(480)")
+            
+        ]
+    )
     SiteConfiguration = apps.get_model('site_configuration', 'SiteConfiguration')
     sites = SiteConfiguration.objects.all()
     for site in sites:


### PR DESCRIPTION
I was using a regular dict to iterate over the sass variables, but they need to be added in specific order, since of them are used later as values.

It worked on staging by pure luck because when dict are stored by hash (until python 3.5, our version) the stored order is different every time. 

We found the bug on staging, where the migration is passing, but sass is not being properly compiled.

The PR changes the regular python dict for an OrderedDict.