### PR TITLE
use /help for PASSWORD_RESET_SUPPORT_LINK

### DIFF
--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -108,6 +108,11 @@ class SiteConfiguration(models.Model):
             root_url=self.site_values['LMS_ROOT_URL'],
         )
 
+        # RED-2471: Use Multi-tenant `/help` URL for password reset emails.
+        self.site_values['PASSWORD_RESET_SUPPORT_LINK'] = '{root_url}/help'.format(
+            root_url=self.site_values['LMS_ROOT_URL'],
+        )
+
         super(SiteConfiguration, self).save(**kwargs)
 
         # recompile SASS on every save

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -74,6 +74,8 @@ class SiteConfigurationTests(TestCase):
                          self.expected_site_root_url)
         self.assertTrue(site_configuration.get_value('ACTIVATION_EMAIL_SUPPORT_LINK'))
         self.assertTrue(site_configuration.get_value('ACTIVATION_EMAIL_SUPPORT_LINK').endswith('/help'))
+        self.assertTrue(site_configuration.get_value('PASSWORD_RESET_SUPPORT_LINK'))
+        self.assertTrue(site_configuration.get_value('PASSWORD_RESET_SUPPORT_LINK').endswith('/help'))
 
     def test_get_value_for_org(self):
         """


### PR DESCRIPTION
## Change description
Update support link for password reset page to route from `/contact-us` to `/help`

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [RED-2471](https://appsembler.atlassian.net/browse/RED-2471)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
