### PR TITLE
Revert "Fix nested SAML exception"

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -94,10 +94,10 @@ class SAMLAuthBackend(SAMLAuth):  # pylint: disable=abstract-method
         except KeyError as ex:
             log.warning(
                 u'[THIRD_PARTY_AUTH] Error in SAML authentication flow. '
-                u'Provider: {idp_name}, Message:'.format(
+                u'Provider: {idp_name}, Message: {message}'.format(
+                    message=ex.message,
                     idp_name=response.get('idp_name')
-                ),
-                exc_info=True
+                )
             )
             raise IncorrectConfigurationException(self)
 


### PR DESCRIPTION
Reverts appsembler/edx-platform#964. 

This yet another attempt to fix the `RelayState` issues we're having (RED-2493).