### PR TITLE
Use `exclude_paths` option to avoid counting translation merge conflicts

### DIFF
--- a/.github/workflows/report_conflicts.yml
+++ b/.github/workflows/report_conflicts.yml
@@ -9,6 +9,7 @@ jobs:
       local_base_branch: ${{ github.base_ref }}
       upstream_repo: 'https://github.com/edx/edx-platform.git'
       upstream_branch: 'master'
+      exclude_paths: 'cms/static/js/,conf/locale/,lms/static/js/,package.json,package-lock.json,.github/'
     secrets:
       github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -19,5 +20,6 @@ jobs:
       local_base_branch: ${{ github.base_ref }}
       upstream_repo: 'https://github.com/edx/edx-platform.git'
       upstream_branch: 'open-release/koa.master'
+      exclude_paths: 'cms/static/js/,conf/locale/,lms/static/js/,package.json,package-lock.json,.github/'
     secrets:
       github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
They don't matter in the report we resolve them by pulling from Transifex.

This should report thousands of resolved conflicts, which is a win I'd like to claim, but unfortunately not true.

I made this since I saw that overnight the conflicts with edX's `master` increased from 2800->3100 conflicts, which is just not reflecting the true number we're looking for: Python and JavaScript conflicts.

See: 
 - https://github.com/appsembler/action-conflict-counter/pull/4