### PR TITLE
Juniper - Fix segment replicate response decode

### DIFF
--- a/common/djangoapps/track/views/segmentio.py
+++ b/common/djangoapps/track/views/segmentio.py
@@ -281,7 +281,7 @@ def send_event(request, method, **params):
     Send event to the main and site segment account.
 
     """
-    data = json.loads(request.body)
+    data = json.loads(request.body.decode('utf-8'))
     # Using the 'browser' api to avoid convert the event to the
     # analytics library format.
     url = 'https://api.segment.io/v1/{0}'.format(method)


### PR DESCRIPTION
_Most of the effort here was in getting the devstack configs set up so that the segmentio.py `send_event` method was called._

Segment events were causing exceptions when the send_event was trying to
load json data from the response body

Needed to do `response.body.decode('utf-8')`

This should fix:

* https://appsembler.atlassian.net/browse/RED-2026
* https://appsembler.atlassian.net/browse/RED-2039
* https://appsembler.atlassian.net/browse/RED-2040
* https://appsembler.atlassian.net/browse/RED-2041
* https://appsembler.atlassian.net/browse/RED-2042
* https://appsembler.atlassian.net/browse/RED-2045
