### PR TITLE
Log `is_active` in `tahoe_social_auth.create_user_with_logs`

### DIFF
--- a/openedx/core/djangoapps/appsembler/tahoe_social_auth/pipeline.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_social_auth/pipeline.py
@@ -19,5 +19,6 @@ def create_user_with_logs(*args, **kwargs):
     beeline.add_context_field('create_user_result', result)
     beeline.add_context_field('is_new_user', result.get('is_new'))
     beeline.add_context_field('create_user__username', getattr(user, 'username', None))
+    beeline.add_context_field('create_user__is_active', getattr(user, 'is_active', 'N/A'))
 
     return result


### PR DESCRIPTION
Monitoring for beeline to debug RED-2176.
