### PR TITLE
Set task queue for Figures from env if Figures is installed

### DIFF
--- a/lms/envs/aws_appsembler.py
+++ b/lms/envs/aws_appsembler.py
@@ -136,7 +136,13 @@ if 'figures' in INSTALLED_APPS:
         update_webpack_loader,
         update_celerybeat_schedule
     )
-    update_webpack_loader(WEBPACK_LOADER,
-                          ENV_TOKENS.get('FIGURES', {}))
-    update_celerybeat_schedule(CELERYBEAT_SCHEDULE,
-                               ENV_TOKENS.get('FIGURES', {}))
+    figures_tasks_default_queue = ENV_TOKENS['FIGURES'].get(
+        'FIGURES_PIPELINE_TASKS_ROUTING_KEY',
+        CELERY_DEFAULT_ROUTING_KEY
+        )
+    update_webpack_loader(WEBPACK_LOADER, ENV_TOKENS['FIGURES'])
+    update_celerybeat_schedule(
+        CELERYBEAT_SCHEDULE,
+        ENV_TOKENS['FIGURES'],
+        figures_tasks_default_queue
+        )


### PR DESCRIPTION
## Change description

Allow setting the Celery queue for Figures tasks from ENV_TOKENS

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
