### PR TITLE
Send account activation signal after SAML SSO workflow

### DIFF
--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -196,10 +196,12 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
                 with patch('third_party_auth.pipeline.get', return_value=pipeline_partial):
                     with patch('third_party_auth.pipeline.running', return_value=True):
                         with patch('third_party_auth.is_enabled', return_value=True):
-                            reg.skip_email_verification = True
-                            inactive_user_view(request)
-                            self.assertEqual(user.is_active, True)
-                            self.assertEqual(email.called, False, msg='method should not have been called')
+                            with patch('third_party_auth.views.USER_ACCOUNT_ACTIVATED') as mock_signal:
+                                reg.skip_email_verification = True
+                                inactive_user_view(request)
+                                self.assertEqual(user.is_active, True)
+                                self.assertEqual(email.called, False, msg='method should not have been called')
+                                mock_signal.send_robust.assert_called_once_with(None, user=user), 'Verify signal'
 
     @patch('student.views.management.compose_activation_email')
     def test_send_email_to_inactive_user(self, email):

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -19,6 +19,7 @@ from student.models import UserProfile
 from student.views import compose_and_send_activation_email
 from third_party_auth import pipeline, provider
 
+from openedx.core.djangoapps.signals.signals import USER_ACCOUNT_ACTIVATED
 from .models import SAMLConfiguration, SAMLProviderConfig
 
 URL_NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
@@ -51,6 +52,7 @@ def inactive_user_view(request):
             user.is_active = True
             user.save()
             activated = True
+            USER_ACCOUNT_ACTIVATED.send_robust(None, user=user)
     if not activated:
         compose_and_send_activation_email(user, profile)
 


### PR DESCRIPTION
RED-2176: This fixes a bug with Course Access Groups which relies on the `USER_ACCOUNT_ACTIVATED` signal to be sent after activating the account.
