### PR TITLE
RED-2368: fix course grading for all visibility options

### DIFF
--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -76,8 +76,13 @@ class CourseGradeBase(object):
             for subsection_grade in chapter['sections']:
                 if subsection_grade.graded:
                     graded_total = subsection_grade.graded_total
-                    if graded_total.possible > 0 and subsection_grade.show_grades(staff_access):
-                        subsections_by_format[subsection_grade.format][subsection_grade.location] = subsection_grade
+                    show_correctness = subsection_grade.show_correctness
+                    if show_correctness == 'past_due':
+                        if graded_total.possible > 0 and subsection_grade.show_grades(staff_access):
+                            subsections_by_format[subsection_grade.format][subsection_grade.location] = subsection_grade
+                    else:
+                        if graded_total.possible > 0:
+                            subsections_by_format[subsection_grade.format][subsection_grade.location] = subsection_grade
         return subsections_by_format
 
     @lazy

--- a/lms/djangoapps/grades/tests/base.py
+++ b/lms/djangoapps/grades/tests/base.py
@@ -105,7 +105,14 @@ class GradeTestBase(SharedModuleStoreTestCase):
                     "min_count": 1,
                     "drop_count": 0,
                     "short_label": "FE",
-                    "weight": 0.5,
+                    "weight": 0.25,
+                },
+                {
+                    "type": "Quiz",
+                    "min_count": 1,
+                    "drop_count": 0,
+                    "short_label": "QZ",
+                    "weight": 0.25,
                 },
                 {
                     "type": "NoCredit",


### PR DESCRIPTION
## Change description
This PR fixes the bug that was introduced from PR #943 where grades for subsections marked as `Never show assessment results` stopped being calculated into the total course grade.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [RED-2368](https://appsembler.atlassian.net/browse/RED-2368) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
