### PR TITLE
fix: "Invalid type for parameter ContentType" error on js upload

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -42,6 +42,20 @@ def plugin_settings(settings):
         'openedx.core.djangoapps.appsembler.analytics.context_processors.mixpanel',
     )
 
+    # Tahoe: fix: "Invalid type for parameter ContentType" error on js upload
+    #
+    #    This fix is useless in the Maple release.
+    #    The upstream Open edX fix is https://github.com/edx/edx-platform/pull/25957
+    #    For more details see: https://github.com/jazzband/django-pipeline/pull/715
+    #
+    settings.PIPELINE['MIMETYPES'] = (
+        (str('text/coffeescript'), str('.coffee')),
+        (str('text/less'), str('.less')),
+        (str('text/javascript'), str('.js')),
+        (str('text/x-sass'), str('.sass')),
+        (str('text/x-scss'), str('.scss')),
+    )
+
     settings.SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
     settings.CLONE_COURSE_FOR_NEW_SIGNUPS = False


### PR DESCRIPTION
RED-2381. This fix is useless and should be reverted once https://github.com/edx/edx-platform/pull/25957 is merged into the Tahoe branch when Maple is used.

This fix is related to SCORM package upload failing.

### Copying the original fix https://github.com/edx/edx-platform/pull/25957

We are affected by this issue:
[jazzband/django-pipeline#297 (comment)](https://github.com/jazzband/django-pipeline/pull/297#issuecomment-264416094)

In particular, this occurs when trying to upload js assets to s3, such
as with the Scorm xblock:
[overhangio/openedx-scorm-xblock#16](https://github.com/overhangio/openedx-scorm-xblock/issues/16)

This issue is resolved by upgrading django-pipeline to 2.0.3+, as the
fix was introduced here:
[jazzband/django-pipeline#715](https://github.com/jazzband/django-pipeline/pull/715)

### Testing (or lack thereof)

I didn’t test the fix, so please test it before merging.


