### PR TITLE
Fix nested SAML exception

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -94,10 +94,10 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
         except KeyError as ex:
             log.warning(
                 u'[THIRD_PARTY_AUTH] Error in SAML authentication flow. '
-                u'Provider: {idp_name}, Message: {message}'.format(
-                    message=ex.message,
+                u'Provider: {idp_name}, Message:'.format(
                     idp_name=response.get('idp_name')
-                )
+                ),
+                exc_info=True
             )
             raise IncorrectConfigurationException(self)
 


### PR DESCRIPTION
Fixes the exception below by using [`exc_info=True`](https://docs.python.org/3/library/logging.html) to print a full stack trace.
```
AttributeError /auth/complete/{backend}/
'KeyError' object has no attribute 'message'
```