### PR TITLE
beeline tracing for third_party_auth create_user pipeline

### DIFF
--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -57,7 +57,8 @@ def apply_settings(django_settings):
         'third_party_auth.pipeline.get_username',
         'third_party_auth.pipeline.set_pipeline_timeout',
         'third_party_auth.pipeline.ensure_user_information',
-        'social_core.pipeline.user.create_user',
+        # Tahoe: Intercept 'social_core.pipeline.user.create_user' with beeline logging.
+        'openedx.core.djangoapps.appsembler.tahoe_social_auth.pipeline.create_user_with_logs',
         'social_core.pipeline.social_auth.associate_user',
         'social_core.pipeline.social_auth.load_extra_data',
         'social_core.pipeline.user.user_details',

--- a/openedx/core/djangoapps/appsembler/tahoe_social_auth/__init__.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_social_auth/__init__.py
@@ -1,0 +1,3 @@
+"""
+A helper app for the third_party_auth.
+"""

--- a/openedx/core/djangoapps/appsembler/tahoe_social_auth/pipeline.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_social_auth/pipeline.py
@@ -1,0 +1,23 @@
+import beeline
+
+from social_core.pipeline.user import create_user
+
+
+@beeline.traced('tahoe_social_auth.create_user_with_logs')
+def create_user_with_logs(*args, **kwargs):
+    """
+    A proxy for social_core.pipeline.user.create_user with beeline monitoring.
+
+    :param args: whatever comes from the social auth pipeline.
+    :param kwargs: whatever comes from the social auth pipeline.
+    :return: result dict for social auth pipeline.
+    """
+    beeline.add_context_field('create_user__user_param', kwargs.get('user'))
+    result = create_user(*args, **kwargs)
+    user = result.get('user')
+
+    beeline.add_context_field('create_user_result', result)
+    beeline.add_context_field('is_new_user', result.get('is_new'))
+    beeline.add_context_field('create_user__username', getattr(user, 'username', None))
+
+    return result


### PR DESCRIPTION
This helps to discover errors in SSO SAML Membership not being created.

Jira issue: RED-2176

### Tests

 - [x] Enable the `third_party_auth` app tests done in #999 