### PR TITLE
change get users for site query method

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/sites.py
+++ b/openedx/core/djangoapps/appsembler/api/sites.py
@@ -73,12 +73,6 @@ def get_enrollments_for_site(site):
     return CourseEnrollment.objects.filter(course_id__in=course_keys)
 
 
-def get_user_ids_for_site(site):
-    orgs = Organization.objects.filter(sites__in=[site])
-    mappings = UserOrganizationMapping.objects.filter(organization__in=orgs)
-    return mappings.values_list('user_id', flat=True)
-
-
 def get_users_for_site(site):
     org = Organization.objects.filter(sites__in=[site]).first()
     return org.users.all()

--- a/openedx/core/djangoapps/appsembler/api/sites.py
+++ b/openedx/core/djangoapps/appsembler/api/sites.py
@@ -80,5 +80,5 @@ def get_user_ids_for_site(site):
 
 
 def get_users_for_site(site):
-    user_ids = get_user_ids_for_site(site)
-    return get_user_model().objects.filter(id__in=user_ids)
+    org = Organization.objects.filter(sites__in=[site]).first()
+    return org.users.all()

--- a/openedx/core/djangoapps/appsembler/api/tests/test_sites.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_sites.py
@@ -110,13 +110,6 @@ class SitesModuleTests(TestCase):
                 aapi_sites.course_belongs_to_site(site=site,
                                                   course_id=self.my_course_overviews[0])
 
-    def test_get_users_ids_for_site(self):
-        my_users = create_org_users(org=self.my_site_org, new_user_count=3)
-        other_users = create_org_users(org=self.other_site_org, new_user_count=2)
-        retrieved_user_ids = aapi_sites.get_user_ids_for_site(self.my_site)
-        assert set(retrieved_user_ids) == set([obj.id for obj in my_users])
-        assert set(retrieved_user_ids).isdisjoint(set([obj.id for obj in other_users]))
-
     def test_get_users_for_site(self):
         my_users = create_org_users(org=self.my_site_org, new_user_count=3)
         other_users = create_org_users(org=self.other_site_org, new_user_count=2)


### PR DESCRIPTION
RedisLabs reported timeouts while querying the Users API with large offsets (18300). Anders conducted the initial investigation and looks like the response is really slow.

I took at the Appsembler API code, and I think the issue is in the ViewSet query set, the query set relies on the `get_users_for_site` the one this PR is changing. 

Basically what we're doing is getting all the user IDs associated with the org, and then filtering all the users table against that list of IDs. 

`get_user_model().objects.filter(id__in=user_ids)`

This was ok until now, but is not super performant, and'll start seeing edge cases for large customers. The function is robust from the logic perspective, but looks like is too much for the db, because I don't exactly know what other operations Django Rest Framework is adding on top of the original query set to work with offsets.

The [Organization model already has a M2M relationship](https://github.com/appsembler/edx-organizations/blob/appsembler/amc/organizations/models.py#L36) through [UserOrganizationMapping model](https://github.com/appsembler/edx-organizations/blob/appsembler/amc/organizations/models.py#L86), which allow us to do this in 1 query. The other benefit of using this method, is that the UserOrganizationMapping is already indexed by user, since Django index by FK by default.

I'm interested in your opinion, if we move forward, I need to do some clean up on the orphan function `get_user_ids_for_site` and the tests.