### PR TITLE
fix RecursionError for xblock translations

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -357,6 +357,10 @@ class ModuleI18nService(object):
     i18n service.
 
     """
+
+    # Prevent ModuleI18nService from falling back to itself infinitly
+    _fallback = None
+
     def __init__(self, block=None):
         """
         Attempt to load an XBlock-specific GNU gettext translator using the XBlock's own domain


### PR DESCRIPTION
This exception below is raised because there's an attempt to make the `ModuleI18nService` fallback to itself due to the use of the magical `ModuleI18nService.__getattr__` which returns `django.utils.translation._fallback` when asked for `ModuleI18nService._fallback`. RED-2263.

This creates a infinite recursion that needs to break.

```
File "xblockutils/templatetags/i18n.py", line 41, in merge_translation
    translation.merge(i18n_service)
...
File "python3.5/gettext.py", line 169, in add_fallback
    self._fallback.add_fallback(fallback)
RecursionError: maximum recursion depth exceeded"
```

### Rough steps for the XBlock translation process

 - Django initialize translations using the po/mo files in `conf/locale`
 - XBlocks get installed afterward
 - Django renders the templates and calls the standard `gettext("Submit")` (Python) and `{% trans "Submit" %}` (templates) in the platform
 - When an XBlock is being used, a combination of the following modules are used to load the XBlock translations and merge them with the platform one:
   - `xblockutils.templatetags.i18n.ProxyTransNode`: Overrides the Django standard `{% trans ... %}` template tags with XBlock aware tags.
   - `xmodule.modulestore.django.ModuleI18nService`: Provides XBlock-aware `gettext`
   - `gettext`: The standard gettext library gets modified by activating and `translation.merge`'ing translations from the service
   - `poll` (like other xblocks): Uses the `@XBlock.needs('i18n')` decorator to load `ModuleI18nService`
   - `poll` (like other xblocks): Creates a new `web_fragments.fragment.Fragment` and [passes the `i18n_service`](https://github.com/open-craft/xblock-poll/blob/5113d9610eeef4b5122f63006f88ee146213ea74/poll/poll.py#L90-L96) to it.


In my opinion there's a simpler and better way to do the work by avoiding the `merge` method and define custom template tags for the xblocks. I'll probably ping edX to do that.

### Tests
I wasn't able to reproduce the issue via scripts or tests. The issue has extended beyond the regular bug timebox of 4 hours.