### PR TITLE
Revert "Tracking log events for successful login (first and third-party auth)"

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -83,7 +83,6 @@ from social_core.utils import module_member, slugify
 
 import third_party_auth
 from edxmako.shortcuts import render_to_string
-from eventtracking import tracker
 from lms.djangoapps.verify_student.models import SSOVerification
 from lms.djangoapps.verify_student.utils import earliest_allowed_verification_date
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -722,8 +721,9 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
 
 
 @partial.partial
-def login_analytics(strategy=None, backend=None, pipeline_index=None, current_partial=None, auth_entry=None, *args, **kwargs):
-    """ Sends login info to Segment (bi) and event tracking backends."""
+def login_analytics(strategy, auth_entry, current_partial=None, *args, **kwargs):
+    """ Sends login info to Segment """
+
     event_name = None
     if auth_entry == AUTH_ENTRY_LOGIN:
         event_name = 'edx.bi.user.account.authenticated'
@@ -734,41 +734,8 @@ def login_analytics(strategy=None, backend=None, pipeline_index=None, current_pa
         segment.track(kwargs['user'].id, event_name, {
             'category': "conversion",
             'label': None,
-            'provider': backend.name
+            'provider': kwargs['backend'].name
         })
-
-    # .. pii: Username, possibly any other social login data including fullname, email, profile URLs, 'other' possible PII sent with social auth.  Retirement will depend on configured event-tracking backends.  PII sent to Segment retired directly through Segment API call in Tubular. Tracking logs retained.   # pylint: disable=line-too-long
-    # .. pii_types: name, username, email_address, birth_date, external_service, image, other
-    # .. pii_retirement: retained, third_party
-    user = kwargs['user']
-    track_data = {
-        'user_id': user.id,
-        'username': user.username,
-        'auth_data': {
-            'tpa_auth_entry': auth_entry,
-            'tpa_provider': backend.name,
-        }
-    }
-
-    # re: PII: Of default enabled social auth backends, only SAML, by default, saves all extra_data
-    # to UserSocialAuth.  This can be configured in SAMLConfiguration object by setting
-    # GET_ALL_EXTRA_DATA to False.  Individual extra_data fields can be specified for storage by
-    # overriding other_config_str in SAMLConfiguration.
-    try:
-        user_social_auth = social_django.models.UserSocialAuth.objects.get(user=user)
-        track_data['auth_data'].update({
-            'tpa_social_uid': user_social_auth.uid,
-            'tpa_social_extra_data': user_social_auth.extra_data
-        })
-    except social_django.models.UserSocialAuth.NotFound:
-        pass
-
-    track_event_name = 'edx.user.account.authenticated'
-    user_tpa_context = dict()
-    user_tpa_context.update(tracker.get_tracker().resolve_context())
-
-    with tracker.get_tracker().context(track_event_name, user_tpa_context):
-        tracker.emit(name=track_event_name, data=track_data)
 
 
 @partial.partial

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -7,7 +7,6 @@ import unittest
 import ddt
 import mock
 
-from lms.djangoapps.program_enrollments.management.commands.tests.utils import UserSocialAuthFactory
 from third_party_auth import pipeline
 from third_party_auth.tests import testutil
 from third_party_auth.tests.specs.base import IntegrationTestMixin
@@ -99,61 +98,3 @@ class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, 
             mock_uuid.return_value = uuid4
             final_username = pipeline.get_username(strategy, details, self.provider.backend_class())
             self.assertEqual(expected_username, final_username['username'])
-
-
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
-class PipelineLoginAnalyticsTest(IntegrationTestMixin, testutil.TestCase):
-    """
-    Tests for login_analytics step in the TPA pipeline.
-    """
-
-    def setUp(self):
-        super(PipelineLoginAnalyticsTest, self).setUp()
-        self.provider = self.configure_dummy_provider(
-            enabled=True,
-            name="Test Dummy Provider",
-            slug='test',
-            backend_name='dummy'
-        )
-
-    def test_tpa_login_tracking_event(self):
-        """
-        Test successful third party auth login produces correct tracking log event.
-        """
-        dummy_extra_data = {"foo_extra_1": "something", "foo_extra_2": "something else"}
-        social = UserSocialAuthFactory.create(slug=self.provider.slug)
-        user = social.user
-        uid = social.uid
-        social.extra_data = dummy_extra_data
-        social.save()
-        expected_track_data = {
-            'user_id': user.id,
-            'username': user.username,
-            'auth_data': {
-                'tpa_auth_entry': pipeline.AUTH_ENTRY_LOGIN,
-                'tpa_provider': 'dummy',
-                'tpa_social_uid': uid,
-                'tpa_social_extra_data': dummy_extra_data
-            }
-        }
-        expected_segment_track_props = {
-            'category': "conversion",
-            'label': None,
-            'provider': 'dummy'
-        }
-
-        __, strategy = self.get_request_and_strategy()
-        pipeline_kws = {'uid': social.uid, 'user': user, 'social': social}
-
-        # don't decorate whole test method with these since they can be called creating UserSocialAuth
-        with mock.patch("third_party_auth.pipeline.tracker.emit") as mock_tracker_emit:
-            with mock.patch("third_party_auth.pipeline.segment.track") as mock_segment_track:
-                pipeline.login_analytics(
-                    strategy=strategy, backend=self.provider.backend_class(),
-                    pipeline_index=0, auth_entry='login', **pipeline_kws
-                )
-                mock_tracker_emit.assert_called_once_with(name='edx.user.account.authenticated', data=expected_track_data)
-                mock_segment_track.assert_called_once_with(
-                    user.id, 'edx.bi.user.account.authenticated',
-                    expected_segment_track_props
-                )

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -24,7 +24,6 @@ from django.views.decorators.csrf import csrf_exempt, csrf_protect, ensure_csrf_
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_http_methods
 from edx_django_utils.monitoring import set_custom_metric
-from eventtracking import tracker
 from ratelimitbackend.exceptions import RateLimitException
 from rest_framework.views import APIView
 
@@ -315,22 +314,6 @@ def _track_user_login(user, request):
             'provider': None
         },
     )
-
-    # Send a standard event-tracking event
-    # .. pii: Username is sent to any configured event-tracking backend.  PII sent to Segment retired directly through Segment API call in Tubular. Tracking logs retained.   # pylint: disable=line-too-long
-    # .. pii_types: username
-    # .. pii_retirement: retained, third_party
-    track_data = {
-        'user_id': user.id,
-        'username': user.username,
-        'auth_data': {}
-    }
-
-    track_event_name = 'edx.user.account.authenticated'
-    context = tracker.get_tracker().resolve_context()
-
-    with tracker.get_tracker().context(track_event_name, context):
-        tracker.emit(name=track_event_name, data=track_data)
 
 
 def _check_user_auth_flow(site, user):


### PR DESCRIPTION
```
AttributeError: type object 'UserSocialAuth' has no attribute 'NotFound'
```

Reverts appsembler/edx-platform#1020. 