### PR TITLE
refactor: Helper for tahoe-auth0 theme work

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -351,11 +351,9 @@ class ProviderConfig(ConfigurationModel):
     def is_auth0_enabled(self):
         is_auth0_enabled = False
         if self.is_tahoe_auth0_backend():
-            from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-            is_auth0_enabled = configuration_helpers.get_value(
-                'ENABLE_TAHOE_AUTH0',
-                settings.FEATURES.get('ENABLE_TAHOE_AUTH0', False),
-            )
+            # Tahoe: Local imports to avoid circular import errors.
+            from openedx.core.djangoapps.site_configuration import tahoe_auth0_helpers
+            is_auth0_enabled = tahoe_auth0_helpers.is_tahoe_auth0_enabled()
 
         return is_auth0_enabled
 

--- a/openedx/core/djangoapps/site_configuration/tahoe_auth0_helpers.py
+++ b/openedx/core/djangoapps/site_configuration/tahoe_auth0_helpers.py
@@ -1,0 +1,19 @@
+"""
+Helper module for Tahoe Auth0.
+
+ - https://github.com/appsembler/tahoe-auth0/
+"""
+from django.conf import settings
+
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
+
+def is_tahoe_auth0_enabled():
+    """
+    Tahoe: Check if tahoe-auth0 package is enabled for the current site (or cluster-wide).
+    """
+    is_enabled = configuration_helpers.get_value(
+        'ENABLE_TAHOE_AUTH0',
+        settings.FEATURES.get('ENABLE_TAHOE_AUTH0', False),
+    )
+    return is_enabled


### PR DESCRIPTION
A little refactoring into a helper. Already tested code.


```
$ pytest --cov=openedx/core/djangoapps/site_configuration \
   common/djangoapps/third_party_auth/tests/test_tahoe_auth0_provider_hack.py
...
openedx/core/djangoapps/site_configuration/tahoe_auth0_helpers.py    5      0   100%
...
```

Jira task: RED-2736.