### PR TITLE
update mongo3.9.0 connection options

### DIFF
--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -73,7 +73,7 @@ def connect_to_mongodb(
             port=port,
             tz_aware=tz_aware,
             document_class=dict,
-            ssl_cert_reqs=ssl.CERT_NONE,
+            tlsAllowInvalidCertificates=True,
             **kwargs
         ),
         db


### PR DESCRIPTION
## Change description

I found this deprecation warning for pymongo when debugging in Django shell:

`2021-06-11 17:22:07,593 WARNING 279 [py.warnings] [user None] uri_parser.py:213 - /edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/pymongo/mongo_client.py:645: DeprecationWarning: Option 'ssl_cert_reqs' is deprecated, use 'tlsAllowInvalidCertificates' instead.
  keyword_opts = _handle_option_deprecations(keyword_opts)`
  

The [changelog](https://pymongo.readthedocs.io/en/stable/changelog.html) for pymongo version 3.9.0 highlights that `ssl_cert_reqs` has been deprecated and recommends `tlsAllowInvalidCertificates` instead:

- ssl_cert_reqs has been deprecated in favor of tlsAllowInvalidCertificates. Instead of ssl.CERT_NONE, ssl.CERT_OPTIONAL and ssl.CERT_REQUIRED, the new option expects a boolean value - True is equivalent to ssl.CERT_NONE, while False is equivalent to ssl.CERT_REQUIRED.