### PR TITLE
fix amc_admin_form in studio

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -164,7 +164,8 @@ def reset_amc_tokens(user, access_token=None, refresh_token=None):
     write a custom hash creation function to generates 32 chars
     """
     app = get_amc_oauth_app()
-    one_year_ahead = timezone.now() + timedelta(days=settings.OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS)
+    valid_days = getattr(settings, 'OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS', 365)
+    one_year_ahead = timezone.now() + timedelta(days=valid_days)
 
     access, _created = AccessToken.objects.get_or_create(
         user=user,


### PR DESCRIPTION
Avoids the error below:

```
AttributeError: 'Settings' object has no attribute 'OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS'
```

A [random error in Sentry](https://sentry.io/organizations/appsembler/issues/2502557798/?project=87786&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox&statsPeriod=14d).