### PR TITLE
update order in authentication_classes for logout

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -408,7 +408,7 @@ class DeactivateLogoutView(APIView):
     # Dictionary key name to store unsuffixed email within user.profile.meta
     APPSEMBLER_RETIREMENT_EMAIL_META_KEY = 'APPSEMBLER_RETIREMENT_EMAIL'
 
-    authentication_classes = (JwtAuthentication, SessionAuthentication, )
+    authentication_classes = (SessionAuthentication, JwtAuthentication, )
     permission_classes = (permissions.IsAuthenticated, )
 
     def post(self, request):


### PR DESCRIPTION
 Update ordering of `authentication_classes` to enable logout when user deletes account

## Type of change
- [x] Bug fix (fixes an issue)

## Related issues

- https://appsembler.atlassian.net/browse/RED-1914
