### PR TITLE
fix: bug in activation email sent despite `send_activation_email=false`

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/helpers.py
+++ b/openedx/core/djangoapps/appsembler/api/helpers.py
@@ -24,7 +24,7 @@ def as_course_key(course_id):
 
 
 @beeline.traced(name='appsembler.skip_registration_email_for_registration_api')
-def skip_registration_email_for_registration_api(request):
+def skip_registration_email_for_registration_api(request, params):
     """
     Helper to check if the Registration API caller has requested email to be skipped.
 
@@ -34,7 +34,7 @@ def skip_registration_email_for_registration_api(request):
     skip_email = False
     if request and request.method == 'POST':
         # TODO: RED-1647 add TahoeAuthMixin permission checks
-        skip_email = not request.POST.get('send_activation_email', True)
+        skip_email = not params.get('send_activation_email', True)
         beeline.add_context_field('appsembler__skip_email', skip_email)
 
     return skip_email

--- a/openedx/core/djangoapps/appsembler/api/tests/test_helpers.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_helpers.py
@@ -63,4 +63,4 @@ class TestAPISendActivationEmail(TestCase):
 
         helper_path = 'openedx.core.djangoapps.user_authn.views.register.skip_registration_email_for_registration_api'
         with patch(helper_path, return_value=True):
-            assert _skip_activation_email(user, {}, None), 'API requested: email can be skipped by AMC admin'
+            assert _skip_activation_email(user, {}, None, {}), 'API requested: email can be skipped by AMC admin'

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_tahoe_skip_activation_email.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_tahoe_skip_activation_email.py
@@ -22,7 +22,7 @@ class TestSkipActivationEmail(TestCase):
         Test for Open edX vanilla behaviour regardless of Tahoe customization.
         """
         user = UserFactory.create()
-        assert _skip_activation_email(user, {}, None), 'Feature enabled: email should be skipped'
+        assert _skip_activation_email(user, {}, None, {}), 'Feature enabled: email should be skipped'
 
     @patch.dict('django.conf.settings.FEATURES', {'SKIP_EMAIL_VALIDATION': False})
     def test_feature_disabled(self):
@@ -30,7 +30,7 @@ class TestSkipActivationEmail(TestCase):
         Test for Open edX vanilla behaviour regardless of Tahoe customization.
         """
         user = UserFactory.create()
-        assert not _skip_activation_email(user, {}, None), 'Feature disabled: email should be sent'
+        assert not _skip_activation_email(user, {}, None, {}), 'Feature disabled: email should be sent'
 
     @patch.dict('django.conf.settings.FEATURES', {'SKIP_EMAIL_VALIDATION': False})
     def test_skip_for_amc_admin(self):
@@ -41,4 +41,4 @@ class TestSkipActivationEmail(TestCase):
 
         is_amc_admin_path = 'openedx.core.djangoapps.user_authn.views.register.is_request_for_amc_admin'
         with patch(is_amc_admin_path, return_value=True):
-            assert _skip_activation_email(user, {}, None), 'AMC admin: email should be skipped'
+            assert _skip_activation_email(user, {}, None, {}), 'AMC admin: email should be skipped'

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -224,7 +224,7 @@ def create_account_with_params(request, params):
 
     # Check if system is configured to skip activation email for the current user.
     skip_email = _skip_activation_email(
-        user, running_pipeline, third_party_provider,
+        user, running_pipeline, third_party_provider, params,
     )
 
     if skip_email:
@@ -364,7 +364,7 @@ def _track_user_registration(user, profile, params, third_party_provider):
         )
 
 
-def _skip_activation_email(user, running_pipeline, third_party_provider):
+def _skip_activation_email(user, running_pipeline, third_party_provider, params):
     """
     Return `True` if activation email should be skipped.
 
@@ -417,7 +417,7 @@ def _skip_activation_email(user, running_pipeline, third_party_provider):
     return (
         settings.FEATURES.get('SKIP_EMAIL_VALIDATION', None) or
         settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING') or
-        skip_registration_email_for_registration_api(get_current_request()) or
+        skip_registration_email_for_registration_api(get_current_request(), params) or
         is_request_for_amc_admin(get_current_request()) or
         (third_party_provider and third_party_provider.skip_email_verification and valid_email)
     )


### PR DESCRIPTION
Jira bug: RED-2438

Problem
-------

A customer confirmed that he is receiving both password reset and activation email.
Despite setting `"send_activation_email": false`.

The root-cause is that `request.POST` is immutable. The way we
workaround this is by using `POST.copy()` and using the mutable
dictionary.

However, in my (@omarithawi) Juniper refactoring of the
`_skip_activation_email` and extracting the `skip_registration_email_for_registration_api`
I forgot to pass the `.copy()`'ed `params` and used the `request.POST`
itself which don't allow writes:

 - Related PR with the bug: https://github.com/appsembler/edx-platform/pull/738 (commit: 8be4039642c5a549bed2de45da42b358970b20f3)

Tests problem
-------------
The bug existed since the Juniper upgrade but tests didn't catch the
issue because the `compose_and_send_activation_email` path have changed
resulting in incorrect mock.patch which made the `assert` useless.

Tests fix
---------
Fixed the `compose_and_send_activation_email` `patch` path and tests
started to fail -- revealing the bug reported by the customer.

Bug fix
-------
Pass the `.copy()`'ed `params` to both `_skip_activation_email` and `skip_registration_email_for_registration_api`,
which would make them read from the correct `send_activation_email` value.
