### PR TITLE
Add all Tahoe installed XBlocks to course outline block_types_filter

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/aws_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/aws_common.py
@@ -82,3 +82,11 @@ def plugin_settings(settings):
     settings.TAHOE_DEFAULT_COURSE_VERSION = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_VERSION', '')
 
     settings.TAHOE_SCORM_XBLOCK_ROOT_DIR = settings.ENV_TOKENS.get('TAHOE_SCORM_XBLOCK_ROOT_DIR', False)
+
+    # DEPRECATE starting with Lilac release: unnecessary
+    # All installed XBlocks need to be listed here whether they require
+    # learner interaction or not.  Otherwise, course outline will
+    # show subsection, section, and course as incomplete.
+    settings.TAHOE_COURSE_OUTLINE_COMPLETABLE_BLOCK_TYPES = settings.ENV_TOKENS.get(
+        'TAHOE_COURSE_OUTLINE_COMPLETABLE_BLOCK_TYPES', []
+    )

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -1,6 +1,8 @@
 """
 Common utilities for the course experience, including course outline.
 """
+from django.conf import settings
+
 from completion.models import BlockCompletion
 
 from lms.djangoapps.course_api.blocks.api import get_blocks
@@ -135,16 +137,11 @@ def get_course_outline_block_tree(request, course_id):
         'poll',
         'word_cloud',
         'lti',
-        'lti_consumer',
-        # Appsembler completable blocks installed to Tahoe
-        # TODO: this really should be dynamic
-        'done',
-        'freetextresponse',
-        'openassessment',
-        'problem-builder',
-        'edx_sga',
-        'ubcpi'
+        'lti_consumer'
     ]
+    # Appsembler: DEPRECATED starting with Lilac
+    addl_block_types = getattr(settings, "TAHOE_COURSE_OUTLINE_COMPLETABLE_BLOCK_TYPES", [])
+    block_types_filter.extend(addl_block_types)
     all_blocks = get_blocks(
         request,
         course_usage_key,


### PR DESCRIPTION
Backport for Hawthorn.  DHIS2 is using Hawthorn Tahoe branch so we do still need this backported even though Juniper is in test.