### PR TITLE
notify edx-configs when main or prod get updated

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,23 @@
+name: Dispatch Notify
+
+on:
+  push:
+    branches:
+      - main
+      - prod
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: appsembler/edx-configs
+          event-type: edx-platform-${{ steps.extract_branch.outputs.branch }}
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Following https://github.com/appsembler/edx-configs/pull/1185 (and https://github.com/appsembler/edx-configs/pull/1184 and https://github.com/appsembler/edx_deploy/pull/23).

When `main` or `prod` branches here are updated, this fires off a `edx-platform-main` or `edx-platform-prod` event to the `edx-configs` repo.  Dispatch handler workflows in that repo can respond however they like; currently, with those other PRs, it will update Sandbox's `server-vars.yml` to point to the new SHA1, but the idea is that it could also update other configs automatically as well.