### PR TITLE
Esther/get value logging

### DIFF
--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -134,7 +134,11 @@ class SiteConfiguration(models.Model):
         """
         if self.enabled:
             try:
-                return self.site_values.get(name, default)
+                site_value = self.site_values.get(name, default)
+                if site_value is not None:
+                    return site_value
+                else:
+                    logger.info(u"Site Configuration key <%s> missing for site <%s>.", name, self.site)
             except AttributeError as error:
                 logger.exception(u'Invalid JSON data. \n [%s]', error)
         else:

--- a/openedx/core/djangoapps/site_configuration/tests/test_models.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_models.py
@@ -194,6 +194,19 @@ class SiteConfigurationTests(TestCase):
         )
         self.assertEqual(site_configuration.get_value("SITE_NAME", "Default Site Name"), "Default Site Name")
 
+    def test_get_value_none_logging(self):
+        """
+        Test that get_value logs missing key
+        """
+        site_configuration = SiteConfigurationFactory.create(
+            site=self.site,
+            site_values=self.test_config1
+        )
+        with self.assertLogs() as captured:
+            site_configuration.get_value("non_existent_name")
+        self.assertEqual(len(captured.records), 1)
+        self.assertEqual(captured.records[0].getMessage(), "Site Configuration key <non_existent_name> missing for site <{}>.".format(site_configuration.site))
+
     @unittest.skip("Custom save method incompatible with saving a list")
     def test_invalid_data_error_on_get_value(self):
         """


### PR DESCRIPTION
## Change description

Add logging for when `SiteConfiguration.get_value(config_name)` gets called and the `config_name` does not exist for site

