### PR TITLE
Create automatic PRs to sync prod with main

### DIFF
--- a/.github/workflows/sync_prod_with_main.yml
+++ b/.github/workflows/sync_prod_with_main.yml
@@ -1,0 +1,18 @@
+name: Sync prod with main
+on:
+  push:
+    branches:
+      - main
+jobs:
+  auto-pull-request:
+    name: PullRequestAction
+    runs-on: ubuntu-latest
+    steps:
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@1.0.12
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_PREFIX: "main"
+          PULL_REQUEST_BRANCH: "prod"
+          PULL_REQUEST_TITLE: "Update from `main` (production)"
+          PULL_REQUEST_REVIEWERS: "melvinsoft OmarIthawi thraxil estherjsuh"


### PR DESCRIPTION
This brings the old process that was used in Hawthorn but with different branch names: [related decision doc](https://appsembler.atlassian.net/l/c/0qB6Faqt)
