### PR TITLE
bump django-tiers==0.2.4

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -2,7 +2,7 @@ django-extensions==3.1.0
 python-intercom==3.1.0
 raven==6.10.0
 django-anymail==5.0
-django-tiers==0.2.3
+django-tiers==0.2.4
 dj-database-url==0.5.0
 psycopg2-binary==2.8.3
 django-hijack==2.1.10


### PR DESCRIPTION
 - fixes for python 3 and django 2
 - more info in error logging
