### PR TITLE
Fix 500 error on `/courses` search due to stale ElasticSearch indexes

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -112,7 +112,7 @@ edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
 edx-proctoring==2.4.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.2.1           # via edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
-https://github.com/appsembler/edx-search/archive/1.3.4-appsembler5.tar.gz  # edx-search==1.3.4
+https://github.com/appsembler/edx-search/archive/1.3.4-appsembler6.tar.gz  # edx-search==1.3.4
 edx-sga==0.11.0           # via -r requirements/edx/base.in
 edx-submissions==3.1.7    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -125,7 +125,7 @@ edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
 edx-proctoring==2.4.0     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.2.1           # via -r requirements/edx/testing.txt, edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
-https://github.com/appsembler/edx-search/archive/1.3.4-appsembler5.tar.gz  # edx-search==1.3.4
+https://github.com/appsembler/edx-search/archive/1.3.4-appsembler6.tar.gz  # edx-search==1.3.4
 edx-sga==0.11.0           # via -r requirements/edx/testing.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
 edx-submissions==3.1.7    # via -r requirements/edx/testing.txt, ora2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -122,7 +122,7 @@ edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
 edx-proctoring==2.4.0     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.2.1           # via -r requirements/edx/base.txt, edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
-https://github.com/appsembler/edx-search/archive/1.3.4-appsembler5.tar.gz  # edx-search==1.3.4
+https://github.com/appsembler/edx-search/archive/1.3.4-appsembler6.tar.gz  # edx-search==1.3.4
 edx-sga==0.11.0           # via -r requirements/edx/base.txt
 edx-submissions==3.1.7    # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/base.txt, edx-enterprise


### PR DESCRIPTION
RED-2440. Updates `edx-search` to include https://github.com/appsembler/edx-search/pull/23