### PR TITLE
Handle segment exceptions more gracefully

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -154,10 +154,10 @@ class DefaultMultipleSegmentClient(object):
                 event_name = args[1]
             except IndexError:
                 event_name = '(unknown event name)'
-            logger.warn(
-                "Error retrieving Site SEGMENT_KEY. Cannot send event {} to "
+            logger.warning(
+                "Error retrieving Site SEGMENT_KEY. Cannot send event %s to "
                 "Site's Segment account. Sending only to main Segment client. "
-                "Error was {}".format(event_name, e.msg)
+                "Error was: ", event_name, exc_info=True
             )
         return site_segment_key
 


### PR DESCRIPTION
When an error happens in segment, Tahoe handle it incorrectly and throws another exception:

```
Unable to send event to backend: segment
...
openedx.core.djangoapps.appsembler.eventtracking.exceptions.EventProcessingError: There isn't and org or course_id attribute set in the segment event, so we couldn't determine the site.
...
During handling of the above exception, another exception occurred:
AttributeError: 'EventProcessingError' object has no attribute 'msg'"
```

The solution is to use Python's native `exc_info=True` to log the
exception correctly.

Another fix is needed to fix the original EventProcessingError error.