### PR TITLE
Revert "Send account activation signal after SAML SSO workflow"

### DIFF
--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -196,12 +196,10 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
                 with patch('third_party_auth.pipeline.get', return_value=pipeline_partial):
                     with patch('third_party_auth.pipeline.running', return_value=True):
                         with patch('third_party_auth.is_enabled', return_value=True):
-                            with patch('third_party_auth.views.USER_ACCOUNT_ACTIVATED') as mock_signal:
-                                reg.skip_email_verification = True
-                                inactive_user_view(request)
-                                self.assertEqual(user.is_active, True)
-                                self.assertEqual(email.called, False, msg='method should not have been called')
-                                mock_signal.send_robust.assert_called_once_with(None, user=user), 'Verify signal'
+                            reg.skip_email_verification = True
+                            inactive_user_view(request)
+                            self.assertEqual(user.is_active, True)
+                            self.assertEqual(email.called, False, msg='method should not have been called')
 
     @patch('student.views.management.compose_activation_email')
     def test_send_email_to_inactive_user(self, email):

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -18,7 +18,6 @@ from student.models import UserProfile
 from student.views import compose_and_send_activation_email
 from third_party_auth import pipeline, provider
 
-from openedx.core.djangoapps.signals.signals import USER_ACCOUNT_ACTIVATED
 from .models import SAMLConfiguration, SAMLProviderConfig
 
 URL_NAMESPACE = getattr(settings, setting_name('URL_NAMESPACE'), None) or 'social'
@@ -55,8 +54,6 @@ def inactive_user_view(request):
             user.is_active = True
             user.save()
             activated = True
-            USER_ACCOUNT_ACTIVATED.send_robust(None, user=user)
-            beeline.add_context_field('activation_signal_sent', True)
     if not activated:
         compose_and_send_activation_email(user, profile)
         beeline.add_context_field('activation_email_sent', True)


### PR DESCRIPTION
Reverts https://github.com/appsembler/edx-platform/pull/959 (73fc86ecf546af4ae81a383e4e370cbaf0f64d3e).

This is being done for RED-2493. This pull request is an attempt to debug a recent problem with [SSO/SAML `RelayState` issue](https://appsembler.atlassian.net/l/c/1Q0JHBeC).