### PR TITLE
John/juniper fix make amc admin , take 2

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/management/commands/make_amc_admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/make_amc_admin.py
@@ -2,8 +2,9 @@ import json
 import logging
 
 from django.db.models.query import Q
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
+from django.core.serializers.json import DjangoJSONEncoder
 
 from openedx.core.djangoapps.appsembler.sites.utils import make_amc_admin
 
@@ -30,6 +31,6 @@ class Command(BaseCommand):
                             help='The organization name or short name.')
 
     def handle(self, *args, **options):
-        user = User.objects.get(Q(email=options['user']) | Q(username=options['user']))
+        user = get_user_model().objects.get(Q(email=options['user']) | Q(username=options['user']))
         details = make_amc_admin(user=user, org_name=options['org'])
-        self.stdout.write(json.dumps(details))
+        self.stdout.write(json.dumps(details, cls=DjangoJSONEncoder))

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -121,7 +121,12 @@ def get_amc_oauth_app():
 def get_amc_tokens(user):
     """
     Return the the access and refresh token with expiry date in a dict.
-    JLB: we need to fix this. can't be returning empty string tokens
+
+    TODO: we need to fix this. Can't be returning empty string tokens
+    But then we need to rework the callers to handle errors. One is the
+    admin iterface, so we have to rewrite some of the form handling there
+    And there's a Django management command, so need to add error handling
+    there. There may be other places
     """
     app = get_amc_oauth_app()
     tokens = {


### PR DESCRIPTION
Fixes to the Django management command and ocd.appsembler.sites.utils.reset_amc_tokens function so that there should be no more 500 errors and no more empty tokens created.

The Django managment command update fixes JSON serialization of the output in the
"make_amc_admin" Django management command. Fixing this bug revealed

another bug in the "openedx.core.djangoapps.appsembler.sites.utils"
code where the token field in AccessToken and RefreshToken would be empty. This is because the `sites.utils` code is directly creating or updating the token models instead of going through the Django OAuth Toolkit API (But honestly, I have to dig into this package to learn how it is supposed to be used)

* https://appsembler.atlassian.net/browse/RED-2081
* https://appsembler.atlassian.net/browse/RED-2097
