### PR TITLE
Platform 2.0 site creation api

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/api_v2.py
+++ b/openedx/core/djangoapps/appsembler/sites/api_v2.py
@@ -12,6 +12,8 @@ import tahoe_sites.api
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
+from .serializers_v2 import TahoeSiteCreationSerializer
+
 
 log = logging.Logger(__name__)
 
@@ -36,3 +38,21 @@ class CompileSassView(views.APIView):
         configuration.init_api_client_adapter(site)
         configuration.compile_microsite_sass()
         return Response(status=status.HTTP_200_OK)
+
+
+class TahoeSiteCreateView(views.APIView):
+    """
+    Site creation API to create a Platform 2.0 Tahoe site.
+    """
+
+    serializer_class = TahoeSiteCreationSerializer
+    permission_classes = [ApiKeyHeaderPermission]
+
+    def post(self, request):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        site_data = serializer.save()
+        return Response({
+            'message': 'Site created successfully',
+            'site_uuid': site_data['site_uuid'],
+        }, status=status.HTTP_201_CREATED)

--- a/openedx/core/djangoapps/appsembler/sites/serializers_v2.py
+++ b/openedx/core/djangoapps/appsembler/sites/serializers_v2.py
@@ -1,0 +1,77 @@
+"""
+Platform 2.0 serializers.
+"""
+
+import beeline
+from rest_framework import serializers
+from django.core import validators
+
+import tahoe_sites.api
+
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+from openedx.core.djangoapps.appsembler.sites import site_config_client_helpers
+
+from .tasks import import_course_on_site_creation_after_transaction
+
+
+ORG_NAME_REGEX = r'^[a-zA-Z0-9\._-]+$'
+
+
+class TahoeSiteCreationSerializer(serializers.Serializer):
+    """
+    Platform 2.0 Tahoe site creation serializer.
+    """
+    site_uuid = serializers.UUIDField(required=False)
+    short_name = serializers.CharField(
+        required=True,
+        help_text=('Organization and site name. Please do not use spaces or special characters. '
+                   'Only allowed special character is hyphen (-).'),
+        validators=[
+            validators.RegexValidator(regex=ORG_NAME_REGEX),
+        ],
+    )
+    domain = serializers.CharField(
+        required=True,
+        help_text='Full domain name for the Tahoe site e.g. academy.tahoe.appsembler.com or courses.example.com',
+    )
+
+    class Meta:
+        fields = ('site_uuid', 'short_name', 'domain',)
+
+    @beeline.traced(name='TahoeSiteCreationSerializer.create')
+    def create(self, validated_data):
+        # assert False, validated_data
+        beeline.add_context_field('validated_data', validated_data)
+        created_site_data = tahoe_sites.api.create_tahoe_site(
+            domain=validated_data['domain'],
+            short_name=validated_data['short_name'],
+            uuid=validated_data.get('site_uuid'),
+        )
+
+        site = created_site_data['site']
+        organization = created_site_data['organization']
+
+        tahoe_custom_site_config_params = {}
+        if hasattr(SiteConfiguration, 'sass_variables'):
+            # This works SiteConfiguration with and without our custom
+            # fields of: sass_variables and page_elements.
+            # TODO: Fix Site Configuration hacks: https://github.com/appsembler/edx-platform/issues/329
+            tahoe_custom_site_config_params['page_elements'] = {}
+            tahoe_custom_site_config_params['sass_variables'] = {}
+
+        site_config = SiteConfiguration.objects.create(
+            site=site,
+            enabled=True,
+            site_values={},  # Empty values. Should use the `site_config_client_helpers` instead this field.
+            **tahoe_custom_site_config_params,
+        )
+
+        site_config_client_helpers.enable_for_site(site)
+        course_creation_task_scheduled = import_course_on_site_creation_after_transaction(organization)
+
+        return {
+            'site_config': site_config,
+            'course_creation_task_scheduled': course_creation_task_scheduled,
+            'site_configuration_client_enabled': True,
+            **created_site_data,
+        }

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_serializers_v2.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_serializers_v2.py
@@ -1,0 +1,89 @@
+"""
+Tests for Platform 2.0 Site Creation serializers view.
+"""
+import pytest
+from unittest.mock import patch
+
+from django.db import IntegrityError
+
+from openedx.core.djangoapps.appsembler.sites.serializers_v2 import TahoeSiteCreationSerializer
+
+
+@pytest.mark.django_db
+def test_create_site_serializer_with_uuid():
+    """
+    Create a site with a UUID to link it with other systems.
+    """
+    site_uuid = 'ee9894a6-898e-11ec-ab4d-9779d2628f5b'
+    serializer = TahoeSiteCreationSerializer(data={
+        'site_uuid': site_uuid,
+        'domain': 'blue-site.localhost',
+        'short_name': 'blue-site',
+    })
+
+    assert serializer.is_valid()
+
+    with patch(
+        'openedx.core.djangoapps.appsembler.sites.site_config_client_helpers.enable_for_site'
+    ) as mocked_enabled_for_site:
+        site_data = serializer.save()
+
+    assert mocked_enabled_for_site.call_count == 1, 'Should enable the site configuration service for new sites.'
+
+    assert site_data, 'Site should be created'
+    assert site_data['site'].domain == 'blue-site.localhost', 'Site domain should be set correctly'
+    assert site_data['site_config'], 'Site config should be created'
+    assert str(site_data['site_uuid']) == site_uuid, 'Should not generate different site UUID'
+
+
+@pytest.mark.django_db
+def test_create_site_serializer_with_no_uuid():
+    """
+    Create a site with no UUID, so the UUID should be created automatically.
+    """
+    serializer = TahoeSiteCreationSerializer(data={
+        'domain': 'blue-site.localhost',
+        'short_name': 'blue-site',
+    })
+
+    assert serializer.is_valid()
+    site_data = serializer.save()
+
+    assert site_data, 'Site should be created'
+    assert site_data['site'].domain == 'blue-site.localhost', 'Site domain should be set correctly'
+    assert site_data['site_config'], 'Site config should be created'
+    assert site_data['site_uuid'], 'Site uuid is created'
+
+
+@pytest.mark.django_db
+def test_create_site_serializer_invalid_organization_short_name():
+    serializer = TahoeSiteCreationSerializer(data={
+        'domain': 'blue-site.localhost',
+        'short_name': 'blue site',  # space should not be allowed
+    })
+    assert not serializer.is_valid()
+
+
+@pytest.mark.django_db
+def test_create_site_serializer_duplicate_uuid():
+    """
+    Should not allow creating two sites with the same UUID.
+    """
+    site_uuid = 'ee9894a6-898e-11ec-ab4d-9779d2628f5b'
+    serializer = TahoeSiteCreationSerializer(data={
+        'site_uuid': site_uuid,
+        'domain': 'blue-site.localhost',
+        'short_name': 'blue-site',
+    })
+    serializer.is_valid()
+    assert serializer.save()
+
+    duplicate_serializer = TahoeSiteCreationSerializer(data={
+        'site_uuid': site_uuid,
+        'domain': 'red-site.localhost',
+        'short_name': 'red-site',
+    })
+    duplicate_serializer.is_valid()
+
+    with pytest.raises(IntegrityError, match=r'UNIQUE constraint failed'):
+        duplicate_serializer.save()

--- a/openedx/core/djangoapps/appsembler/sites/urls.py
+++ b/openedx/core/djangoapps/appsembler/sites/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     url(r'^domain_switch/', DomainSwitchView.as_view()),
     url(r'^register/', SiteCreateView.as_view(), name='tahoe_site_creation'),
     url(r'^v2/compile_sass/', api_v2.CompileSassView.as_view(), name='tahoe_compile_sass'),
+    url(r'^v2/create-site/', api_v2.TahoeSiteCreateView.as_view(), name='tahoe_site_creation_v2'),
     url(r'^', include(router.urls)),
 ]
 


### PR DESCRIPTION
Creates a "Tahoe 2.0" site with:

 - tahoe_sites.models.TahoeSite and its UUID
 - organizations.models.Organization
 - Django `Site`
 - `SiteConfiguration` model for backward compatibility with Open edX
 - Enable the SiteConfigAdapter/client for this specific site
 - Link Site with Organization

Other notable differences:

 - This API don't attempt to create the `amc_admin` user which the AMC API used to created. This is not handled by the tahoe OAuth backend.