### PR TITLE
Use `course_key` in `get_site_config_for_event` for Segment events

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/tests/test_utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tests/test_utils.py
@@ -40,7 +40,7 @@ def test_gets_site_config():
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('context_key', ['org', 'course_id'])
+@pytest.mark.parametrize('context_key', ['org', 'course_id', 'course_key'])
 def test_event_has_site_context(context_key):
     """
     A bit about the event dict.
@@ -51,8 +51,11 @@ def test_event_has_site_context(context_key):
     org = OrganizationFactory(sites=[site_config.site])
     org_course = OrganizationCourseFactory(organization=org)
 
-    site_context = dict(org=org.short_name,
-                        course_id=str(org_course.course_id))
+    site_context = dict(
+        org=org.short_name,
+        course_id=str(org_course.course_id),
+        course_key=str(org_course.course_id),
+    )
 
     event_props = {context_key: site_context[context_key]}
     with patch(EVENTTRACKING_MODULE + '.utils.get_current_site_configuration',

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -58,14 +58,17 @@ def get_site_config_for_event(event_props):
                 org_name = event_props['org']
                 org = Organization.objects.get(short_name=org_name)
             # try by OrganizationCourse relationship if event has a course_id property
-            elif 'course_id' in event_props:
-                course_id = event_props['course_id']
+            elif 'course_id' in event_props or 'course_key' in event_props:
+                if 'course_id' in event_props:
+                    course_id = event_props['course_id']
+                else:
+                    course_id = event_props['course_key']
                 # allow to fail if more than one Organization to avoid sharing data
                 org = Organization.objects.get(
                     organizationcourse__course_id=str(course_id))
             else:
                 raise EventProcessingError(
-                    "There isn't and org or course_id attribute set in the "
+                    "There isn't and org, course_key or course_id attribute set in the "
                     "segment event, so we couldn't determine the site."
                 )
             # Same logic as in 'appsembler.sites.utils.get_site_by_organization'


### PR DESCRIPTION
* **Jira issue:** RED-2487

This an attempt to fix the error below:

```
Error retrieving Site SEGMENT_KEY. Cannot send event edx.librarycontentblock.content.assigned to Site's Segment account. Sending only to main Segment client. Error was:
Traceback (most recent call last):
  File "lms/djangoapps/grades/course_grade_factory.py", line 54, in read
    return self._read(user, course_data)
  File "lms/djangoapps/grades/course_grade_factory.py", line 155, in _read
    raise PersistentCourseGrade.DoesNotExist
lms.djangoapps.grades.models.PersistentCourseGrade.DoesNotExist

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "common/djangoapps/track/shim.py", line 149, in _get_site_segment_key
    siteconfig = utils.get_site_config_for_event(event_props)
  File "openedx/core/djangoapps/appsembler/eventtracking/utils.py", line 63, in get_site_config_for_event
    "There isn't and org or course_id attribute set in the "
openedx.core.djangoapps.appsembler.eventtracking.exceptions.EventProcessingError: There isn't and org or course_id attribute set in the segment event, so we couldn't determine the site.
```
