### PR TITLE
Event tracking segment: log get_site_config_for_event exceptions + clean up

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -149,7 +149,7 @@ class DefaultMultipleSegmentClient(object):
             siteconfig = utils.get_site_config_for_event(event_props)
             if siteconfig:
                 site_segment_key = siteconfig.get_value('SEGMENT_KEY', None)
-        except (IndexError, exceptions.EventProcessingError) as e:
+        except (IndexError, exceptions.EventProcessingError):
             try:
                 event_name = args[1]
             except IndexError:

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -15,6 +15,8 @@ of functionality). Yes, naming matters.
 Where? appsembler.eventracking.sites is a likely candidate as the purpose of the
 `get_site_config_for_event` is specific to sites.
 """
+
+import logging
 from django.core.exceptions import MultipleObjectsReturned
 
 from openedx.core.djangoapps.site_configuration.helpers import (
@@ -24,6 +26,9 @@ from openedx.core.djangoapps.site_configuration.helpers import (
 from openedx.core.djangoapps.appsembler.eventtracking.exceptions import (
     EventProcessingError
 )
+
+
+log = logging.getLogger(__name__)
 
 
 def get_site_config_for_event(event_props):
@@ -74,5 +79,6 @@ def get_site_config_for_event(event_props):
             MultipleObjectsReturned,
             Organization.DoesNotExist
         ) as e:
+            log.exception('get_site_config_for_event: Cannot get site config for event. props=`%s`', repr(event_props))
             raise EventProcessingError(e)
     return site_configuration


### PR DESCRIPTION
This log is useful to debug cases like RED-2487 in which customer segment isn't receiving the error but the main segment receives it.

I did some test refactoring to make use of `caplog`. Not sure what's the Python standard/nosetest equivalent of `caplog`.