### PR TITLE
candidate_sites_cleanup: change SITE_NAME for production-candidate envs

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/management/commands/danger_candidate_sites_cleanup.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/danger_candidate_sites_cleanup.py
@@ -29,6 +29,8 @@ class Command(BaseCommand):
             self.stdout.write('TO {}'.format(site.domain))
             site.save()
 
+            site.configuration.site_values['SITE_NAME'] = site.domain
+
             try:
                 del site.configuration.site_values['SEGMENT_KEY']
                 self.stdout.write('deleted SEGMENT_KEY')

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -138,6 +138,7 @@ class TestCandidateSitesCleanupCommand(TestCase):
         assert self.get_site().domain == 'blue.newlocalhost:18000'
         assert not self.get_site().configuration.get_value('customer_gtm_id')
         assert not self.get_site().configuration.get_value('SEGMENT_KEY')
+        assert self.get_site().configuration.get_value('SITE_NAME') == self.get_site().domain
 
 
 @override_settings(


### PR DESCRIPTION
Based on Maxi's feedback that the script didn't handle `SITE_NAME`.



Note: `LMS_ROOT_URL` is handled by `save()` so no need to handle this one

https://github.com/appsembler/edx-platform/blob/66cdda525e999bd7f3348d7183e9103a1914caf5/openedx/core/djangoapps/site_configuration/models.py#L93-L100