### PR TITLE
enable grades tests in `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -153,7 +153,7 @@ commands =
         lms/djangoapps/courseware/tests/test_access_control_backends.py \
         lms/djangoapps/courseware/tests/test_navigation.py  \
         lms/djangoapps/discussion/django_comment_client/ \
-        lms/djangoapps/grades/tests/integration/test_events.py \
+        lms/djangoapps/grades/ \
         lms/djangoapps/instructor/ \
         lms/djangoapps/verify_student/tests/test_services.py  \
         openedx/core/djangoapps/appsembler \


### PR DESCRIPTION
Increase our code coverage to ensure #943 is being tested.