### PR TITLE
remove honeycomb tracing for static files in mako templates

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -15,7 +15,6 @@
 
 import logging
 
-import beeline
 import six
 from django.conf import settings
 from django.http import HttpResponse
@@ -150,7 +149,6 @@ def marketing_link_context_processor(request):
     )
 
 
-@beeline.traced(name='common.djangoapps.edxmako.shortcuts.render_to_string')
 def render_to_string(template_name, dictionary, namespace='main', request=None):
     """
     Render a Mako template to as a string.
@@ -171,8 +169,6 @@ def render_to_string(template_name, dictionary, namespace='main', request=None):
         request: The request to use to construct the RequestContext for rendering
             this template. If not supplied, the current request will be used.
     """
-    beeline.add_context_field('render_to_string.template_name', template_name)
-    beeline.add_context(dictionary)
     if namespace == 'lms.main':
         engine = engines[Engines.PREVIEW]
     else:

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -2,7 +2,6 @@
 <%!
 import logging
 import json
-import beeline
 from django.contrib.staticfiles.storage import staticfiles_storage
 from pipeline_mako import compressed_css, compressed_js
 from pipeline_mako.helpers.studiofrontend import load_sfe_i18n_messages
@@ -32,15 +31,10 @@ logger = logging.getLogger(__name__)
 %></%def>
 
 <%def name='url(file, raw=False)'><%
-with beeline.tracer(name='static_content.html.url'):
-    beeline.add_context_field('url.file', file)
-    try:
-        url = staticfiles_storage.url(file)
-        beeline.add_context_field('url.error', False)
-    except:
-        beeline.add_context_field('url.error', True)
-        url = file
-    beeline.add_context_field('url.url', url)
+try:
+    url = staticfiles_storage.url(file)
+except:
+    url = file
 ## HTML-escaping must be handled by caller
 %>${url | n, decode.utf8}${"?raw" if raw else ""}</%def>
 


### PR DESCRIPTION
This reverts commit c5164f65855dedc244d75f5a25041bec641c6e07.

This should've been included in #933 but I forgot that we had instrumentation in the mako template as well.