### PR TITLE
fix django hijack 500 server error

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -13,6 +13,7 @@ def plugin_settings(settings):
     settings.APPSEMBLER_FEATURES = {}
 
     settings.INSTALLED_APPS += [
+        'compat',
         'hijack',
         'hijack_admin',
 


### PR DESCRIPTION
RED-2107:

 - `compat` template tags are needed for the hijack templates to work.
 - `compat` template tags are provided by https://pypi.org/project/django-compat/