### PR TITLE
Allow studio to access YouTube metadata

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
@@ -47,6 +47,7 @@ def plugin_settings(settings):
             'oauth',
             'status',
             '/heartbeat',
+            '/courses/yt_video_metadata',
             '/accounts/manage_user_standing',
             '/accounts/disable_account_ajax',
         ]


### PR DESCRIPTION
RED-1958: Allow studio to access the API below:

 - https://tahoe-us-juniper-prod.appsembler.com/courses/yt_video_metadata?id=3_yD_cEKoCk

This is a partial fix for the error in: https://appsembler.atlassian.net/browse/RED-1958?focusedCommentId=35115. Needs https://github.com/appsembler/edx-configs/pull/1101 to work.


### Expected beheviour
https://tahoe-us-juniper-prod.appsembler.com/courses/yt_video_metadata?id=3_yD_cEKoCk to provide metadata for the youtube video.

### Actual behaviour
Now if we go to https://tahoe-us-juniper-prod.appsembler.com/courses/yt_video_metadata?id=3_yD_cEKoCk it redirects us to Tahoe home page.

### Fix
Whitelist `/courses/yt_video_metadata` so the redirect no longer happens.