### PR TITLE
create v2 registration api

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/tests/test_registration_api_v2.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_registration_api_v2.py
@@ -1,0 +1,67 @@
+"""
+Tests for openedx.core.djangoapps.appsembler.api.v2.views.RegistrationViewSet
+
+"""
+from django.urls import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+
+import ddt
+from mock import patch
+
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
+
+APPSEMBLER_API_VIEWS_MODULE_V2 = 'openedx.core.djangoapps.appsembler.api.v2.views'
+
+
+@ddt.ddt
+@patch(APPSEMBLER_API_VIEWS_MODULE_V2 + '.RegistrationViewSet.authentication_classes', [])
+@patch(APPSEMBLER_API_VIEWS_MODULE_V2 + '.RegistrationViewSet.permission_classes', [AllowAny])
+@patch(APPSEMBLER_API_VIEWS_MODULE_V2 + '.RegistrationViewSet.throttle_classes', [])
+@override_settings(APPSEMBLER_FEATURES={
+    'SKIP_LOGIN_AFTER_REGISTRATION': False,
+})
+class RegistrationApiViewTestsV2(TestCase):
+    def setUp(self):
+
+        self.site = SiteFactory()
+        # The DRF Router appends '-list' to the base 'registrations' name when
+        # registering the endpoint
+        self.url = reverse('tahoe-api:v2:registrations-list')
+        self.sample_user_data = {
+            'username': 'MrRobot',
+            'password': 'edX',
+            'email': 'mr.robot@example.com',
+            'name': 'Mr Robot'
+        }
+
+    def test_registration_response(self):
+        res = self.client.post(self.url, self.sample_user_data)
+        self.assertNotContains(res, "user_id ")
+        self.assertContains(res, "user_id", status_code=200)
+
+    def test_duplicate_identifiers(self):
+        self.client.post(self.url, self.sample_user_data)
+        res = self.client.post(self.url, {
+            'username': self.sample_user_data['username'],
+            'password': 'Another Password!',
+            'email': 'me@example.com',
+            'name': 'The Boss'
+        })
+        self.assertContains(res, 'Username already exists', status_code=status.HTTP_409_CONFLICT)
+        res = self.client.post(self.url, {
+            'username': 'world_changer',
+            'password': 'Yet Another Password!',
+            'email': self.sample_user_data['email'],
+            'name': 'World Changer'
+        })
+        self.assertContains(res, 'Email already exists', status_code=status.HTTP_409_CONFLICT)
+        res = self.client.post(self.url, {
+            'username': self.sample_user_data['username'],
+            'password': 'This Is A Password',
+            'email': self.sample_user_data['email'],
+            'name': 'Batman'
+        })
+        self.assertContains(res, 'Both email and username already exist', status_code=status.HTTP_409_CONFLICT)

--- a/openedx/core/djangoapps/appsembler/api/urls.py
+++ b/openedx/core/djangoapps/appsembler/api/urls.py
@@ -6,8 +6,10 @@ Use this URL handler module to manage versioned Tahoe APIs
 from django.conf.urls import include, url
 
 from openedx.core.djangoapps.appsembler.api.v1 import urls as v1_urls
+from openedx.core.djangoapps.appsembler.api.v2 import urls as v2_urls
 
 
 urlpatterns = [
     url(r'^v1/', include((v1_urls, 'v1'), namespace='v1')),
+    url(r'^v2/', include((v2_urls, 'v2'), namespace='v2'))
 ]

--- a/openedx/core/djangoapps/appsembler/api/v2/api.py
+++ b/openedx/core/djangoapps/appsembler/api/v2/api.py
@@ -1,0 +1,10 @@
+from student.models import (email_exists_or_retired,
+                            username_exists_or_retired)
+
+
+def email_exists(email):
+    return email and email_exists_or_retired(email, check_for_new_site=False)
+
+
+def username_exists(username):
+    return username and username_exists_or_retired(username)

--- a/openedx/core/djangoapps/appsembler/api/v2/urls.py
+++ b/openedx/core/djangoapps/appsembler/api/v2/urls.py
@@ -1,0 +1,39 @@
+"""URL definitions for Tahoe API version 2
+"""
+
+from django.urls import include, path
+from rest_framework import routers
+
+from openedx.core.djangoapps.appsembler.api.v1 import views
+from openedx.core.djangoapps.appsembler.api.v2 import views as views_v2
+
+
+router = routers.DefaultRouter()
+
+router.register(
+    r'courses',
+    views.CourseViewSet,
+    basename='courses',
+)
+
+router.register(
+    r'enrollments',
+    views.EnrollmentViewSet,
+    basename='enrollments',
+)
+
+router.register(
+    r'registrations',
+    views_v2.RegistrationViewSet,
+    basename='registrations',
+)
+
+router.register(
+    r'users',
+    views.UserIndexViewSet,
+    basename='users'
+)
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/openedx/core/djangoapps/appsembler/api/v2/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v2/views.py
@@ -1,0 +1,173 @@
+"""Tahoe version 2 API views
+
+Only include view classes here. See the tests/test_permissions.py:get_api_classes()
+method.
+"""
+import beeline
+import logging
+
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
+from django.db import transaction
+from django.utils.decorators import method_decorator
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from openedx.core.djangoapps.user_authn.views.register import create_account_with_params
+from student.helpers import AccountValidationError
+
+from openedx.core.djangoapps.appsembler.api.v1.views import (
+    RegistrationViewSet as RegistrationViewSetV1,
+    create_password,
+    send_password_reset_email
+)
+from openedx.core.djangoapps.appsembler.api.v2.api import (
+    email_exists,
+    username_exists
+)
+
+# TODO: Just move into v1 directory
+from openedx.core.djangoapps.appsembler.api.permissions import (
+    TahoeAPIUserThrottle
+)
+
+
+log = logging.getLogger(__name__)
+
+
+class RegistrationViewSet(RegistrationViewSetV1):
+    """
+    Allows remote clients to register new users via API
+
+    This API has a rate limit of 60 requets per minutes
+    """
+    throttle_classes = (TahoeAPIUserThrottle,)
+    http_method_names = ['post', 'head']
+
+    @method_decorator(transaction.non_atomic_requests)
+    def dispatch(self, *args, **kwargs):
+        return super(RegistrationViewSet, self).dispatch(*args, **kwargs)
+
+    @beeline.traced(name="apis.v2.views.RegistrationViewSet.create")
+    def create(self, request):
+        """Creates a new user account for the site that calls this view
+
+        Changes between v1 and v2:
+        - HttpResponse: 200 on success, {"user_id ": 9} -> {"user_id": 9}
+
+        To use, perform a token authenticated POST to the URL::
+
+            /tahoe/api/v2/registrations/
+
+        Required arguments (JSON data):
+            "username"
+            "email"
+            "name"
+
+        Optional arguments:
+            "password"
+            "send_activation_email"
+
+        Returns:
+            HttpResponse: 200 on success, {"user_id": 9}
+            HttpResponse: 400 if the request is not valid.
+            HttpResponse: 409 if an account with the given username or email
+                address already exists
+
+        The code here is adapted from the LMS ``appsembler_api`` bulk registration
+        code. See the ``appsembler/ginkgo/master`` branch
+        """
+        # Using .copy() to make the POST data mutable
+        # see: https://stackoverflow.com/a/49794425/161278
+        data = request.data.copy()
+        password_provided = 'password' in data
+
+        # set the honor_code and honor_code like checked,
+        # so we can use the already defined methods for creating an user
+        data['honor_code'] = 'True'
+        data['terms_of_service'] = 'True'
+
+        if password_provided:
+            try:
+                # Default behavior is True - send the email
+
+                data['send_activation_email'] = self._normalize_bool_param(
+                    data.get('send_activation_email', True))
+            except ValueError:
+                errors = {
+                    'user_message': '{0} is not a valid value for "send_activation_email"'.format(
+                        data['send_activation_email'])
+                }
+                return Response(errors, status=status.HTTP_400_BAD_REQUEST)
+
+        else:
+            data['password'] = create_password()
+            data['send_activation_email'] = False
+
+        email = request.data.get('email')
+        username = request.data.get('username')
+
+        # v2: Returns specific error message for duplicate email and/or username
+        email_exists_error = email_exists(email=email)
+        username_exists_error = username_exists(username=username)
+        if email_exists_error and username_exists_error:
+            errors = {
+                "user_message": "Both email and username already exist",
+                "invalid-params": ["email", "username"]
+            }
+            return Response(errors, status=status.HTTP_409_CONFLICT)
+        elif email_exists_error:
+            errors = {
+                "title": "Email already exists",
+                "invalid-params": ["email"]
+            }
+            return Response(errors, status=status.HTTP_409_CONFLICT)
+        elif username_exists_error:
+            errors = {
+                "title": "Username already exists",
+                "invalid-params": ["username"]
+            }
+            return Response(errors, status=status.HTTP_409_CONFLICT)
+
+        try:
+            user = create_account_with_params(
+                request=request,
+                params=data,
+            )
+            if password_provided:
+                # if send_activation_email is True, we want to keep the user
+                # inactive until the email is properly validated. If the param
+                # is False, we activate it.
+                user.is_active = not data['send_activation_email']
+            else:
+                # if the password is not provided, keep the user inactive until
+                # the password is set.
+                user.is_active = False
+            user.save()
+            user_id = user.id
+            if not password_provided:
+                success = send_password_reset_email(request)
+                if not success:
+                    log.error('Tahoe Reg API: Error sending password reset '
+                              'email to user {}'.format(user.username))
+
+        except ValidationError as err:
+            log.error('ValidationError. err={}'.format(err))
+            # Should only get non-field errors from this function
+
+            assert NON_FIELD_ERRORS not in err.message_dict
+            # Only return first error for each field
+            # TODO: Let's give a clue as to which are the error causing fields
+            msg = 'Invalid parameters on user creation'
+            return Response(dict(user_message=msg), status=status.HTTP_400_BAD_REQUEST)
+        except AccountValidationError as err:
+            log.error('AccountValidationError. err={}'.format(err))
+            # Should only get non-field errors from this function
+
+            # assert NON_FIELD_ERRORS not in err.message_dict
+            # Only return first error for each field
+            # TODO: Let's give a clue as to which are the error causing fields
+            msg = 'Invalid parameters on user creation: {field}'.format(
+                field=err.field)
+            return Response(dict(user_message=msg), status=status.HTTP_400_BAD_REQUEST)
+        return Response({'user_id': user_id}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Change description

- Create appsembler api v2

- v2/api.py
  - add `email_exists`
  - add `username_exists`

- v2/views.py
  - remove trailing space in response: 
  `return Response({'user_id': user_id}, status=status.HTTP_200_OK)`
  - return specific response for when email and/or username exist
  
  ```
        email_exists_error = email_exists(email=email)
        username_exists_error = username_exists(username=username)
        if email_exists_error and username_exists_error:
            errors = {
                "user_message": "Both email and username already exist",
                "invalid-params": ["email", "username"]
            }
            return Response(errors, status=status.HTTP_409_CONFLICT)
        elif email_exists_error:
            errors = {
                "title": "Email already exists",
                "invalid-params": ["email"]
            }
            return Response(errors, status=status.HTTP_409_CONFLICT)
        elif username_exists_error:
            errors = {
                "title": "Username already exists",
                "invalid-params": ["username"]
            }
            return Response(errors, status=status.HTTP_409_CONFLICT)```
- Add tests: `test_registration_api_v2.py`

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues
- [RED-1681](https://appsembler.atlassian.net/browse/RED-1681)
- [RED-2318](https://appsembler.atlassian.net/browse/RED-2318)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
