### PR TITLE
report git conflict fix: `github_token` is reserved

### DIFF
--- a/.github/workflows/report_conflicts.yml
+++ b/.github/workflows/report_conflicts.yml
@@ -11,7 +11,7 @@ jobs:
       upstream_branch: 'master'
       exclude_paths: 'cms/static/js/,conf/locale/,lms/static/js/,package.json,package-lock.json,.github/'
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      custom_github_token: ${{ secrets.GITHUB_TOKEN }}
 
   report_koa:
     name: 'koa'
@@ -22,4 +22,4 @@ jobs:
       upstream_branch: 'open-release/koa.master'
       exclude_paths: 'cms/static/js/,conf/locale/,lms/static/js/,package.json,package-lock.json,.github/'
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      custom_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Renaming `github_token` to `custom_github_token` to avoid syntax error.

 - Needs: https://github.com/appsembler/action-conflict-counter/pull/8 