### PR TITLE
allow theme to use site configs

### DIFF
--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -167,6 +167,27 @@ class SiteConfiguration(models.Model):
 
         return default
 
+    @beeline.traced('site_config.get_page_content')
+    def get_page_content(self, name, default=None):
+        """
+        Tahoe: Get page content from Site Configuration service settings.
+
+        If SiteConfiguration adapter isn't in use, fallback to the deprecated `SiteConfiguration.page_elements` field.
+
+        Args:
+            name (str): Name of the page to fetch.
+            default: default value to return if page is not found in the configuration.
+
+        Returns:
+            Page content `dict`.
+        """
+        if self.api_adapter:
+            beeline.add_context_field('page_source', 'site_config_service')
+            return self.api_adapter.get_amc_v1_page(name, default)
+        else:
+            beeline.add_context_field('page_source', 'django_model')
+            return self.page_elements.get(name, default)
+
     @classmethod
     def get_configuration_for_org(cls, org, select_related=None):
         """

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -122,6 +122,10 @@ class SiteConfigAPIClientTests(TestCase):
         "$brand-accent-color": "#7f8c8d",
     }
 
+    about_page = {
+        'title': 'About page from site configuration service',
+    }
+
     @classmethod
     def setUpClass(cls):
         super(SiteConfigAPIClientTests, cls).setUpClass()
@@ -132,6 +136,7 @@ class SiteConfigAPIClientTests(TestCase):
         cls.api_adapter = Mock(
             get_value=cls.test_config.get,
             get_amc_v1_theme_css_variables=Mock(return_value=cls.sass_variables),
+            get_amc_v1_page=Mock(return_value=cls.about_page),
         )
 
     def test_get_value_with_adapter(self):
@@ -156,3 +161,36 @@ class SiteConfigAPIClientTests(TestCase):
         )
         site_configuration.api_adapter = self.api_adapter
         assert site_configuration._formatted_sass_variables()
+
+    def test_page_content_without_adapter(self):
+        """
+        Test `get_page_content()` without the SiteConfig adapter.
+        """
+        site_configuration = SiteConfigurationFactory.create(
+            site=self.site,
+            page_elements={
+                'about': {
+                    'title': 'About page in Django model.',
+                },
+            },
+        )
+        assert site_configuration.get_page_content('about') == {
+            'title': 'About page in Django model.',
+        }
+
+    def test_page_content_with_adapter(self):
+        """
+        Ensure `get_page_content()` uses the SiteConfig adapter when available.
+        """
+        site_configuration = SiteConfigurationFactory.create(
+            site=self.site,
+            page_elements={
+                'about': {
+                    'title': 'About page in Django model.',
+                },
+            },
+        )
+        site_configuration.api_adapter = self.api_adapter
+        assert site_configuration.get_page_content('about') == {
+            'title': 'About page from site configuration service',
+        }


### PR DESCRIPTION
RED-2511. 

New `get_page_content()` method to use the SiteConfigAdapter when available in theme.

### Related PRs:

 - Unblocks: https://github.com/appsembler/edx-theme-customers/pull/172