### PR TITLE
ensure that the CMS has a different staticfiles cache key prefix

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -209,7 +209,7 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
-# ensure that the CMS has a different staticfiles cache prefix than the lms
+# Tahoe: RED-1961 ensure that the CMS has a different staticfiles cache prefix than the lms
 if 'staticfiles' in CACHES and 'KEY_PREFIX' in CACHES['staticfiles']:
     CACHES['staticfiles']['KEY_PREFIX'] = CACHES['staticfiles']['KEY_PREFIX'] + "_cms"
 

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -209,11 +209,9 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
-# Tahoe: RED-1961 Disable the upstream prefix override to refresh cache on every deploy and use the random prefix:
-#        https://github.com/appsembler/configuration/pull/348
-#
-# if 'staticfiles' in CACHES:
-#     CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
+# ensure that the CMS has a different staticfiles cache prefix than the lms
+if 'staticfiles' in CACHES and 'KEY_PREFIX' in CACHES['staticfiles']:
+    CACHES['staticfiles']['KEY_PREFIX'] = CACHES['staticfiles']['KEY_PREFIX'] + "_cms"
 
 # In order to transition from local disk asset storage to S3 backed asset storage,
 # we need to run asset collection twice, once for local disk and once for S3.


### PR DESCRIPTION
since studio assets are served from `/static/studio` rather than just `/static`, they can't use the same cache.

See: https://github.com/appsembler/configuration/pull/368