### PR TITLE
fix bug in signal marking notpassing whitelisted certs

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -87,8 +87,11 @@ def _listen_for_failing_grade(sender, user, course_id, grade, **kwargs):  # pyli
     downstream signal from COURSE_GRADE_CHANGED
     """
     cert = GeneratedCertificate.certificate_for_student(user, course_id)
+    # Appsembler fix: If the cert was whitelisted (Exception certificate)
+    # we want to keep in "downloadble" status.
+    whitelist_cert = CertificateWhitelist.get_certificate_white_list(course_id, user)
     if cert is not None:
-        if CertificateStatuses.is_passing_status(cert.status):
+        if CertificateStatuses.is_passing_status(cert.status) and len(whitelist_cert) == 0:
             cert.mark_notpassing(grade.percent)
             log.info(u'Certificate marked not passing for {user} : {course} via failing grade: {grade}'.format(
                 user=user.id,

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -281,6 +281,68 @@ class FailingGradeCertsTest(ModuleStoreTestCase):
         self.assertEqual(cert.status, expected_status)
 
 
+@ddt.ddt
+class FailingGradeCertsTestWithWhiteLabelCert(ModuleStoreTestCase):
+    """
+    Tests for marking if a certificate is whitelisted it won't change from a
+    passing status to notpassing when grade goes from passing to failing, we
+    also test and that the signal has no effect on the cert status if the cert
+    has a non-passing status
+    """
+
+    def setUp(self):
+        super(FailingGradeCertsTestWithWhiteLabelCert, self).setUp()
+        self.course = CourseFactory.create(
+            self_paced=True,
+        )
+        self.user = UserFactory.create()
+        self.enrollment = CourseEnrollmentFactory(
+            user=self.user,
+            course_id=self.course.id,
+            is_active=True,
+            mode="verified",
+        )
+        self.whitelist_cert = CertificateWhitelist.objects.create(
+            user=self.user,
+            course_id=self.course.id,
+            whitelist=True
+        )
+        attempt = SoftwareSecurePhotoVerification.objects.create(
+            user=self.user,
+            status='submitted'
+        )
+        attempt.approve()
+
+    @ddt.data(
+        CertificateStatuses.deleted,
+        CertificateStatuses.deleting,
+        CertificateStatuses.downloadable,
+        CertificateStatuses.error,
+        CertificateStatuses.generating,
+        CertificateStatuses.notpassing,
+        CertificateStatuses.restricted,
+        CertificateStatuses.unavailable,
+        CertificateStatuses.auditing,
+        CertificateStatuses.audit_passing,
+        CertificateStatuses.audit_notpassing,
+        CertificateStatuses.unverified,
+        CertificateStatuses.invalidated,
+        CertificateStatuses.requesting,
+    )
+    def test_cert_failure(self, status):
+        # we want to make sure the certificate status does not change
+        # upon course change, since the certificate is whitelisted.
+        expected_status = status
+        GeneratedCertificate.eligible_certificates.create(
+            user=self.user,
+            course_id=self.course.id,
+            status=status
+        )
+        CourseGradeFactory().update(self.user, self.course)
+        cert = GeneratedCertificate.certificate_for_student(self.user, self.course.id)
+        self.assertEqual(cert.status, expected_status)
+
+
 class LearnerTrackChangeCertsTest(ModuleStoreTestCase):
     """
     Tests for certificate generation task firing on learner verification

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -152,7 +152,7 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(3):
             _assert_read(expected_pass=True, expected_percent=0.5)  # updated to grade of 1.0
 
-        num_queries = 33
+        num_queries = 34
         with self.assertNumQueries(num_queries), mock_get_score(0, 0):  # the subsection now is worth zero
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -164,10 +164,10 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             self.assertEqual(mock_block_structure_create.call_count, 1)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 37, True),
-        (ModuleStoreEnum.Type.mongo, 1, 37, False),
-        (ModuleStoreEnum.Type.split, 3, 37, True),
-        (ModuleStoreEnum.Type.split, 3, 37, False),
+        (ModuleStoreEnum.Type.mongo, 1, 38, True),
+        (ModuleStoreEnum.Type.mongo, 1, 38, False),
+        (ModuleStoreEnum.Type.split, 3, 38, True),
+        (ModuleStoreEnum.Type.split, 3, 38, False),
     )
     @ddt.unpack
     def test_query_counts(self, default_store, num_mongo_calls, num_sql_calls, create_multiple_subsections):
@@ -179,8 +179,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
                     self._apply_recalculate_subsection_grade()
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 37),
-        (ModuleStoreEnum.Type.split, 3, 37),
+        (ModuleStoreEnum.Type.mongo, 1, 38),
+        (ModuleStoreEnum.Type.split, 3, 38),
     )
     @ddt.unpack
     def test_query_counts_dont_change_with_more_content(self, default_store, num_mongo_calls, num_sql_calls):
@@ -225,8 +225,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
         )
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 20),
-        (ModuleStoreEnum.Type.split, 3, 20),
+        (ModuleStoreEnum.Type.mongo, 1, 21),
+        (ModuleStoreEnum.Type.split, 3, 21),
     )
     @ddt.unpack
     def test_persistent_grades_not_enabled_on_course(self, default_store, num_mongo_queries, num_sql_queries):
@@ -240,8 +240,8 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
             self.assertEqual(len(PersistentSubsectionGrade.bulk_read_grades(self.user.id, self.course.id)), 0)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 1, 38),
-        (ModuleStoreEnum.Type.split, 3, 38),
+        (ModuleStoreEnum.Type.mongo, 1, 39),
+        (ModuleStoreEnum.Type.split, 3, 39),
     )
     @ddt.unpack
     def test_persistent_grades_enabled_on_course(self, default_store, num_mongo_queries, num_sql_queries):


### PR DESCRIPTION
Fix RED-2361

Problem description: Certificates have a Django signal, when a certificate object is created and has a passing status (`downloadable` or `generating`) but the course or the grading change, and it ends up in a non passing grade for the learner, the certificate change automatically to `notpassing`.
That's fine except when there is an Exception certificate created from the instructor dashboard, then it should never change to `notpassing`.