### PR TITLE
fix: use tahoe-auth0 backend only on sites with feature flag

### DIFF
--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -4,13 +4,14 @@
 import re
 import unittest
 
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import connections, DEFAULT_DB_ALIAS
 from django.test.utils import CaptureQueriesContext
 from mock import Mock, patch
 
-from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration, with_site_configuration_context
-from third_party_auth import provider, models
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
+from third_party_auth import provider
 from third_party_auth.tests import testutil
 
 SITE_DOMAIN_A = 'professionalx.example.com'
@@ -78,7 +79,7 @@ class RegistryTest(testutil.TestCase):
         with patch('third_party_auth.provider._PSA_OAUTH2_BACKENDS', backend_names):
             self.assertEqual(sorted(provider_names), [prov.name for prov in provider.Registry.enabled()])
 
-    @unittest.expectedFailure  # Tahoe: Skip this performance since we query sites a lot.
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Tahoe: Skip this performance test since we query sites a lot.')
     def test_enabled_doesnt_query_site(self):
         """Regression test for 1+N queries for django_site (ARCHBOM-1139)"""
         re_django_site_query = re.compile(r'FROM\s+"django_site"')
@@ -160,54 +161,8 @@ class RegistryTest(testutil.TestCase):
         prov = self.configure_google_provider(visible=True, enabled=True, site=Site.objects.get_current())
         self.assertEqual(prov.enabled_for_current_site, True)
 
-    def test_is_auth0_disabled_for_no_tahoe_auth0(self):
-        prov = self.configure_oauth_provider(enabled=True, backend_name="dummy")
-
-        with with_site_configuration_context(configuration={"ENABLE_TAHOE_AUTH0": True}):
-            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": True}):
-                self.assertEqual(prov.enabled_for_current_site, False)
-
-    def test_is_auth0_enabled_for_site_configuration(self):
-        """
-        Verify that Tahoe Auth0 is enabled when the Site Configuration asks for it.
-        """
-        prov = self.configure_oauth_provider(enabled=True, backend_name="tahoe-auth0")
-
-        with with_site_configuration_context(configuration={"ENABLE_TAHOE_AUTH0": True}):
-            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": True}):
-                self.assertEqual(prov.enabled_for_current_site, True)
-
-            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": False}):
-                self.assertEqual(prov.enabled_for_current_site, True)
-
-    def test_is_auth0_publicly_configured(self):
-        """
-        Verify that Tahoe Auth0 is enabled or disabled based on the public setting
-        if the Site Configuration doesn't specify a custom value.
-        """
-        prov = self.configure_oauth_provider(enabled=True, backend_name="tahoe-auth0")
-
-        with with_site_configuration_context(configuration={}):
-            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": True}):
-                self.assertEqual(prov.enabled_for_current_site, True)
-
-            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": False}):
-                self.assertEqual(prov.enabled_for_current_site, False)
-
     @with_site_configuration(SITE_DOMAIN_A)
-    @patch.object(models.ProviderConfig, "is_auth0_enabled", return_value=True)
-    def test_provider_enabled_for_mismatching_site_with_auth0_enabled(self, mock_is_auth0_enabled):
-        """
-        Verify that enabled_for_current_site returns True when Auth0 provider is configured
-        for a different site.
-        """
-        site_b = Site.objects.get_or_create(domain=SITE_DOMAIN_B, name=SITE_DOMAIN_B)[0]
-        prov = self.configure_oauth_provider(enabled=True, site=site_b, backend_name="tahoe-auth0")
-        self.assertEqual(prov.enabled_for_current_site, True)
-
-    @with_site_configuration(SITE_DOMAIN_A)
-    @patch.object(models.ProviderConfig, "is_auth0_enabled", return_value=False)
-    def test_provider_disabled_for_mismatching_site(self, mock_is_auth0_enabled):
+    def test_provider_disabled_for_mismatching_site(self):
         """
         Verify that enabled_for_current_site returns False when the provider is configured for a different site.
         """

--- a/common/djangoapps/third_party_auth/tests/test_tahoe_auth0_provider_hack.py
+++ b/common/djangoapps/third_party_auth/tests/test_tahoe_auth0_provider_hack.py
@@ -1,0 +1,94 @@
+"""
+Tests for the hacks we have to enable the tahoe-auth0 package.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import ddt
+from django.contrib.sites.models import Site
+
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
+from third_party_auth.tests import testutil
+
+SITE_DOMAIN_A = 'professionalx.example.com'
+SITE_DOMAIN_B = 'somethingelse.example.com'
+
+
+@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@ddt.ddt
+class TahoeAuth0IntegrationHackTests(testutil.TestCase):
+    """Tests registry discovery and operation."""
+
+    def test_is_auth0_disabled_for_no_tahoe_auth0(self):
+        prov = self.configure_oauth_provider(enabled=True, backend_name="dummy")
+
+        with with_site_configuration_context(configuration={"ENABLE_TAHOE_AUTH0": True}):
+            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": True}):
+                self.assertEqual(prov.enabled_for_current_site, False)
+
+    def test_is_auth0_enabled_for_site_configuration(self):
+        """
+        Verify that Tahoe Auth0 is enabled when the Site Configuration asks for it.
+        """
+        prov = self.configure_oauth_provider(enabled=True, backend_name="tahoe-auth0")
+
+        with with_site_configuration_context(configuration={"ENABLE_TAHOE_AUTH0": True}):
+            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": True}):
+                self.assertEqual(prov.enabled_for_current_site, True)
+
+            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": False}):
+                self.assertEqual(prov.enabled_for_current_site, True)
+
+    def test_is_auth0_publicly_configured(self):
+        """
+        Verify that Tahoe Auth0 is enabled or disabled based on the public setting
+        if the Site Configuration doesn't specify a custom value.
+        """
+        prov = self.configure_oauth_provider(enabled=True, backend_name="tahoe-auth0")
+
+        with with_site_configuration_context(configuration={}):
+            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": True}):
+                self.assertEqual(prov.enabled_for_current_site, True)
+
+            with self.settings(FEATURES={"ENABLE_TAHOE_AUTH0": False}):
+                self.assertEqual(prov.enabled_for_current_site, False)
+
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_TAHOE_AUTH0': True})
+    @ddt.data(
+        {'auth0_backend_enabled': False, 'domain_name': SITE_DOMAIN_A},
+        {'auth0_backend_enabled': False, 'domain_name': SITE_DOMAIN_B},
+        {'auth0_backend_enabled': True, 'domain_name': SITE_DOMAIN_A},
+        {'auth0_backend_enabled': True, 'domain_name': SITE_DOMAIN_B},
+    )
+    @ddt.unpack
+    def test_auth0_feature_enabled_with_different_sites(self, auth0_backend_enabled, domain_name):
+        """
+        Verify that enabled_for_current_site returns True when Auth0 provider is configured
+        for a different site.
+
+        The `ProviderConfig.enabled` (auth0_backend_enabled) property is disregarded.
+        """
+        site_b, _created = Site.objects.get_or_create(domain=SITE_DOMAIN_B, name=SITE_DOMAIN_B)
+        with with_site_configuration_context(domain_name):
+            prov = self.configure_oauth_provider(enabled=auth0_backend_enabled, site=site_b, backend_name="tahoe-auth0")
+            assert prov.enabled_for_current_site, 'Backend should be shown when ENABLE_TAHOE_AUTH0 is enabled'
+
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_TAHOE_AUTH0': False})
+    @ddt.data(
+        {'auth0_backend_enabled': False, 'domain_name': SITE_DOMAIN_A},
+        {'auth0_backend_enabled': False, 'domain_name': SITE_DOMAIN_B},
+        {'auth0_backend_enabled': True, 'domain_name': SITE_DOMAIN_A},
+        {'auth0_backend_enabled': True, 'domain_name': SITE_DOMAIN_B},
+    )
+    @ddt.unpack
+    def test_auth0_feature_disabled_with_different_sites(self, auth0_backend_enabled, domain_name):
+        """
+        Verify that enabled_for_current_site returns False when ENABLE_TAHOE_AUTH0 is set to False.
+
+        The `ProviderConfig.enabled` (auth0_backend_enabled) property is disregarded.
+        """
+        site_b, _created = Site.objects.get_or_create(domain=SITE_DOMAIN_B, name=SITE_DOMAIN_B)
+        with with_site_configuration_context(domain_name):
+            prov = self.configure_oauth_provider(enabled=auth0_backend_enabled, site=site_b, backend_name="tahoe-auth0")
+            assert not prov.enabled_for_current_site, 'Backend should be hidden when ENABLE_TAHOE_AUTH0 is disabled'


### PR DESCRIPTION
Jira: RED-2617


### Fix
Without this fix, `tahoe-auth` backend button appears on all staging sites.

This fix makes it explicitly required to use `ENABLE_TAHOE_AUTH0` whether locally in site configurations or at the cluster `FEATURES['ENABLE_TAHOE_AUTH0']`

### Change of logic
The `ProviderConfig.enabled` is ignored to avoid manual errors and makes a canonical place to enable the feature.

