### PR TITLE
WIP feat: change youtube api for the transcript

### DIFF
--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -253,7 +253,7 @@ def check_transcripts(request):
         youtube_transcript_name = youtube_video_transcript_name(youtube_text_api)
         if youtube_transcript_name:
             youtube_text_api['params']['name'] = youtube_transcript_name
-        youtube_response = requests.get('http://' + youtube_text_api['url'], params=youtube_text_api['params'])
+        youtube_response = requests.get('http://' + youtube_text_api['url'] + youtube_id, params=youtube_text_api['params'])
 
         if youtube_response.status_code == 200 and youtube_response.text:
             transcripts_presence['youtube_server'] = True

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -260,11 +260,7 @@ def check_transcripts(request):
         #check youtube local and server transcripts for equality
         if transcripts_presence['youtube_server'] and transcripts_presence['youtube_local']:
             try:
-                youtube_server_subs = get_transcripts_from_youtube(
-                    youtube_id,
-                    settings,
-                    item.runtime.service(item, "i18n")
-                )
+                youtube_server_subs = YouTubeTranscriptApi.get_transcript(youtube_id)
                 if json.loads(local_transcripts) == youtube_server_subs:  # check transcripts for equality
                     transcripts_presence['youtube_diff'] = False
             except GetTranscriptsFromYouTubeException:
@@ -408,7 +404,7 @@ def replace_transcripts(request):
         return error_response(response, 'YouTube id {} is not presented in request data.'.format(youtube_id))
 
     try:
-        download_youtube_subs(youtube_id, item, settings)
+        YouTubeTranscriptApi.get_transcript(youtube_id)
     except GetTranscriptsFromYouTubeException as e:
         return error_response(response, e.message)
 

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -10,6 +10,7 @@ import logging
 from pysrt import SubRipTime, SubRipItem, SubRipFile
 from lxml import etree
 from HTMLParser import HTMLParser
+from youtube_transcript_api import YouTubeTranscriptApi
 
 from xmodule.exceptions import NotFoundError
 from xmodule.contentstore.content import StaticContent
@@ -148,6 +149,7 @@ def get_transcripts_from_youtube(youtube_id, settings, i18n, youtube_transcript_
         raise GetTranscriptsFromYouTubeException(msg)
 
     sub_starts, sub_ends, sub_texts = [], [], []
+    data.content = YouTubeTranscriptApi.get_transcript(youtube_id)
     xmltree = etree.fromstring(data.content, parser=utf8_parser)
     for element in xmltree:
         if element.tag == "text":
@@ -184,10 +186,11 @@ def download_youtube_subs(youtube_id, video_descriptor, settings):
     i18n = video_descriptor.runtime.service(video_descriptor, "i18n")
     _ = i18n.ugettext
 
-    subs = get_transcripts_from_youtube(youtube_id, settings, i18n)
+    subs = YouTubeTranscriptApi.get_transcript(youtube_id)
     save_subs_to_store(subs, youtube_id, video_descriptor)
 
     log.info("Transcripts for youtube_id %s for 1.0 speed are downloaded and saved.", youtube_id)
+    return json.dumps(subs, indent=2)
 
 
 def remove_subs_from_store(subs_id, item, lang='en'):

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -810,6 +810,29 @@ XBLOCK_SETTINGS = ENV_TOKENS.get('XBLOCK_SETTINGS', {})
 XBLOCK_SETTINGS.setdefault("VideoDescriptor", {})["licensing_enabled"] = FEATURES.get("LICENSING", False)
 XBLOCK_SETTINGS.setdefault("VideoModule", {})['YOUTUBE_API_KEY'] = AUTH_TOKENS.get('YOUTUBE_API_KEY', YOUTUBE_API_KEY)
 YOUTUBE_API_KEY = AUTH_TOKENS.get('YOUTUBE_API_KEY', YOUTUBE_API_KEY)
+YOUTUBE = {
+    # YouTube JavaScript API
+    'API': 'https://www.youtube.com/iframe_api',
+
+    'TEST_TIMEOUT': 1500,
+
+    # URL to get YouTube metadata
+    'METADATA_URL': 'https://www.googleapis.com/youtube/v3/videos/',
+
+    # Current youtube api for requesting transcripts.
+    # For example: https://youtube.googleapis.com/youtube/v3/captions/j_jEn79vS3g?tfmt=srt&tlang=en&key=[YOUTUBE-API-KEY]
+    'TEXT_API': {
+        'url': 'youtube.googleapis.com/youtube/v3/captions/',
+        'params': {
+            'lang': 'en',
+            'v': 'set_youtube_id_of_11_symbols_here',
+            'tfmt': 'srt',
+            'key': YOUTUBE_API_KEY,
+        },
+    },
+
+    'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080
+}
 
 ######################### rate limit for yt_video_metadata api ############
 


### PR DESCRIPTION
Since Nov 15 we noticed the YouTube  transcript API is not working and after doing some research we found out the API openedx used to use for the transcript is not working anymore. For more information, take a look at [my comment in the corresponding Jira ticket](https://appsembler.atlassian.net/browse/BLACK-2163?focusedCommentId=40478&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-40478)
After some research, I found [youtube has new api](https://developers.google.com/youtube/v3/docs/captions/download?hl=en) for downloading caption.
In this PR, we are changing related pieces of `edx-platform` to use YouTube API for downloading captions.