### PR TITLE
Use site's `/help` URL for activation emails

### DIFF
--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -103,6 +103,11 @@ class SiteConfiguration(models.Model):
         # domain instead the Tahoe URL.
         self.site_values['SITE_NAME'] = self.site.domain
 
+        # RED-2385: Use Multi-tenant `/help` URL for activation emails.
+        self.site_values['ACTIVATION_EMAIL_SUPPORT_LINK'] = '{root_url}/help'.format(
+            root_url=self.site_values['LMS_ROOT_URL'],
+        )
+
         super(SiteConfiguration, self).save(**kwargs)
 
         # recompile SASS on every save

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -72,6 +72,8 @@ class SiteConfigurationTests(TestCase):
                          self.test_config['platform_name'])
         self.assertEqual(site_configuration.get_value("LMS_ROOT_URL"),
                          self.expected_site_root_url)
+        self.assertTrue(site_configuration.get_value('ACTIVATION_EMAIL_SUPPORT_LINK'))
+        self.assertTrue(site_configuration.get_value('ACTIVATION_EMAIL_SUPPORT_LINK').endswith('/help'))
 
     def test_get_value_for_org(self):
         """


### PR DESCRIPTION
RED-2385: The text "Appsembler Academy Support" links to https://appsembler.com/about/contact-us, which is incorrect. This should link to the site's `/help` page.