### PR TITLE
set URL to redirect after hicjacking user

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_cms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_cms.py
@@ -35,3 +35,5 @@ def plugin_settings(settings):
     settings.SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
     settings.XQUEUE_WAITTIME_BETWEEN_REQUESTS = 5
+
+    settings.HIJACK_LOGIN_REDIRECT_URL = '/home'

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
@@ -97,3 +97,5 @@ def plugin_settings(settings):
 
     settings.STATICFILES_DIRS = get_tahoe_theme_static_dirs(settings)
     settings.AUTHENTICATION_BACKENDS = get_tahoe_multitenant_auth_backends(settings)
+
+    settings.HIJACK_LOGIN_REDIRECT_URL = '/dashboard'


### PR DESCRIPTION
RED-2107:

This is a follow up of https://github.com/appsembler/edx-platform/pull/930

It add the correct settings to redirect the user to `/dashboard` if it's LMS and `/home` if it's Studio. 