### PR TITLE
update apt cache on GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Install dependencies
       # TODO: Remove tox-pip-version once we upgrade to Koa+, or whenever we have addressed pip 20.3 strict issues.
       run: |
+        sudo apt-get update -y
         sudo apt-get install -y python-dev libxml2-dev libxmlsec1-dev
         pip install tox tox-pip-version
     - name: Run tox


### PR DESCRIPTION
fixes

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/u/unbound/libunbound2_1.6.7-1ubuntu2.3_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
Fetched 4391 kB in 0s (9409 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```