### PR TITLE
Enforce static file look up for ProductionS3Storage backend

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -209,8 +209,11 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
-if 'staticfiles' in CACHES:
-    CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
+# Tahoe: RED-1961 Disable the upstream prefix override to refresh cache on every deploy and use the random prefix:
+#        https://github.com/appsembler/configuration/pull/348
+#
+# if 'staticfiles' in CACHES:
+#     CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
 
 # In order to transition from local disk asset storage to S3 backed asset storage,
 # we need to run asset collection twice, once for local disk and once for S3.

--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -15,6 +15,7 @@
 
 import logging
 
+import beeline
 import six
 from django.conf import settings
 from django.http import HttpResponse
@@ -149,6 +150,7 @@ def marketing_link_context_processor(request):
     )
 
 
+@beeline.traced(name='common.djangoapps.edxmako.shortcuts.render_to_string')
 def render_to_string(template_name, dictionary, namespace='main', request=None):
     """
     Render a Mako template to as a string.
@@ -169,6 +171,8 @@ def render_to_string(template_name, dictionary, namespace='main', request=None):
         request: The request to use to construct the RequestContext for rendering
             this template. If not supplied, the current request will be used.
     """
+    beeline.add_context_field('render_to_string.template_name', template_name)
+    beeline.add_context(dictionary)
     if namespace == 'lms.main':
         engine = engines[Engines.PREVIEW]
     else:

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -2,6 +2,7 @@
 <%!
 import logging
 import json
+import beeline
 from django.contrib.staticfiles.storage import staticfiles_storage
 from pipeline_mako import compressed_css, compressed_js
 from pipeline_mako.helpers.studiofrontend import load_sfe_i18n_messages
@@ -31,10 +32,15 @@ logger = logging.getLogger(__name__)
 %></%def>
 
 <%def name='url(file, raw=False)'><%
-try:
-    url = staticfiles_storage.url(file)
-except:
-    url = file
+with beeline.tracer(name='static_content.html.url'):
+    beeline.add_context_field('url.file', file)
+    try:
+        url = staticfiles_storage.url(file)
+        beeline.add_context_field('url.error', False)
+    except:
+        beeline.add_context_field('url.error', True)
+        url = file
+    beeline.add_context_field('url.url', url)
 ## HTML-escaping must be handled by caller
 %>${url | n, decode.utf8}${"?raw" if raw else ""}</%def>
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -233,8 +233,11 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
-if 'staticfiles' in CACHES:
-    CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
+# Tahoe: RED-1961 Disable the upstream prefix override to refresh cache on every deploy and use the random prefix:
+#        https://github.com/appsembler/configuration/pull/348
+#
+# if 'staticfiles' in CACHES:
+#     CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
 
 # In order to transition from local disk asset storage to S3 backed asset storage,
 # we need to run asset collection twice, once for local disk and once for S3.


### PR DESCRIPTION
RED-1961.

- Honeycomb tracing to debug staticfiles slow lookup.
- Disable `CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION` by upstream which assumes we're deploying via git tags. We don't, we deploy from `main` and the upstream override keeps the cache stale and invalid.
- Cache `ProductionS3Storage.url` look up results manually.

### Tests

 - I will add tests after we get this to work on staging/prod: https://github.com/appsembler/edx-platform/issues/912. Otherwise, we should revert and use a different approach.