### PR TITLE
workaround for inconsistent page sizes

### DIFF
--- a/lms/static/js/discovery/collection.js
+++ b/lms/static/js/discovery/collection.js
@@ -8,7 +8,7 @@
         return Backbone.Collection.extend({
 
             model: CourseCard,
-            pageSize: 20,
+            pageSize: 40,  // Tahoe: RED-2571 hack: use 40 instead of 20 to hide a bug in course results with Course Access Groups.
             totalCount: 0,
             latestModelsCount: 0,
             searchTerm: '',


### PR DESCRIPTION
**Problem:**

When NOT logged in, the count at the top of the page says 20 courses, but only 16 actually show up on the page. You can search for the missing courses and they show up, so we do not think it's a course settings or Course Access Groups issue.

**Why this is happening?**

Course Access Groups filter (MySQL-based) isn’t working reliably with paginated results from ElasticSearch due to the use of two different database systems. This is a solvable problem, but no solution is easy.

**More details:** in RED-2571

**Fix:**
Bump the page size to 40 to hide the problem. Customers with more than 40 courses in the home page will also face this problem.
