### PR TITLE
Fixed email activation fixes: missing end_anchor and remove email again

### DIFF
--- a/common/templates/student/edx_ace/accountactivation/email/body.html
+++ b/common/templates/student/edx_ace/accountactivation/email/body.html
@@ -50,7 +50,7 @@
                 {% blocktrans trimmed asvar assist_msg %}
                 If you need help, please use our web form at {start_anchor_web}{{ support_url }}{end_anchor}.
                 {% endblocktrans %}
-                {% interpolate_html assist_msg start_anchor_web='<a href="'|add:support_url|add:'">'|safe %}
+                {% interpolate_html assist_msg start_anchor_web='<a href="'|add:support_url|add:'">'|safe end_anchor='</a>'|safe %}
                 <br />
             </p>
         </td>

--- a/common/templates/student/edx_ace/accountactivation/email/body.txt
+++ b/common/templates/student/edx_ace/accountactivation/email/body.txt
@@ -5,7 +5,7 @@
 
 {% blocktrans %}Enjoy learning with {{ platform_name }}.{% endblocktrans %}
 
-{% blocktrans %}If you need help, please use our web form at {{ support_url }} or email {{ contact_email }}.{% endblocktrans %}
+{% blocktrans %}If you need help, please use our web form at {{ support_url }}.{% endblocktrans %}
 
 {% blocktrans %}This email message was automatically sent by {{ lms_url }} because someone attempted to create an account on {{ platform_name }} using this email address.{% endblocktrans %}
 {% endautoescape %}


### PR DESCRIPTION
RED-2451

 - https://sentry.io/organizations/appsembler/issues/2601203777/?environment=staging&project=145493&referrer=alert_email
