### PR TITLE
Run `diff-cover` tests in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,13 +40,13 @@ jobs:
         pip install tox tox-pip-version
     - name: Run tox
       run: |
-        PYTEST_ARGS='--cov=.' tox -e ${{ matrix.tox-env }}
-        if [ -f reports/.coverage ]; then mv reports/.coverage reports/.coverage-${{ matrix.tox-env }}; fi
+        PYTEST_ARGS='--cov --cov-append --cov-report=term-missing' tox -e ${{ matrix.tox-env }}
+        if [ -f reports/.coverage ]; then mv reports/.coverage reports/.coverage.${{ matrix.tox-env }}; fi
     - name: Upload coverage data
       uses: actions/upload-artifact@v2
       with:
         name: coverage-data
-        path: "reports/*coverage*"
+        path: "reports/*.coverage.*"
         if-no-files-found: ignore
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@v20201129
@@ -78,11 +78,11 @@ jobs:
       - name: Combine and run diff-cover
         # TODO: use `coverage report --fail-under=100` once we understand our coverage and get it to a reasonable diff.
         run: |
-          coverage combine reports/.coverage-*
+          coverage combine reports/
           coverage xml -o reports/combined-coverage.xml
 
           git fetch origin open-release/juniper.master
-          diff-cover reports/combined-coverage.xml --compare-branch=origin/open-release/juniper.master --html-report=diff-coverage.html
+          diff-cover reports/combined-coverage.xml --compare-branch=origin/open-release/juniper.master --html-report=reports/diff-coverage.html
 
           REPORT="$(coverage report)"
           echo "${REPORT}"
@@ -98,7 +98,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: diff-coverage.html
-          path: diff-coverage.html
+          path: reports/diff-coverage.html
 
   coveralls_finish:
     needs: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,13 @@ jobs:
     - name: Run tox
       run: |
         PYTEST_ARGS='--cov=.' tox -e ${{ matrix.tox-env }}
+        if [ -f reports/.coverage ]; then mv reports/.coverage reports/.coverage-${{ matrix.tox-env }}; fi
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-data
+        path: "reports/*coverage*"
+        if-no-files-found: ignore
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@v20201129
       if: ${{ matrix.tox-env != 'pep8' }}
@@ -48,11 +55,56 @@ jobs:
         parallel: true
         flag-name: Unit Test
 
+  coverage:
+    name: Diff coverage
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0  # TODO: Consider changing to 1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.5
+      - run: python -m pip install --upgrade coverage==5.1 diff-cover==2.6.1
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-data
+          path: reports
+
+      - name: Combine and run diff-cover
+        # TODO: use `coverage report --fail-under=100` once we understand our coverage and get it to a reasonable diff.
+        run: |
+          coverage combine reports/.coverage-*
+          coverage xml -o reports/combined-coverage.xml
+
+          git fetch origin open-release/juniper.master
+          diff-cover reports/combined-coverage.xml --compare-branch=origin/open-release/juniper.master --html-report=diff-coverage.html
+
+          REPORT="$(coverage report)"
+          echo "${REPORT}"
+
+          REPORT="${REPORT//'%'/'%25'}"
+          REPORT="${REPORT//$'\n'/'%0A'}"
+          REPORT="${REPORT//$'\r'/'%0D'}"
+          echo "::set-output name=conflict_report::${REPORT}"
+
+      # TODO: Parse and comment $REPORT while linking to `diff-coverage.html` and hide previous coverage comments.
+
+      - name: Upload diff-cover coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: diff-coverage.html
+          path: diff-coverage.html
+
   coveralls_finish:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls Finished
+    - name: Coveralls finished
       uses: AndreMiras/coveralls-python-action@v20201129
       with:
         flag-name: Unit Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.5
-      - run: python -m pip install --upgrade coverage==5.1 diff-cover==2.6.1
+      - run: python -m pip install --upgrade coverage==5.5 diff-cover==4.2.3
 
       - name: Download coverage data
         uses: actions/download-artifact@v2
@@ -81,16 +81,16 @@ jobs:
           coverage combine reports/
           coverage xml -o reports/combined-coverage.xml
 
-          git fetch origin open-release/juniper.master
-          diff-cover reports/combined-coverage.xml --compare-branch=origin/open-release/juniper.master --html-report=reports/diff-coverage.html
+          git fetch -v origin open-release/juniper.master:open-release/juniper.master
+          diff-cover reports/combined-coverage.xml --compare-branch=open-release/juniper.master --html-report=reports/diff-coverage.html
 
-          REPORT="$(coverage report)"
-          echo "${REPORT}"
-
-          REPORT="${REPORT//'%'/'%25'}"
-          REPORT="${REPORT//$'\n'/'%0A'}"
-          REPORT="${REPORT//$'\r'/'%0D'}"
-          echo "::set-output name=conflict_report::${REPORT}"
+#          REPORT="$(coverage report)"
+#          echo "${REPORT}"
+#
+#          REPORT="${REPORT//'%'/'%25'}"
+#          REPORT="${REPORT//$'\n'/'%0A'}"
+#          REPORT="${REPORT//$'\r'/'%0D'}"
+#          echo "::set-output name=conflict_report::${REPORT}"
 
       # TODO: Parse and comment $REPORT while linking to `diff-coverage.html` and hide previous coverage comments.
 

--- a/openedx/core/djangoapps/appsembler/api/helpers.py
+++ b/openedx/core/djangoapps/appsembler/api/helpers.py
@@ -38,6 +38,11 @@ def skip_registration_email_for_registration_api(request, params):
         skip_email = not params.get('send_activation_email', True)
         beeline.add_context_field('appsembler__skip_email', skip_email)
 
+    if ''.lower():
+        # Tahoe: Just random uncovered lines in Tahoe, shouldn't be merged
+        x = 20
+        abs(x)
+
     return skip_email
 
 


### PR DESCRIPTION

Using `diff-cover` which is a command line tool that compares an XML coverage report with the output of `git diff`. It then reports coverage information for lines in the diff.


### Benefits
- This helps us to measure the coverage of our customization on Open edX `$ git diff main open-release/juniper.master`.
- This helps us to run a good balance of test coverage without the cost of running the entire test suite of edX.

### Refs
 - Jira issue: RED-1667
 - Manual coverage reports via GitHub Actions: https://hynek.me/articles/ditch-codecov-python/
 - The `diff-cover` tool: https://github.com/Bachmann1234/diff_cover

### TODOs for later PRs

 - [ ] Post the report in a GitHub comment
