### PR TITLE
Remove "edX" from the logout popup message

### DIFF
--- a/lms/static/js/ajax-error.js
+++ b/lms/static/js/ajax-error.js
@@ -1,7 +1,7 @@
 $(document).ajaxError(function(event, jXHR) {
     if (jXHR.status === 403 && jXHR.responseText === 'Unauthenticated') {
         var message = gettext(
-            'You have been logged out of your edX account. ' +
+            'You have been logged out of your account. ' +
             'Click Okay to log in again now. ' +
             'Click Cancel to stay on this page ' +
             '(you must log in again to save your work).'


### PR DESCRIPTION
Not using `settings.PLATFORM_NAME` because sharing it with this script would need too much platform changes for this small error.

Removing the word "edX" makes the statement more accurate for other forks. Generally there shouldn't be any mention of "edX" in the code.

Cherry-picks https://github.com/edx/edx-platform/pull/27605 to resolve RED-2127.