### PR TITLE
SiteConfigAdapter returns CSS as list

### DIFF
--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -318,16 +318,10 @@ class SiteConfiguration(models.Model):
             # Tahoe: Use `SiteConfigAdapter` if available.
             beeline.add_context_field('value_source', 'site_config_service')
             sass_variables = self.api_adapter.get_amc_v1_theme_css_variables()
-            # Note: css variables from adapter is in dict format
-            formatted_sass_variables = ""
-            for key, val in sass_variables.items():
-                formatted_sass_variables += "{}: {};".format(key, val)
-            return formatted_sass_variables
         else:
             beeline.add_context_field('value_source', 'django_model')
-            # Note: sass variables in list format
             sass_variables = self.sass_variables
-            return " ".join(["{}: {};".format(var, val[0]) for var, val in sass_variables])
+        return " ".join(["{}: {};".format(var, val[0]) for var, val in sass_variables])
 
     def _sass_var_override(self, path):
         if 'branding-basics' in path:

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -117,10 +117,10 @@ class SiteConfigAPIClientTests(TestCase):
         "course_about_show_social_links": False,
     }
 
-    sass_variables = {
-        "$brand-primary-color": "#0090C1",
-        "$brand-accent-color": "#7f8c8d",
-    }
+    sass_variables = [
+        ["$brand-primary-color", ["#0090C1", "#0090C1"]],
+        ["$brand-accent-color", ["#7f8c8d", "#7f8c8d"]],
+    ]
 
     about_page = {
         'title': 'About page from site configuration service',


### PR DESCRIPTION
No need for special handling in Open edX.


 - Needs: https://github.com/appsembler/site-configuration-client/pull/45 