### PR TITLE
bump edx-orgs to `5.2.0-appsembler14`

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/permissions.py
+++ b/openedx/core/djangoapps/appsembler/sites/permissions.py
@@ -7,7 +7,6 @@ class AMCAdminPermission(permissions.BasePermission):
     """
 
     def has_permission(self, request, view):
-        is_microsite_admin = request.user.usersitemapping_set.filter(is_amc_admin=True).exists()
         is_organization_admin = request.user.userorganizationmapping_set.filter(is_amc_admin=True).exists()
         is_superuser = request.user.is_superuser
-        return is_microsite_admin or is_organization_admin or is_superuser
+        return is_organization_admin or is_superuser

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_permissions.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_permissions.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from organizations.models import UserOrganizationMapping, UserSiteMapping
+from organizations.models import UserOrganizationMapping
 from organizations.tests.factories import UserFactory, OrganizationFactory
 from rest_framework.test import APIRequestFactory
 
@@ -11,8 +11,7 @@ class AMCAdminPermissionsTestCase(TestCase):
     """
     Verify permissions for AMC users.
 
-    If the user is an admin user and either a part of an organization or a site, they should
-    be able to have access.
+    If the user is an admin user of an organization, they should be able to have access.
     """
 
     def setUp(self):
@@ -36,12 +35,4 @@ class AMCAdminPermissionsTestCase(TestCase):
 
     def test_organization_admin_user(self):
         UserOrganizationMapping.objects.create(user=self.user, organization=self.organization, is_amc_admin=True)
-        self.assertTrue(AMCAdminPermission().has_permission(self.request, None))
-
-    def test_site_nonadmin_user(self):
-        UserSiteMapping.objects.create(user=self.user, site=self.site, is_amc_admin=False)
-        self.assertFalse(AMCAdminPermission().has_permission(self.request, None))
-
-    def test_site_admin_user(self):
-        UserSiteMapping.objects.create(user=self.user, site=self.site, is_amc_admin=True)
         self.assertTrue(AMCAdminPermission().has_permission(self.request, None))

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -24,7 +24,7 @@ from django.utils.text import slugify
 
 from organizations import api as org_api
 from organizations import models as org_models
-from organizations.models import UserOrganizationMapping, Organization, UserSiteMapping
+from organizations.models import UserOrganizationMapping, Organization
 
 from openedx.core.lib.api.api_key_permissions import is_request_has_valid_api_key
 from openedx.core.lib.log_utils import audit_log
@@ -218,17 +218,11 @@ def make_amc_admin(user, org_name):
       - Return the recent tokens.
     """
     org = Organization.objects.get(Q(name=org_name) | Q(short_name=org_name))
-    site = get_site_by_organization(org)
 
     uom, _ = UserOrganizationMapping.objects.get_or_create(user=user, organization=org)
     uom.is_active = True
     uom.is_amc_admin = True
     uom.save()
-
-    usm, _ = UserSiteMapping.objects.get_or_create(user=user, site=site)
-    usm.is_active = True
-    usm.is_amc_admin = True
-    usm.save()
 
     return {
         'user_email': user.email,

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -78,7 +78,7 @@ edx-django-utils
 edx-drf-extensions
 edx-enterprise
 edx-milestones
-https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler13.tar.gz  # edx-organizations
+https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler14.tar.gz  # edx-organizations
 edx-proctoring>=2.0.1
 edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed
 edx-rest-api-client

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -107,7 +107,7 @@ edx-enterprise==3.2.14    # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler13.tar.gz  # edx-organizations==5.2.0
+https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler14.tar.gz  # edx-organizations==5.2.0
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
 edx-proctoring==2.4.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.2.1           # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -120,7 +120,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
 edx-lint==1.4.1           # via -r requirements/edx/testing.txt
 edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler13.tar.gz  # edx-organizations==5.2.0
+https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler14.tar.gz  # edx-organizations==5.2.0
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
 edx-proctoring==2.4.0     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.2.1           # via -r requirements/edx/testing.txt, edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -117,7 +117,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/ed
 edx-lint==1.4.1           # via -r requirements/edx/testing.in
 edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler13.tar.gz  # edx-organizations==5.2.0
+https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler14.tar.gz  # edx-organizations==5.2.0
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
 edx-proctoring==2.4.0     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.2.1           # via -r requirements/edx/base.txt, edx-enterprise


### PR DESCRIPTION
Mostly for better testing experience by avoiding the need to import the models inline due to Django 2 update.

More details can be found in:

 - Removal of `UserSiteMapping`: https://github.com/appsembler/edx-organizations/pull/15
 - The release on GitHub: https://github.com/appsembler/edx-organizations/releases/tag/5.2.0-appsembler14
