### PR TITLE
Use transactions for site delete scripts

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/management/commands/remove_site.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/remove_site.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.contrib.sites.models import Site
+from django.db import transaction
 
 from openedx.core.djangoapps.appsembler.sites.utils import delete_site
 
@@ -25,7 +26,9 @@ class Command(BaseCommand):
         self.stdout.write('Removing "%s" in progress...' % organization_domain)
         organization = self._get_site(organization_domain)
 
-        delete_site(organization)
+        with transaction.atomic():
+            delete_site(organization)
+
         self.stdout.write(self.style.SUCCESS('Successfully removed site "%s"' % organization_domain))
 
     def _get_site(self, domain):


### PR DESCRIPTION
## Change description

> The remove_site scripts don’t make use of the MySQL transactions which makes it unsafe in production in the case of failure (i.e. deleting only a part of the site).
 
## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [OT-478](https://appsembler.atlassian.net/browse/OT-478)
> Pull request [amc#518](https://github.com/appsembler/amc/pull/518)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
