### PR TITLE
refactoring: don't save dynamic SiteConfiguration custom values

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/apps.py
+++ b/openedx/core/djangoapps/appsembler/sites/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
-from django.db.models.signals import pre_save, post_save
+from django.db.models.signals import pre_save, post_init
 
 
 class SitesConfig(AppConfig):
@@ -9,5 +9,9 @@ class SitesConfig(AppConfig):
 
     def ready(self):
         from openedx.core.djangoapps.appsembler.sites.models import patched_clear_site_cache
+        from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
-        pre_save.connect(patched_clear_site_cache, sender='site_configuration.SiteConfiguration')
+        from .config_values_modifier import init_configuration_modifier_for_site_config
+
+        pre_save.connect(patched_clear_site_cache, sender=SiteConfiguration)
+        post_init.connect(init_configuration_modifier_for_site_config, sender=SiteConfiguration)

--- a/openedx/core/djangoapps/appsembler/sites/config_values_modifier.py
+++ b/openedx/core/djangoapps/appsembler/sites/config_values_modifier.py
@@ -1,0 +1,103 @@
+"""
+Tahoe: Configuration modifiers for Tahoe.
+"""
+
+from urllib.parse import urlsplit
+
+from django.conf import settings
+
+
+class TahoeConfigurationValueModifier:
+    """
+    Calculate URL values for Tahoe.
+
+    This is useful to reduce the cost of changing a Site domain.
+    """
+
+    FIELD_OVERRIDERS = {
+        'SITE_NAME': 'get_site_name',
+        'LMS_ROOT_URL': 'get_lms_root_url',
+        'ACTIVATION_EMAIL_SUPPORT_LINK': 'get_activation_email_support_link',
+        'PASSWORD_RESET_SUPPORT_LINK': 'get_password_reset_support_link',
+        'css_overrides_file': 'get_css_overrides_file',
+    }
+
+    def __init__(self, site_config_instance):
+        self.site_config_instance = site_config_instance
+
+    def normalize_get_value_params(self, name, default):
+        """
+        Amend the name and default values for Tahoe.
+
+        This resolves few quirks and tech-debt in Open edX in which some variables don't exist while others exists
+        in multiple spellings/cases.
+        """
+        # Tahoe: Default value is needed for this
+        if name == 'LANGUAGE_CODE' and default is None:
+            # TODO: Ask Dashboard 2.0 / AMC to set the `LANGUAGE_CODE` by default.
+            default = 'en'
+
+        if name == 'PLATFORM_NAME':
+            # Always use the lower case so the configuration is easier to maintain.
+            name = 'platform_name'
+
+        return name, default
+
+    def get_domain(self):
+        domain = None
+        if hasattr(self.site_config_instance, 'site'):
+            domain = self.site_config_instance.site.domain
+
+        return domain
+
+    def get_site_name(self):
+        return self.get_domain()
+
+    def get_css_overrides_file(self):
+        domain_without_port_number = self.get_domain().split(':')[0]
+        return '{}.css'.format(domain_without_port_number)
+
+    def get_lms_root_url(self):
+        """
+        Provide override for LMS_ROOT_URL synced with `SITE_NAME`.
+        """
+        # We cannot simply use a protocol-relative URL for LMS_ROOT_URL
+        # This is because the URL here will be used by such activities as
+        # sending activation links to new users. The activation link needs the
+        # scheme address verification emails. The callers using this variable
+        # expect the scheme in the URL
+        return '{scheme}://{domain}'.format(
+            scheme=urlsplit(settings.LMS_ROOT_URL).scheme,
+            domain=self.get_domain(),
+        )
+
+    def get_activation_email_support_link(self):
+        """
+        RED-2471: Use Multi-tenant `/help` URL for password reset emails.
+        """
+        return '{root_url}/help'.format(root_url=self.get_lms_root_url())
+
+    def get_password_reset_support_link(self):
+        """
+        RED-2385: Use Multi-tenant `/help` URL for activation emails.
+        """
+        return '{root_url}/help'.format(root_url=self.get_lms_root_url())
+
+    def override_value(self, name):
+        """
+        Given a value name, return a hard-coded default completely disregarding the stored values.
+
+        This is useful to simplify the domain name change for Sites.
+
+        :return (should_override, overridden_value)
+        """
+        value_getter_method_name = self.FIELD_OVERRIDERS.get(name)
+        if value_getter_method_name:
+            if self.get_domain():
+                value_getter = getattr(self, value_getter_method_name)
+                return True, value_getter()
+        return False, None
+
+
+def init_configuration_modifier_for_site_config(sender, instance, **kwargs):
+    instance.tahoe_config_modifier = TahoeConfigurationValueModifier(site_config_instance=instance)

--- a/openedx/core/djangoapps/appsembler/sites/config_values_modifier.py
+++ b/openedx/core/djangoapps/appsembler/sites/config_values_modifier.py
@@ -3,8 +3,13 @@ Tahoe: Configuration modifiers for Tahoe.
 """
 
 from urllib.parse import urlsplit
+from logging import getLogger
 
 from django.conf import settings
+
+from openedx.core.djangoapps.appsembler.sites.waffle import ENABLE_CONFIG_VALUES_MODIFIER
+
+log = getLogger(__name__)
 
 
 class TahoeConfigurationValueModifier:
@@ -100,4 +105,7 @@ class TahoeConfigurationValueModifier:
 
 
 def init_configuration_modifier_for_site_config(sender, instance, **kwargs):
-    instance.tahoe_config_modifier = TahoeConfigurationValueModifier(site_config_instance=instance)
+    if ENABLE_CONFIG_VALUES_MODIFIER.is_enabled():
+        instance.tahoe_config_modifier = TahoeConfigurationValueModifier(site_config_instance=instance)
+    else:
+        log.info('ENABLE_CONFIG_VALUES_MODIFIER: switch is not enabled, not using TahoeConfigurationValueModifier')

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_config_values_modifier.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_config_values_modifier.py
@@ -1,0 +1,93 @@
+"""
+Tests for TahoeConfigurationValueModifier.
+"""
+import pytest
+
+from unittest.mock import Mock
+
+from openedx.core.djangoapps.appsembler.sites.config_values_modifier import TahoeConfigurationValueModifier
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+
+
+@pytest.mark.django_db
+def test_site_config_init_signal():
+    """
+    Ensure SiteConfiguration gets a TahoeConfigurationValueModifier instance after initialization.
+    """
+    site_config = SiteConfiguration()
+    assert site_config.tahoe_config_modifier, (
+        'The `init_configuration_modifier_for_site_config` function should be '
+        'connected correctly to SiteConfiguration\'s `post_init`'
+    )
+
+
+def test_values_normalization():
+    """
+    Ensure `normalize_get_value_params` normalizes values correctly.
+    """
+    modifier = TahoeConfigurationValueModifier(site_config_instance=Mock())
+
+    _, lang_code_default = modifier.normalize_get_value_params('LANGUAGE_CODE', None)
+    assert lang_code_default == 'en', 'Should always provide LANGUAGE_CODE so them works well'
+
+    platform_name_var, _ = modifier.normalize_get_value_params('PLATFORM_NAME', None)
+    assert platform_name_var == 'platform_name', 'Always use lower case `platform_name`'
+
+
+def test_domain_name():
+    modifier = TahoeConfigurationValueModifier(site_config_instance=Mock())
+    modifier.site_config_instance.site.domain = 'testing.com'
+    assert modifier.get_domain() == 'testing.com'
+
+    modifier.site_config_instance = object()  # An object with no `site` attribute
+    assert not modifier.get_domain(), 'Should not get domain when SiteConfiguration instance has no Site'
+
+
+@pytest.mark.parametrize('config_name, expected_value, message', [
+    ['SITE_NAME', 'mysite.com', 'Should sync SITE_NAME with site.domain.'],
+    ['LMS_ROOT_URL', 'https://mysite.com', 'Should use `https` for security.'],
+    ['ACTIVATION_EMAIL_SUPPORT_LINK', 'https://mysite.com/help', 'Should fix RED-2385.'],
+    ['PASSWORD_RESET_SUPPORT_LINK', 'https://mysite.com/help', 'Should fix RED-2471.'],
+    ['PASSWORD_RESET_SUPPORT_LINK', 'https://mysite.com/help', 'Should fix RED-2471.'],
+    ['css_overrides_file', 'mysite.com.css', 'Should configure the path for css_override_file'],
+])
+def test_modifier_urls(settings, config_name, expected_value, message):
+    settings.LMS_ROOT_URL = 'https://hello-world.com'
+    modifier = TahoeConfigurationValueModifier(site_config_instance=Mock())
+    modifier.site_config_instance.site.domain = 'mysite.com'
+
+    should_override, overriding_value = modifier.override_value(config_name)
+    assert should_override, 'Should override {}'.format(config_name)
+    assert overriding_value == expected_value, message
+
+
+def test_css_override_file_with_port_number():
+    modifier = TahoeConfigurationValueModifier(site_config_instance=Mock())
+    modifier.site_config_instance.site.domain = 'test.localhost:18000'
+    assert modifier.get_css_overrides_file() == 'test.localhost.css', 'Should not include port number in css file name'
+
+
+@pytest.mark.parametrize('config_name', [
+    'SITE_NAME',
+    'LMS_ROOT_URL',
+    'ACTIVATION_EMAIL_SUPPORT_LINK',
+    'PASSWORD_RESET_SUPPORT_LINK',
+    'css_overrides_file',
+])
+def test_modifier_urls_no_site(config_name):
+    """
+    Should not override URls where there is no site on the SiteConfiguration instance.
+    """
+    modifier = TahoeConfigurationValueModifier(site_config_instance=object())  # An site_config with no `site`
+    should_override, _ = modifier.override_value(config_name)
+    assert not should_override, 'Do not {} when the SiteConfiguration instance has no site'.format(config_name)
+
+
+@pytest.mark.parametrize('config_name', [
+    'PLATFORM_NAME',
+    'ENABLE_AUTH0',
+])
+def test_non_overriding_values(config_name):
+    """
+    Should not override values other than explicitly mentioned.
+    """

--- a/openedx/core/djangoapps/appsembler/sites/waffle.py
+++ b/openedx/core/djangoapps/appsembler/sites/waffle.py
@@ -1,0 +1,13 @@
+"""
+Waffle flags and switches for user tahoe sites.
+"""
+
+
+from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNamespace
+
+_WAFFLE_NAMESPACE = u'openedx_core_tahoe_sites'
+_WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_prefix=u'Tahoe Sites (Open edX Core): ')
+
+ENABLE_CONFIG_VALUES_MODIFIER = WaffleSwitch(
+    _WAFFLE_SWITCH_NAMESPACE, 'enable_configuration_values_modifier'
+)

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -91,9 +91,13 @@ class SiteConfiguration(models.Model):
             from openedx.core.djangoapps.appsembler.sites.config_values_modifier import TahoeConfigurationValueModifier
             tahoe_config_modifier = TahoeConfigurationValueModifier(site_config_instance=self)
 
+            if not self.site_values:
+                self.site_values = {}
+
+            if not self.get_value('platform_name'):
+                self.site_values['platform_name'] = self.site.name
+
             if not self.get_value('PLATFORM_NAME'):  # First-time the config is saved with save()
-                if not self.get_value('platform_name'):
-                    self.site_values['platform_name'] = self.site.name
                 self.site_values['css_overrides_file'] = tahoe_config_modifier.get_css_overrides_file()
                 self.site_values['ENABLE_COMBINED_LOGIN_REGISTRATION'] = True
 

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -1,6 +1,7 @@
 """
 Tests for site configuration's Tahoe customizations.
 """
+import ddt
 from urllib.parse import urlsplit
 
 from django.conf import settings
@@ -9,14 +10,30 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from mock import Mock
 
+from openedx.core.djangoapps.appsembler.sites.waffle import ENABLE_CONFIG_VALUES_MODIFIER
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
+
+
+def ddt_without_and_with_modifier(test_func):
+    """
+    Decorator to pass `use_modifier` parameter.
+    """
+    test_func = ddt.data({
+        'use_modifier': False,
+    }, {
+        'use_modifier': True,
+    })(test_func)
+
+    test_func = ddt.unpack(test_func)
+    return test_func
 
 
 @override_settings(
     ENABLE_COMPREHENSIVE_THEMING=True,
     DEFAULT_SITE_THEME='edx-theme-codebase',
 )
+@ddt.ddt
 class SiteConfigurationTests(TestCase):
     """
     Tests for SiteConfiguration and its signals/receivers.
@@ -47,27 +64,32 @@ class SiteConfigurationTests(TestCase):
         cls.expected_site_root_url = '{scheme}://{domain}'.format(
             scheme=cls.scheme, domain=cls.domain)
 
-    def test_site_configuration_compile_sass(self):
+    @ddt_without_and_with_modifier
+    def test_site_configuration_compile_sass(self, use_modifier):
         """
         Test that and entry is added to SiteConfigurationHistory model each time a new
         SiteConfiguration is added.
         """
-        # add SiteConfiguration to database
-        site_configuration = SiteConfigurationFactory.build(
-            site=self.site,
-        )
+        with ENABLE_CONFIG_VALUES_MODIFIER.override(use_modifier):
+            # add SiteConfiguration to database
+            site_configuration = SiteConfigurationFactory.build(
+                site=self.site,
+            )
 
-        site_configuration.save()
+            site_configuration.save()
 
-    def test_get_value(self):
+    @ddt_without_and_with_modifier
+    def test_get_value(self, use_modifier):
         """
         Test that get_value returns correct value for Tahoe custom keys.
         """
         # add SiteConfiguration to database
-        site_configuration = SiteConfigurationFactory.create(
-            site=self.site,
-            site_values=self.test_config
-        )
+        with ENABLE_CONFIG_VALUES_MODIFIER.override(use_modifier):
+            site_configuration = SiteConfigurationFactory.create(
+                site=self.site,
+                site_values=self.test_config
+            )
+            assert bool(site_configuration.tahoe_config_modifier) == use_modifier, 'Sanity check for `override()`'
 
         # Make sure entry is saved and retrieved correctly
         self.assertEqual(site_configuration.get_value("PLATFORM_NAME"),
@@ -79,38 +101,56 @@ class SiteConfigurationTests(TestCase):
         self.assertTrue(site_configuration.get_value('PASSWORD_RESET_SUPPORT_LINK'))
         self.assertTrue(site_configuration.get_value('PASSWORD_RESET_SUPPORT_LINK').endswith('/help'))
 
-    def test_hardcoded_values_for_unsaved_config_instance(self):
+    @ddt_without_and_with_modifier
+    def test_hardcoded_values_for_unsaved_config_instance(self, use_modifier):
         """
         If a SiteConfiguration has no site yet, the `get_value` will work safely.
         """
-        site_config = SiteConfiguration(enabled=True)
+        with ENABLE_CONFIG_VALUES_MODIFIER.override(use_modifier):
+            site_config = SiteConfiguration(enabled=True)
+
         assert site_config.get_value('SITE_NAME') is None
         assert site_config.get_value('SITE_NAME', 'test.com') == 'test.com'
 
-    def test_hardcoded_values_for_config_instance_with_site(self):
+    def test_hardcoded_values_for_config_instance_with_site_without_modifier(self):
         """
-        If a SiteConfiguration has no site yet, the `get_value` will work safely.
-        """
-        site_config = SiteConfiguration(enabled=True)
-        site_config.site = Site(domain='my-site.com')
-        assert site_config.get_value('SITE_NAME', 'test.com') == 'my-site.com'
+        If a SiteConfiguration has a site the `get_value` should return the right one.
 
-    def test_get_value_for_org(self):
+        with ENABLE_CONFIG_VALUES_MODIFIER disabled.
+        """
+        with ENABLE_CONFIG_VALUES_MODIFIER.override(False):
+            site = Site.objects.create(domain='my-site.com')
+            site_config = SiteConfiguration(enabled=True, site=site)
+            site_config.save()
+            assert site_config.get_value('SITE_NAME', 'test.com') == 'my-site.com'
+
+    def test_hardcoded_values_for_config_instance_with_site_with_modifier(self):
+        """
+        If a SiteConfiguration has a site the `get_value` should return the right one.
+
+        with ENABLE_CONFIG_VALUES_MODIFIER enabled.
+        """
+        with ENABLE_CONFIG_VALUES_MODIFIER.override(True):
+            site = Site.objects.create(domain='my-site.com')
+            site_config = SiteConfiguration(enabled=True, site=site)  # No need to save for the value modifier to work
+            assert site_config.get_value('SITE_NAME', 'test.com') == 'my-site.com'
+
+    @ddt_without_and_with_modifier
+    def test_get_value_for_org(self, use_modifier):
         """
         Test that get_value_for_org returns correct value for Tahoe custom keys.
         """
-        # add SiteConfiguration to database
-        SiteConfigurationFactory.create(
-            site=self.site,
-            site_values=self.test_config
-        )
+        with ENABLE_CONFIG_VALUES_MODIFIER.override(use_modifier):
+            # add SiteConfiguration to database
+            site_config = SiteConfigurationFactory.create(
+                site=self.site,
+                site_values=self.test_config
+            )
+            site_config.save()
 
-        # Test that LMS_ROOT_URL is assigned to the SiteConfiguration on creation
-        self.assertEqual(
-            SiteConfiguration.get_value_for_org(
-                self.test_config['course_org_filter'], 'LMS_ROOT_URL'),
-            self.expected_site_root_url
-        )
+            # Test that LMS_ROOT_URL is assigned to the SiteConfiguration on creation
+            tahoex_org_name = self.test_config['course_org_filter']
+            assert SiteConfiguration.get_value_for_org(tahoex_org_name, 'LMS_ROOT_URL') == self.expected_site_root_url
 
 
 @override_settings(

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -79,6 +79,22 @@ class SiteConfigurationTests(TestCase):
         self.assertTrue(site_configuration.get_value('PASSWORD_RESET_SUPPORT_LINK'))
         self.assertTrue(site_configuration.get_value('PASSWORD_RESET_SUPPORT_LINK').endswith('/help'))
 
+    def test_hardcoded_values_for_unsaved_config_instance(self):
+        """
+        If a SiteConfiguration has no site yet, the `get_value` will work safely.
+        """
+        site_config = SiteConfiguration(enabled=True)
+        assert site_config.get_value('SITE_NAME') is None
+        assert site_config.get_value('SITE_NAME', 'test.com') == 'test.com'
+
+    def test_hardcoded_values_for_config_instance_with_site(self):
+        """
+        If a SiteConfiguration has no site yet, the `get_value` will work safely.
+        """
+        site_config = SiteConfiguration(enabled=True)
+        site_config.site = Site(domain='my-site.com')
+        assert site_config.get_value('SITE_NAME', 'test.com') == 'my-site.com'
+
     def test_get_value_for_org(self):
         """
         Test that get_value_for_org returns correct value for Tahoe custom keys.

--- a/openedx/core/djangoapps/site_configuration/tests/test_util.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_util.py
@@ -13,22 +13,6 @@ from django.contrib.sites.models import Site
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
 
-def apply_appsembler_theme_configs(site_configuration, values):
-    """
-    Save the SiteConfiguration for testing in compatibility with the theme.
-
-    Using get_initial_microsite_values() to ensure the theme configs are used
-    correctly.
-
-    This helper is related to our hack in the `SiteConfiguration.save()` method.
-    """
-    appsembler_configs = site_configuration.get_initial_microsite_values()
-    appsembler_configs.update(values or {})
-    site_configuration.site_values = appsembler_configs
-    site_configuration.save()
-    return site_configuration
-
-
 def with_site_configuration(domain="test.localhost", configuration=None):
     """
     A decorator to run a test with a configuration enabled.
@@ -45,9 +29,11 @@ def with_site_configuration(domain="test.localhost", configuration=None):
             site, __ = Site.objects.get_or_create(domain=domain, name=domain)
             site_configuration, created = SiteConfiguration.objects.get_or_create(
                 site=site,
-                defaults={"enabled": True},
+                defaults={"enabled": True, "site_values": configuration},
             )
-            apply_appsembler_theme_configs(site_configuration, configuration)
+            if not created:
+                site_configuration.site_values = configuration
+                site_configuration.save()
 
             with patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
                        return_value=site_configuration):
@@ -68,11 +54,13 @@ def with_site_configuration_context(domain="test.localhost", configuration=None)
         configuration (dict): configuration to use for the test site.
     """
     site, __ = Site.objects.get_or_create(domain=domain, name=domain)
-    site_configuration, _created = SiteConfiguration.objects.get_or_create(
+    site_configuration, created = SiteConfiguration.objects.get_or_create(
         site=site,
-        defaults={"enabled": True},
+        defaults={"enabled": True, "site_values": configuration},
     )
-    apply_appsembler_theme_configs(site_configuration, configuration)
+    if not created:
+        site_configuration.site_values = configuration
+        site_configuration.save()
 
     with patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
                return_value=site_configuration):

--- a/openedx/core/djangoapps/site_configuration/tests/test_util.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_util.py
@@ -35,6 +35,9 @@ def with_site_configuration(domain="test.localhost", configuration=None):
                 site_configuration.site_values = configuration
                 site_configuration.save()
 
+            # TODO: RED-2828 remove this line after ENABLE_CONFIG_VALUES_MODIFIER is enabled on prod
+            site_configuration.save()
+
             with patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
                        return_value=site_configuration):
                 with patch('openedx.core.djangoapps.theming.helpers.get_current_site', return_value=site):
@@ -61,6 +64,9 @@ def with_site_configuration_context(domain="test.localhost", configuration=None)
     if not created:
         site_configuration.site_values = configuration
         site_configuration.save()
+
+    # TODO: RED-2828 remove this line after ENABLE_CONFIG_VALUES_MODIFIER is enabled on prod
+    site_configuration.save()
 
     with patch('openedx.core.djangoapps.site_configuration.helpers.get_current_site_configuration',
                return_value=site_configuration):


### PR DESCRIPTION
### Benefits
 - enables the Platform 2.0 Site Creation API to work with no dependency over the SiteConfiguraiton service
 - this is useful to avoid needing too much `save()`

### Performance
This adds a query (`self.site`), we'll see how the performance work in staging/production.

I'm assuming it's a quick query that happens only once in a certain request.

### Testing
This is already tested via `test_tahoe_changes.py` file and the refactoring don't affect the functionality as far as I've noticed.

One test is added to cover the case of a new un-initialized site configuration instance.

### Risks
This change is risky, but I have no other feasible good way to provide defaults for Open edX. I'm going to test in staging and ask for some QA for:

([coordinating with QA](https://appsembler.slack.com/archives/C0249RFLREG/p1644909770397119))

 - [ ] Staging: AMC configurations
 - [ ] Staging: Compile Sass
 - [ ] Staging: Deployments
 - [ ] Staging: New sites trial signup (AMC)
 - [ ] Staging: Old sites
 - [ ] Staging: Activation email
 - [ ] Staging: New learner email

### TODO

 - [x] Quick test on devstack
 - [x] Put the change behind a Waffle Switch so it's safer on production

### Alternatives
 - [ ] ~Let Dashboard save those values -- I've got to discuss that with Matej~