### PR TITLE
Remove support email address from the activation email message

### DIFF
--- a/common/templates/student/edx_ace/accountactivation/email/body.html
+++ b/common/templates/student/edx_ace/accountactivation/email/body.html
@@ -48,9 +48,9 @@
         <td>
             <p style="color: rgba(0,0,0,.75);">
                 {% blocktrans trimmed asvar assist_msg %}
-                If you need help, please use our web form at {start_anchor_web}{{ support_url }}{end_anchor} or email {start_anchor_email}{{ contact_email }}{end_anchor}.
+                If you need help, please use our web form at {start_anchor_web}{{ support_url }}{end_anchor}.
                 {% endblocktrans %}
-                {% interpolate_html assist_msg start_anchor_web='<a href="'|add:support_url|add:'">'|safe start_anchor_email='<a href="mailto:'|add:contact_email|add:'">'|safe end_anchor='</a>'|safe %}
+                {% interpolate_html assist_msg start_anchor_web='<a href="'|add:support_url|add:'">'|safe %}
                 <br />
             </p>
         </td>


### PR DESCRIPTION
RED-2385: CSMs asked us to do this because it's confusing customers.

### Conflicts

I've checked conflicts with upstream `master` and found no conflicts -- or so I hope!