### PR TITLE
Add all Tahoe installed XBlocks to course outline block_types_filter

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -199,13 +199,22 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
         'lti',
         'lti_consumer',
         # Appsembler completable blocks installed to Tahoe
+        # All installed XBlocks need to be listed here whether they require
+        # learner interaction or not.  Otherwise, course outline will
+        # show subsection, section, and course as incomplete.
         # TODO: this really should be dynamic
         'done',
         'freetextresponse',
         'openassessment',
         'problem-builder',
         'edx_sga',
-        'ubcpi'
+        'ubcpi',
+        'scorm',
+        'google-document',
+        'google-calendar',
+        'feedback',
+        'launchcontainer',
+        'pdf'
     ]
     all_blocks = get_blocks(
         request,


### PR DESCRIPTION
Any new custom installed XBlocks needs to be added here, regardless of whether they are actually scored components.    This is required to take them into account for 'Resume Course' (find last completed block) and so that the course outline will show the block as completed.    

Keep in mind that if a custom completion method isn't defined, all XBlocks are completed in the same way as an HTML block (scroll browser so that bottom of the block is in view and remain 5 seconds on the page).