### PR TITLE
Add coveralls.io back after a major outage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,20 @@ jobs:
         pip install tox tox-pip-version
     - name: Run tox
       run: |
-        tox -e ${{ matrix.tox-env }}
+        PYTEST_ARGS='--cov=.' tox -e ${{ matrix.tox-env }}
+    - name: Coveralls
+      uses: AndreMiras/coveralls-python-action@v20201129
+      if: ${{ matrix.tox-env != 'pep8' }}
+      with:
+        parallel: true
+        flag-name: Unit Test
+
+  coveralls_finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: AndreMiras/coveralls-python-action@v20201129
+      with:
+        flag-name: Unit Tests
+        parallel-finished: true


### PR DESCRIPTION
Reverts appsembler/edx-platform#1016 because coveralls.io has gone back up: https://status.coveralls.io/incidents/ppvnbpd172gy