### PR TITLE
Hide inactive courses from global staff users

### DIFF
--- a/cms/djangoapps/appsembler/waffle.py
+++ b/cms/djangoapps/appsembler/waffle.py
@@ -1,0 +1,12 @@
+"""
+Tahoe: Waffle flags for Studio.
+"""
+
+from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNamespace
+
+WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='tahoe_studio', log_prefix=u'Tahoe Studio: ')
+
+GLOBAL_STAFF_HIDE_INACTIVE_SITES_COURSES = WaffleSwitch(
+    waffle_namespace=WAFFLE_SWITCH_NAMESPACE,
+    switch_name='global_staff_hide_inactive_sites_courses',
+)

--- a/cms/djangoapps/contentstore/tests/test_tahoe_active_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_tahoe_active_course_listing.py
@@ -1,0 +1,112 @@
+"""
+Tahoe: Unit tests listing the active courses in Studio home.
+
+Ref: RED-2766
+"""
+
+from unittest.mock import patch
+
+from django.test import RequestFactory
+
+from contentstore.tests.utils import AjaxEnabledTestClient
+from contentstore.views.course import (
+    get_courses_accessible_to_user
+)
+from student.roles import GlobalStaff
+from student.tests.factories import UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls
+
+from organizations.tests.factories import OrganizationFactory
+from organizations.models import OrganizationCourse
+
+
+from appsembler.waffle import GLOBAL_STAFF_HIDE_INACTIVE_SITES_COURSES
+
+
+class TestCourseListingGlobalStaffActiveOrgs(ModuleStoreTestCase):
+    """
+    Tests for the GLOBAL_STAFF_HIDE_INACTIVE_SITES_COURSES Tahoe Waffle Switch.
+    """
+
+    def setUp(self):
+        """
+        Add a user and a course.
+        """
+        super().setUp()
+        self.staff_user = UserFactory.create()
+        GlobalStaff().add_users(self.staff_user)
+        self.factory = RequestFactory()
+        self.request = self.factory.get('/home')
+        self.request.user = self.staff_user
+        self.client = AjaxEnabledTestClient()
+        self.client.login(username=self.staff_user.username, password='test')
+
+        assert GlobalStaff().has_user(self.staff_user), 'Sanity check: verify staff role to the user'
+
+    def _create_course_with_org(self):
+        """
+        Create dummy course with 'CourseFactory' and link it with a new organization.
+        """
+        course = CourseFactory.create()
+        org = OrganizationFactory.create()
+        OrganizationCourse.objects.create(course_id=course.id, organization=org)
+        return course, org
+
+    def tearDown(self):
+        """
+        Reverse the setup
+        """
+        self.client.logout()
+        ModuleStoreTestCase.tearDown(self)
+
+    def test_list_all_active_orgs_when_active_feature_enabled(self):
+        """
+        TBD.
+        """
+        active_course_1, active_organization_1 = self._create_course_with_org()
+        active_course_2, active_organization_2 = self._create_course_with_org()
+
+        with patch('contentstore.views.course.get_active_organizations') as mocked:
+            # List all courses, because all orgs are enabled
+            mocked.return_value = [active_organization_1, active_organization_2]
+            # Fetch accessible courses list & verify their IDs
+            with GLOBAL_STAFF_HIDE_INACTIVE_SITES_COURSES.override(True):
+                courses_list_by_staff, __ = get_courses_accessible_to_user(self.request)
+                course_ids = set(str(course.id) for course in courses_list_by_staff)
+                assert course_ids == {str(active_course_1.id), str(active_course_2.id)}, 'Should list all course'
+
+    # def test_list_active_orgs_when_active_feature_enabled(self):
+    #     """
+    #     TBD
+    #     """
+    #     active_course, active_organization = self._create_course_with_org()
+    #     _inactive_course, _inactive_organization = self._create_course_with_org()
+    #
+    #     with patch('contentstore.views.course.get_active_organizations') as mocked:
+    #         # list only course from active orgs
+    #         mocked.return_value = [active_organization]
+    #
+    #         # List only courses belonging to active organizations when Tiers enabled
+    #         with GLOBAL_STAFF_HIDE_INACTIVE_SITES_COURSES.override(True):
+    #             courses_list_by_staff, __ = get_courses_accessible_to_user(self.request)
+    #             course_ids = set(str(course.id) for course in courses_list_by_staff)
+    #             assert course_ids == {str(active_course.id)}, 'Should list only active courses'
+    #
+    # def test_list_all_orgs_when_active_feature_disabled(self):
+    #     """
+    #     TBD
+    #     """
+    #     active_course, active_organization = self._create_course_with_org()
+    #     inactive_course, _inactive_organization = self._create_course_with_org()
+    #
+    #     with patch('contentstore.views.course.get_active_organizations') as mocked:
+    #         # list only course from active orgs
+    #         mocked.return_value = [active_organization]
+    #
+    #         # List all courses the flag is disabled regardless for Tiers output
+    #         with GLOBAL_STAFF_HIDE_INACTIVE_SITES_COURSES.override(False):
+    #             courses_list_by_staff, __ = get_courses_accessible_to_user(self.request)
+    #             course_ids = set(str(course.id) for course in courses_list_by_staff)
+    #             assert course_ids == {str(active_course.id),
+    #                                   str(inactive_course.id)}, 'Should list all courses, when flag is inactive'

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -87,12 +87,14 @@ def get_active_organizations():
 
     TODO: This helper should live in a future Tahoe Sites package.
     """
-    active_tiers_uuids = _get_active_tiers_uuids()
-
-    # Now back to the LMS MySQL database
-    return Organization.objects.filter(
-        edx_uuid__in=[str(edx_uuid) for edx_uuid in active_tiers_uuids],
-    )
+    if settings.FEATURES.get('ENABLE_TIERS_APP', False):
+        active_tiers_uuids = _get_active_tiers_uuids()
+        # Now back to the LMS MySQL database
+        return Organization.objects.filter(
+            edx_uuid__in=[str(edx_uuid) for edx_uuid in active_tiers_uuids],
+        )
+    else:
+        return Organization.objects.all()
 
 
 def get_active_sites(order_by='domain'):


### PR DESCRIPTION
 - Jira issue: RED-2766

### Waffle Switch

This PR introduces a new Waffle Switch until we're confident with the new functionality:


```
tahoe_studio.global_staff_hide_inactive_sites_courses
```

Switches are set via the Tahoe Django admin: https://studio.staging-tahoe.appsembler.com/admin/waffle/switch/