### PR TITLE
RED-2096: fix activation email server error in celery

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -8,16 +8,19 @@ import logging
 from celery.exceptions import MaxRetriesExceededError
 from celery.task import task
 from django.conf import settings
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from edx_ace import ace
 from edx_ace.errors import RecoverableChannelDeliveryError
 from edx_ace.message import Message
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+from openedx.core.lib.celery.task_utils import emulate_http_request
 
 log = logging.getLogger('edx.celery.task')
 
 
 @task(bind=True)
-def send_activation_email(self, msg_string, from_address=None):
+def send_activation_email(self, msg_string, site_id, from_address):
     """
     Sending an activation email to the user.
     """
@@ -26,16 +29,19 @@ def send_activation_email(self, msg_string, from_address=None):
     max_retries = settings.RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS
     retries = self.request.retries
 
-    if from_address is None:
-        from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS') or (
-            configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
-        )
     msg.options['from_address'] = from_address
 
     dest_addr = msg.recipient.email_address
 
+    user = User.objects.get(username=msg.recipient.username)
+
+    # Tahoe: `get_current_site()` don't work in celery tasks because there's no `request`.
+    #        Getting the `site` from the caller instead.
+    site = Site.objects.get(pk=site_id)
+
     try:
-        ace.send(msg)
+        with emulate_http_request(site=site, user=user):
+            ace.send(msg)
     except RecoverableChannelDeliveryError:
         log.info('Retrying sending email to user {dest_addr}, attempt # {attempt} of {max_attempts}'.format(
             dest_addr=dest_addr,

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -210,11 +210,13 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
         inactive_user = UserFactory(is_active=False)
         Registration().register(inactive_user)
         request = RequestFactory().get(settings.SOCIAL_AUTH_INACTIVE_USER_URL)
-        request.site = Mock()
+        request.site = Mock(pk=settings.SITE_ID)
         request.user = inactive_user
         with patch('edxmako.request_context.get_current_request', return_value=request):
             with patch('third_party_auth.pipeline.running', return_value=False):
-                inactive_user_view(request)
+                with patch('student.views.management.get_current_site', return_value=request.site):
+                    # Tahoe: Added support for multi-tenant email branding
+                    inactive_user_view(request)
                 self.assertEqual(email.called, True, msg='method should have been called')
 
 

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -212,7 +212,11 @@ def compose_and_send_activation_email(user, profile, user_registration=None):
     root_url = configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
     msg = compose_activation_email(root_url, user, user_registration, route_enabled, profile.name)
 
-    send_activation_email.delay(str(msg))
+    from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS') or (
+        configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
+    )
+    site = get_current_site()
+    send_activation_email.delay(str(msg), site_id=site.pk, from_address=from_address)
 
 
 @login_required


### PR DESCRIPTION
RED-2096: The error happened because of the incomplete `example.com` fix in https://github.com/appsembler/edx-platform/pull/884

This commit fixes the issue by getting back the mandatory `emulate_http_request` but now with a better method to know the site using our `appsembler.sites.utils` helpers.

This should work on celery tasks while printing the correct site domain instead of `example.com` as it used to do before RED-1886 was fixed.


### Root cause
Attempting to `get_current_site` in celery context is incorrect. The error has been introduced by upstream (https://github.com/edx/edx-platform/pull/22042) and I'm planning to contribute the fix.