### PR TITLE
fallback to STATICFILES_DIRS when comprehensive theming not enabled

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/helpers.py
+++ b/openedx/core/djangoapps/appsembler/settings/helpers.py
@@ -37,6 +37,8 @@ def get_tahoe_theme_static_dirs(settings):
         if path.isdir(theme_static):
             static_files_dir_setting += [theme_static]
         return static_files_dir_setting
+    # comprehensive theming not enabled
+    return settings.STATICFILES_DIRS
 
 
 def get_tahoe_multitenant_auth_backends(settings):

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
@@ -6,6 +6,7 @@ from mock import patch
 
 from openedx.core.djangoapps.theming.helpers_dirs import Theme
 
+from openedx.core.djangoapps.appsembler.settings.helpers import get_tahoe_theme_static_dirs
 from openedx.core.djangoapps.appsembler.settings.settings import (
     devstack_cms,
     devstack_lms,
@@ -56,3 +57,22 @@ def test_production_lms(fake_production_settings, retval, additional_count):
             expected_dir_len = len(settings.STATICFILES_DIRS) + additional_count
             production_lms.plugin_settings(settings)
             assert len(settings.STATICFILES_DIRS) == expected_dir_len
+
+
+@pytest.fixture(scope='function')
+def fake_production_settings_non_comprehensive_themes(settings):
+    """
+    Pytest fixture to fake production settings for comprehensive theming turned off
+    """
+    settings.STATICFILES_DIRS = ['dummy', 'dummy']
+    settings.ENABLE_COMPREHENSIVE_THEMING = False
+    return settings
+
+
+def test_get_tahoe_theme_static_dirs_non_comprehensive(fake_production_settings_non_comprehensive_themes):
+    """
+    get_tahoe_theme_static_dirs() should just return the default STATICFILES_DIRS
+    when comprehensive theming isn't enabled
+    """
+    settings = fake_production_settings_non_comprehensive_themes
+    assert get_tahoe_theme_static_dirs(settings) == settings.STATICFILES_DIRS


### PR DESCRIPTION
`get_tahoe_theme_static_dirs()` didn't have a fallback case for when `settings.ENABLE_COMPREHENSIVE_THEMING` is false. That results in python returning `None` when the function is called. `production_lms.py` assigns that to `STATICFILES_DIRS`: https://github.com/appsembler/edx-platform/blob/main/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py#L100

Later, when Django tries to do stuff with the LMS (even just validating models), it tries to iterate over `settings.STATICFILES_DIRS`, which fails because it's `None`:

```
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/bin/celery", line 8, in <module>
    sys.exit(main())
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/__main__.py", line 30, in main
    main()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/celery.py", line 81, in main
    cmd.execute_from_commandline(argv)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/celery.py", line 793, in execute_from_commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/base.py", line 311, in execute_from_commandline
    return self.handle_argv(self.prog_name, argv[1:])
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/celery.py", line 785, in handle_argv
    return self.execute(command, argv)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/celery.py", line 717, in execute
    ).run_from_argv(self.prog_name, argv[1:], command=argv[0])
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/worker.py", line 179, in run_from_argv
    return self(*args, **options)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/base.py", line 274, in __call__
    ret = self.run(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/worker.py", line 212, in run
    state_db=self.node_format(state_db, hostname), **kwargs
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/worker/__init__.py", line 95, in __init__
    self.app.loader.init_worker()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/loaders/base.py", line 128, in init_worker
    self.import_default_modules()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/loaders/base.py", line 116, in import_default_modules
    signals.import_modules.send(sender=self.app)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/utils/dispatch/signal.py", line 166, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/fixups/django.py", line 73, in on_import_modules
    self.worker_fixup.validate_models()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/fixups/django.py", line 173, in validate_models
    cmd.check()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/management/base.py", line 390, in check
    include_deployment_checks=include_deployment_checks,
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/management/base.py", line 377, in _run_checks
    return checks.run_checks(**kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/checks/registry.py", line 72, in run_checks
    new_errors = check(app_configs=app_configs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/contrib/staticfiles/checks.py", line 7, in check_finders
    for finder in get_finders():
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/contrib/staticfiles/finders.py", line 283, in get_finders
    yield get_finder(finder_path)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/contrib/staticfiles/finders.py", line 296, in get_finder
    return Finder()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/contrib/staticfiles/finders.py", line 58, in __init__
    for root in settings.STATICFILES_DIRS:
TypeError: 'NoneType' object is not iterable
```

I ran into this deploying the sandbox, which uses our `edx-platform` branch, but sticks to default theme settings.

This simply adds a fall-through case to `get_tahoe_theme_static_dirs()` that does a no-op and returns whatever `settings.STATICFILES_DIRS` was already set to.