### PR TITLE
Django command to debug i18n translations

### DIFF
--- a/openedx/core/djangoapps/appsembler/i18n/__init__.py
+++ b/openedx/core/djangoapps/appsembler/i18n/__init__.py
@@ -1,0 +1,3 @@
+"""
+Internationalization (i18n) utilities for Open edX.
+"""

--- a/openedx/core/djangoapps/appsembler/i18n/helpers.py
+++ b/openedx/core/djangoapps/appsembler/i18n/helpers.py
@@ -1,0 +1,43 @@
+import json
+
+from django.template import Template, Context, Engine
+from django.utils import translation
+from django.utils.translation import gettext
+from xblock.core import XBlock
+from xmodule.modulestore.django import ModuleI18nService
+
+
+class XBlockImitator:
+    """
+    A simple object that acts like other xblocks.
+    """
+    def __init__(self, name):
+        # Allow `ModuleI18nService` to load the right XBlock class
+        self.unmixed_class = XBlock.load_class(name)
+
+
+def translate(lang, source_text):
+    with translation.override(lang):
+        return gettext(source_text)
+
+
+def xblock_translate(xblock_name, lang, source_text):
+    """
+    Translates a text from both platform and XBlock translations po/mo files.
+
+    Every xblock comes with it's own translations, so this may produce different
+    translations for the same source text when used on different xblocks.
+    """
+    block = XBlockImitator(xblock_name)
+    engine = Engine(libraries={
+        'i18n': 'xblockutils.templatetags.i18n',
+    })
+
+    with translation.override(lang):
+        i18n_service = ModuleI18nService(block=block)
+        template_content = '{% load i18n %} {% trans %s %}'.replace(
+            '%s', json.dumps(source_text)
+        )
+        template = Template(template_content, engine=engine)
+        context = Context({'source_text': source_text, '_i18n_service': i18n_service})
+        return template.render(context)

--- a/openedx/core/djangoapps/appsembler/i18n/management/__init__.py
+++ b/openedx/core/djangoapps/appsembler/i18n/management/__init__.py
@@ -1,0 +1,3 @@
+"""
+Internationalization (i18n) management commands.
+"""

--- a/openedx/core/djangoapps/appsembler/i18n/management/commands/__init__.py
+++ b/openedx/core/djangoapps/appsembler/i18n/management/commands/__init__.py
@@ -1,0 +1,3 @@
+"""
+Internationalization (i18n) commands.
+"""

--- a/openedx/core/djangoapps/appsembler/i18n/management/commands/tahoe_translate.py
+++ b/openedx/core/djangoapps/appsembler/i18n/management/commands/tahoe_translate.py
@@ -1,0 +1,60 @@
+"""
+Command to test Tahoe `gettext` without the need to use the GUI.
+"""
+
+from django.core.management.base import BaseCommand
+from openedx.core.djangoapps.appsembler.i18n.helpers import translate, xblock_translate
+
+
+class Command(BaseCommand):
+    """
+    Test Tahoe `gettext` without the need to use the GUI with xblock support.
+
+    Currently missing the following features:
+      1) TODO: Handle theme translations
+      2) TODO: Support JavaScript edX Platform translations (djangojs.po)
+      3) TODO: Support JavaScript XBlock translations (textjs.po)
+    """
+
+    help = "Test Tahoe `gettext` without the need to use the GUI with xblock support."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-x', '--xblock',
+            default=None,
+            help='A name for the XBlock to use the translations for.'
+        )
+        parser.add_argument(
+            'language',
+            help='The language code to translate to e.g. "eo", "ja-jp", "fr-ca".'
+        )
+        parser.add_argument(
+            'text',
+            help='The text to translate. Always provide the English text in quotes e.g. "Sign in".',
+        )
+
+    def handle(self, *args, **options):
+        translated_text = translate(options['language'], options['text'])
+
+        if options['xblock']:
+            translated_xblock_text = xblock_translate(options['xblock'], options['language'], options['text'])
+        else:
+            translated_xblock_text = ''
+
+        self.stdout.write(
+            'Translation result: \n'
+            '  - Source language:         en\n'
+            '  - Translation language:    {lang}\n'
+            '  - Source text:             "{text}" (stripped)\n'
+            '  - Translated text:         "{translated_text}" (stripped)\n'
+            '\n'
+            '  - XBlock:                  {xblock}\n'
+            '  - XBlock translated text : "{translated_xblock_text}" (stripped)\n'
+            '\n'.format(
+                lang=options['language'],
+                text=options['text'].strip(),
+                xblock=options['xblock'] or '[Not used]',
+                translated_text=translated_text.strip(),
+                translated_xblock_text=translated_xblock_text.strip() if translated_xblock_text else '',
+            )
+        )

--- a/openedx/core/djangoapps/appsembler/i18n/tests/test_helpers.py
+++ b/openedx/core/djangoapps/appsembler/i18n/tests/test_helpers.py
@@ -1,0 +1,9 @@
+"""
+Test the i18n module helpers.
+"""
+from openedx.core.djangoapps.appsembler.i18n.helpers import xblock_translate
+
+
+def test_xblock_translate():
+    translated_text = xblock_translate('drag-and-drop-v2', 'eo', 'The Top Zone')
+    assert 'Töp' in translated_text

--- a/openedx/core/djangoapps/appsembler/i18n/tests/test_translate_command.py
+++ b/openedx/core/djangoapps/appsembler/i18n/tests/test_translate_command.py
@@ -1,0 +1,18 @@
+"""
+Tests for the pre-prod candidate site configurations export/import commands.
+"""
+
+from django.core.management import call_command
+
+
+def test_translate_command(capsys):
+    """
+    Test the `./manage.py lms tahoe_translate` command.
+    """
+    call_command(
+        'tahoe_translate',
+        'eo',
+        'Sign in',
+    )
+    captured = capsys.readouterr()
+    assert 'Sïgn' in captured.out, 'Dummy Esperanto language should be translated with weird accents'

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -17,6 +17,7 @@ def plugin_settings(settings):
         'hijack',
         'hijack_admin',
 
+        'openedx.core.djangoapps.appsembler.i18n',
         'openedx.core.djangoapps.appsembler.sites',
         'openedx.core.djangoapps.appsembler.html_certificates',
         'openedx.core.djangoapps.appsembler.api',


### PR DESCRIPTION
This command makes it easier to debug translations without the need to use the GUI. This should remove the most annoying step when debugging i18n issues for missing translations.

I'll update our Runbooks and this is a good thing to be contributed to the Open edX community.

### Related: Problem with `xblock-utils:ProxyTransNode.merge_translation` method 
The `merge_translation` method isn't cleaning up after the merge and leaves stray translations in the following way:

 - ✔️ Calling `i18n.helpers.translate('fr_CA', 'Thank you.') returns the untranslated 'Thank you.'
 - ✔️ Calling `i18n.helpers.xblock_translate('fr_CA', 'Thank you.') returns 'Merci !' 
 - ❌ Calling `i18n.helpers.translate('fr_CA', 'Thank you.')` again returns the the translated 'Merci !' which means that the `merge_translation` didn't clean up after itself

**Workaround:** Call `translate` then `xblock_translate` in the `tahoe_translate` command.

**Long term fix:** Work with upstream to fix the cleanup process around `translation.activate(...)`  as documented in https://github.com/appsembler/edx-platform/issues/954
