### PR TITLE
Remove coveralls.io due to major outage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,20 +41,4 @@ jobs:
         pip install tox tox-pip-version
     - name: Run tox
       run: |
-        PYTEST_ARGS='--cov=.' tox -e ${{ matrix.tox-env }}
-    - name: Coveralls
-      uses: AndreMiras/coveralls-python-action@v20201129
-      if: ${{ matrix.tox-env != 'pep8' }}
-      with:
-        parallel: true
-        flag-name: Unit Test
-
-  coveralls_finish:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: AndreMiras/coveralls-python-action@v20201129
-      with:
-        flag-name: Unit Tests
-        parallel-finished: true
+        tox -e ${{ matrix.tox-env }}


### PR DESCRIPTION
https://status.coveralls.io/incidents/ppvnbpd172gy

This commit can be reverted later.