### PR TITLE
Get back edX VAL migration command

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/migrate_transcripts.py
+++ b/cms/djangoapps/contentstore/management/commands/migrate_transcripts.py
@@ -1,0 +1,155 @@
+"""
+Command to migrate transcripts to django storage.
+"""
+
+
+import logging
+
+from django.core.management import BaseCommand, CommandError
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locator import CourseLocator
+from six.moves import map
+
+from cms.djangoapps.contentstore.tasks import (
+    DEFAULT_ALL_COURSES,
+    DEFAULT_COMMIT,
+    DEFAULT_FORCE_UPDATE,
+    enqueue_async_migrate_transcripts_tasks
+)
+from openedx.core.djangoapps.video_config.models import MigrationEnqueuedCourse, TranscriptMigrationSetting
+from openedx.core.lib.command_utils import get_mutually_exclusive_required_option, parse_course_keys
+from xmodule.modulestore.django import modulestore
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Example usage:
+        $ ./manage.py cms migrate_transcripts --all-courses --force-update --commit
+        $ ./manage.py cms migrate_transcripts --course-id 'Course1' --course-id 'Course2' --commit
+        $ ./manage.py cms migrate_transcripts --from-settings
+    """
+    help = 'Migrates transcripts to S3 for one or more courses.'
+
+    def add_arguments(self, parser):
+        """
+        Add arguments to the command parser.
+        """
+        parser.add_argument(
+            '--course-id', '--course_id',
+            dest='course_ids',
+            action='append',
+            help=u'Migrates transcripts for the list of courses.'
+        )
+        parser.add_argument(
+            '--all-courses', '--all', '--all_courses',
+            dest='all_courses',
+            action='store_true',
+            default=DEFAULT_ALL_COURSES,
+            help=u'Migrates transcripts to the configured django storage for all courses.'
+        )
+        parser.add_argument(
+            '--from-settings', '--from_settings',
+            dest='from_settings',
+            help='Migrate Transcripts with settings set via django admin',
+            action='store_true',
+            default=False,
+        )
+        parser.add_argument(
+            '--force-update', '--force_update',
+            dest='force_update',
+            action='store_true',
+            default=DEFAULT_FORCE_UPDATE,
+            help=u'Force migrate transcripts for the requested courses, overwrite if already present.'
+        )
+        parser.add_argument(
+            '--commit',
+            dest='commit',
+            action='store_true',
+            default=DEFAULT_COMMIT,
+            help=u'Commits the discovered video transcripts to django storage. '
+                 u'Without this flag, the command will return the transcripts discovered for migration.'
+        )
+
+    def _parse_course_key(self, raw_value):
+        """ Parses course key from string """
+        try:
+            result = CourseKey.from_string(raw_value)
+        except InvalidKeyError:
+            raise CommandError(u"Invalid course_key: '%s'." % raw_value)
+
+        if not isinstance(result, CourseLocator):
+            raise CommandError(u"Argument {0} is not a course key".format(raw_value))
+
+        return result
+
+    def _get_migration_options(self, options):
+        """
+        Returns the command arguments configured via django admin.
+        """
+        force_update = options['force_update']
+        commit = options['commit']
+        courses_mode = get_mutually_exclusive_required_option(options, 'course_ids', 'all_courses', 'from_settings')
+        if courses_mode == 'all_courses':
+            course_keys = [course.id for course in modulestore().get_course_summaries()]
+        elif courses_mode == 'course_ids':
+            course_keys = list(map(self._parse_course_key, options['course_ids']))
+        else:
+            migration_settings = self._latest_settings()
+            if migration_settings.all_courses:
+                all_courses = [course.id for course in modulestore().get_course_summaries()]
+                # Following is to avoid re-rerunning migrations for the already enqueued courses.
+                # Although the migrations job is idempotent, but we need to track if the transcript migration
+                # job was initiated for specific course(s) in order to elevate load from the workers and for
+                # the job to be able identify the past enqueued courses.
+                migrated_courses = MigrationEnqueuedCourse.objects.all().values_list('course_id', flat=True)
+                non_migrated_courses = [
+                    course_key
+                    for course_key in all_courses
+                    if course_key not in migrated_courses
+                ]
+                # Course batch to be migrated.
+                course_keys = non_migrated_courses[:migration_settings.batch_size]
+
+                log.info(
+                    (u'[Transcript Migration] Courses(total): %s, '
+                     u'Courses(migrated): %s, Courses(non-migrated): %s, '
+                     u'Courses(migration-in-process): %s'),
+                    len(all_courses),
+                    len(migrated_courses),
+                    len(non_migrated_courses),
+                    len(course_keys),
+                )
+            else:
+                course_keys = parse_course_keys(migration_settings.course_ids.split())
+
+            force_update = migration_settings.force_update
+            commit = migration_settings.commit
+
+        return course_keys, force_update, commit
+
+    def _latest_settings(self):
+        """
+        Return the latest version of the TranscriptMigrationSetting
+        """
+        return TranscriptMigrationSetting.current()
+
+    def handle(self, *args, **options):
+        """
+        Invokes the migrate transcripts enqueue function.
+        """
+        migration_settings = self._latest_settings()
+        course_keys, force_update, commit = self._get_migration_options(options)
+        command_run = migration_settings.increment_run() if commit else -1
+        enqueue_async_migrate_transcripts_tasks(
+            course_keys=course_keys, commit=commit, command_run=command_run, force_update=force_update
+        )
+
+        if commit and options.get('from_settings') and migration_settings.all_courses:
+            for course_key in course_keys:
+                enqueued_course, created = MigrationEnqueuedCourse.objects.get_or_create(course_id=course_key)
+                if created:
+                    enqueued_course.command_run = command_run
+                    enqueued_course.save()

--- a/cms/djangoapps/contentstore/management/commands/tests/test_migrate_transcripts.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_migrate_transcripts.py
@@ -1,0 +1,345 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for course transcript migration management command.
+"""
+
+
+import itertools
+import logging
+from datetime import datetime
+
+import ddt
+import pytz
+import six
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+from edxval import api as api
+from mock import patch
+from testfixtures import LogCapture
+
+from openedx.core.djangoapps.video_config.models import MigrationEnqueuedCourse, TranscriptMigrationSetting
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.video_module import VideoBlock
+from xmodule.video_module.transcripts_utils import save_to_store
+
+LOGGER_NAME = "cms.djangoapps.contentstore.tasks"
+
+SRT_FILEDATA = '''
+0
+00:00:00,270 --> 00:00:02,720
+sprechen sie deutsch?
+
+1
+00:00:02,720 --> 00:00:05,430
+Ja, ich spreche Deutsch
+
+2
+00:00:6,500 --> 00:00:08,600
+可以用“我不太懂艺术 但我知道我喜欢什么”做比喻
+'''
+
+CRO_SRT_FILEDATA = '''
+0
+00:00:00,270 --> 00:00:02,720
+Dobar dan!
+
+1
+00:00:02,720 --> 00:00:05,430
+Kako ste danas?
+
+2
+00:00:6,500 --> 00:00:08,600
+可以用“我不太懂艺术 但我知道我喜欢什么”做比喻
+'''
+
+
+VIDEO_DICT_STAR = dict(
+    client_video_id='TWINKLE TWINKLE',
+    duration=42.0,
+    edx_video_id='test_edx_video_id',
+    status='upload',
+)
+
+
+class TestArgParsing(TestCase):
+    """
+    Tests for parsing arguments for the `migrate_transcripts` management command
+    """
+    def test_no_args(self):
+        errstring = "Must specify exactly one of --course_ids, --all_courses, --from_settings"
+        with self.assertRaisesRegex(CommandError, errstring):
+            call_command('migrate_transcripts')
+
+    def test_invalid_course(self):
+        errstring = "Invalid course_key: 'invalid-course'."
+        with self.assertRaisesRegex(CommandError, errstring):
+            call_command('migrate_transcripts', '--course-id', 'invalid-course')
+
+
+@ddt.ddt
+class TestMigrateTranscripts(ModuleStoreTestCase):
+    """
+    Tests migrating video transcripts in courses from contentstore to django storage
+    """
+    def setUp(self):
+        """ Common setup. """
+        super(TestMigrateTranscripts, self).setUp()
+        self.store = modulestore()
+        self.course = CourseFactory.create()
+        self.course_2 = CourseFactory.create()
+
+        video = {
+            'edx_video_id': 'test_edx_video_id',
+            'client_video_id': 'test1.mp4',
+            'duration': 42.0,
+            'status': 'upload',
+            'courses': [six.text_type(self.course.id)],
+            'encoded_videos': [],
+            'created': datetime.now(pytz.utc)
+        }
+        api.create_video(video)
+
+        video_sample_xml = '''
+            <video display_name="Test Video"
+                   edx_video_id="test_edx_video_id"
+                   youtube="1.0:p2Q6BrNhdh8,0.75:izygArpw-Qo,1.25:1EeWXzPdhSA,1.5:rABDYkeK0x8"
+                   show_captions="false"
+                   download_track="false"
+                   start_time="1.0"
+                   download_video="false"
+                   end_time="60.0">
+              <source src="http://www.example.com/source.mp4"/>
+              <track src="http://www.example.com/track"/>
+              <handout src="http://www.example.com/handout"/>
+              <transcript language="ge" src="subs_grmtran1.srt" />
+              <transcript language="hr" src="subs_croatian1.srt" />
+            </video>
+        '''
+
+        video_sample_xml_2 = '''
+            <video display_name="Test Video 2"
+                   edx_video_id="test_edx_video_id_2"
+                   youtube="1.0:p2Q6BrNhdh8,0.75:izygArpw-Qo,1.25:1EeWXzPdhSA,1.5:rABDYkeK0x8"
+                   show_captions="false"
+                   download_track="false"
+                   start_time="1.0"
+                   download_video="false"
+                   end_time="60.0">
+              <source src="http://www.example.com/source.mp4"/>
+              <track src="http://www.example.com/track"/>
+              <handout src="http://www.example.com/handout"/>
+              <transcript language="ge" src="not_found.srt" />
+            </video>
+        '''
+        self.video_descriptor = ItemFactory.create(
+            parent_location=self.course.location, category='video',
+            **VideoBlock.parse_video_xml(video_sample_xml)
+        )
+        self.video_descriptor_2 = ItemFactory.create(
+            parent_location=self.course_2.location, category='video',
+            **VideoBlock.parse_video_xml(video_sample_xml_2)
+        )
+
+        save_to_store(SRT_FILEDATA, 'subs_grmtran1.srt', 'text/srt', self.video_descriptor.location)
+        save_to_store(CRO_SRT_FILEDATA, 'subs_croatian1.srt', 'text/srt', self.video_descriptor.location)
+
+    def test_migrated_transcripts_count_with_commit(self):
+        """
+        Test migrating transcripts with commit
+        """
+        # check that transcript does not exist
+        languages = api.get_available_transcript_languages(self.video_descriptor.edx_video_id)
+        self.assertEqual(len(languages), 0)
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+        # now call migrate_transcripts command and check the transcript availability
+        call_command('migrate_transcripts', '--course-id', six.text_type(self.course.id), '--commit')
+
+        languages = api.get_available_transcript_languages(self.video_descriptor.edx_video_id)
+        self.assertEqual(len(languages), 2)
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+    def test_migrated_transcripts_without_commit(self):
+        """
+        Test migrating transcripts as a dry-run
+        """
+        # check that transcripts do not exist
+        languages = api.get_available_transcript_languages(self.video_descriptor.edx_video_id)
+        self.assertEqual(len(languages), 0)
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+        # now call migrate_transcripts command and check the transcript availability
+        call_command('migrate_transcripts', '--course-id', six.text_type(self.course.id))
+
+        # check that transcripts still do not exist
+        languages = api.get_available_transcript_languages(self.video_descriptor.edx_video_id)
+        self.assertEqual(len(languages), 0)
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+    def test_migrate_transcripts_availability(self):
+        """
+        Test migrating transcripts
+        """
+        translations = self.video_descriptor.available_translations(self.video_descriptor.get_transcripts_info())
+        six.assertCountEqual(self, translations, ['hr', 'ge'])
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+        # now call migrate_transcripts command and check the transcript availability
+        call_command('migrate_transcripts', '--course-id', six.text_type(self.course.id), '--commit')
+
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+    def test_migrate_transcripts_idempotency(self):
+        """
+        Test migrating transcripts multiple times
+        """
+        translations = self.video_descriptor.available_translations(self.video_descriptor.get_transcripts_info())
+        six.assertCountEqual(self, translations, ['hr', 'ge'])
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertFalse(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+        # now call migrate_transcripts command and check the transcript availability
+        call_command('migrate_transcripts', '--course-id', six.text_type(self.course.id), '--commit')
+
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+        # now call migrate_transcripts command again and check the transcript availability
+        call_command('migrate_transcripts', '--course-id', six.text_type(self.course.id), '--commit')
+
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+        # now call migrate_transcripts command with --force-update and check the transcript availability
+        call_command('migrate_transcripts', '--course-id', six.text_type(self.course.id), '--force-update', '--commit')
+
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'hr'))
+        self.assertTrue(api.is_transcript_available(self.video_descriptor.edx_video_id, 'ge'))
+
+    def test_migrate_transcripts_logging(self):
+        """
+        Test migrate transcripts logging and output
+        """
+        course_id = six.text_type(self.course.id)
+        expected_log = (
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [run=-1] [video-transcripts-migration-process-started-for-course] '
+                 u'[course={}]'.format(course_id))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [run=-1] [video-transcript-will-be-migrated] '
+                 u'[revision=rev-opt-published-only] [video={}] [edx_video_id=test_edx_video_id] '
+                 u'[language_code=hr]'.format(self.video_descriptor.location))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [run=-1] [video-transcript-will-be-migrated] '
+                 u'[revision=rev-opt-published-only] [video={}] [edx_video_id=test_edx_video_id] '
+                 u'[language_code=ge]'.format(self.video_descriptor.location))
+            ),
+            # Tahoe: Added because we don't use tasks anymore
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [run=-1] [video-transcripts-migration-complete-for-a-video] '
+                 u'[tasks_count=2] [course_id={}] '
+                 u'[revision=rev-opt-published-only] [video={}]'.format(course_id, self.video_descriptor.location))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [run=-1] [transcripts-migration-tasks-submitted] '
+                 u'[transcripts_count=2] [course={}] '
+                 u'[revision=rev-opt-published-only] [video={}]'.format(course_id, self.video_descriptor.location))
+            )
+        )
+
+        with LogCapture(LOGGER_NAME, level=logging.INFO) as logger:
+            call_command('migrate_transcripts', '--course-id', six.text_type(self.course.id))
+            logger.check(
+                *expected_log
+            )
+
+    def test_migrate_transcripts_exception_logging(self):
+        """
+        Test migrate transcripts exception logging
+        """
+        course_id = six.text_type(self.course_2.id)
+        expected_log = (
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [run=1] [video-transcripts-migration-process-started-for-course] '
+                 u'[course={}]'.format(course_id))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [run=1] [transcripts-migration-process-started-for-video-transcript] '
+                 u'[revision=rev-opt-published-only] [video={}] [edx_video_id=test_edx_video_id_2] '
+                 u'[language_code=ge]'.format(self.video_descriptor_2.location))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'ERROR',
+                (u'[Transcript Migration] [run=1] [video-transcript-migration-failed-with-known-exc] '
+                 u'[revision=rev-opt-published-only] [video={}] [edx_video_id=test_edx_video_id_2] '
+                 u'[language_code=ge]'.format(self.video_descriptor_2.location))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [run=1] [video-transcripts-migration-complete-for-a-video] '
+                 u'[tasks_count=1] [course_id={}] '
+                 u'[revision=rev-opt-published-only] [video={}]'.format(course_id, self.video_descriptor_2.location))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [run=1] [transcripts-migration-tasks-submitted] '
+                 u'[transcripts_count=1] [course={}] '
+                 u'[revision=rev-opt-published-only] [video={}]'.format(course_id, self.video_descriptor_2.location))
+            )
+        )
+
+        with LogCapture(LOGGER_NAME, level=logging.INFO) as logger:
+            call_command('migrate_transcripts', '--course-id', six.text_type(self.course_2.id), '--commit')
+            logger.check(
+                *expected_log
+            )
+
+    @ddt.data(*itertools.product([1, 2], [True, False], [True, False]))
+    @ddt.unpack
+    @patch('contentstore.management.commands.migrate_transcripts.log')
+    def test_migrate_transcripts_batch_size(self, batch_size, commit, all_courses, mock_logger):
+        """
+        Test that migrations across course batches, is working as expected.
+        """
+        migration_settings = TranscriptMigrationSetting.objects.create(
+            batch_size=batch_size, commit=commit, all_courses=all_courses
+        )
+
+        # Assert the number of job runs and migration enqueued courses.
+        self.assertEqual(migration_settings.command_run, 0)
+        self.assertEqual(MigrationEnqueuedCourse.objects.count(), 0)
+
+        call_command('migrate_transcripts', '--from-settings')
+
+        migration_settings = TranscriptMigrationSetting.current()
+        # Command run is only incremented if commit=True.
+        expected_command_run = 1 if commit else 0
+        self.assertEqual(migration_settings.command_run, expected_command_run)
+
+        if all_courses:
+            mock_logger.info.assert_called_with(
+                (u'[Transcript Migration] Courses(total): %s, Courses(migrated): %s, '
+                 u'Courses(non-migrated): %s, Courses(migration-in-process): %s'),
+                2, 0, 2, batch_size
+            )
+
+        # enqueued courses are only persisted if commit=True and job is running for all courses.
+        enqueued_courses = batch_size if commit and all_courses else 0
+        self.assertEqual(MigrationEnqueuedCourse.objects.count(), enqueued_courses)


### PR DESCRIPTION
RED-2378. This is useful to resolve the `NotFoundError` for transcripts since they haven't been migrated.

More info in my Open edX discussion post: https://discuss.openedx.org/t/add-edxval-records-to-old-courses/5666

### Partial revert:
   - Reverts the d1a043f "Remove video thumbnail and transcript tasks using chord_task." commit
   - This commit doesn't include the `video_thumbnails` command and its tasks


### TODO

  - [x] Tests should pass
  - [x] Try on devstack