### PR TITLE
Handle failures on scss compile gracefully

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/serializers_v2.py
+++ b/openedx/core/djangoapps/appsembler/sites/serializers_v2.py
@@ -66,12 +66,15 @@ class TahoeSiteCreationSerializer(serializers.Serializer):
             **tahoe_custom_site_config_params,
         )
 
+        sass_status = site_config.compile_microsite_sass()
+
         site_config_client_helpers.enable_for_site(site)
         course_creation_task_scheduled = import_course_on_site_creation_after_transaction(organization)
 
         return {
-            'site_config': site_config,
+            'site_configuration': site_config,
             'course_creation_task_scheduled': course_creation_task_scheduled,
             'site_configuration_client_enabled': True,
+            **sass_status,
             **created_site_data,
         }

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_serializers_v2.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_serializers_v2.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from django.db import IntegrityError
 
 from openedx.core.djangoapps.appsembler.sites.serializers_v2 import TahoeSiteCreationSerializer
+from openedx.core.djangoapps.appsembler.sites.waffle import ENABLE_CONFIG_VALUES_MODIFIER
 
 
 @pytest.mark.django_db
@@ -32,7 +33,7 @@ def test_create_site_serializer_with_uuid():
 
     assert site_data, 'Site should be created'
     assert site_data['site'].domain == 'blue-site.localhost', 'Site domain should be set correctly'
-    assert site_data['site_config'], 'Site config should be created'
+    assert site_data['site_configuration'], 'Site config should be created'
     assert str(site_data['site_uuid']) == site_uuid, 'Should not generate different site UUID'
 
 
@@ -47,11 +48,16 @@ def test_create_site_serializer_with_no_uuid():
     })
 
     assert serializer.is_valid()
-    site_data = serializer.save()
+
+    with ENABLE_CONFIG_VALUES_MODIFIER.override(True):
+        site_data = serializer.save()
 
     assert site_data, 'Site should be created'
     assert site_data['site'].domain == 'blue-site.localhost', 'Site domain should be set correctly'
-    assert site_data['site_config'], 'Site config should be created'
+    assert site_data['site_configuration'], 'Site config should be created'
+    assert not site_data['site_configuration'].site_values, (
+        'Should have empty site_values because of ENABLE_CONFIG_VALUES_MODIFIER'
+    )
     assert site_data['site_uuid'], 'Site uuid is created'
 
 

--- a/openedx/core/djangoapps/appsembler/sites/urls.py
+++ b/openedx/core/djangoapps/appsembler/sites/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
     url(r'^custom_domain/', CustomDomainView.as_view()),
     url(r'^domain_switch/', DomainSwitchView.as_view()),
     url(r'^register/', SiteCreateView.as_view(), name='tahoe_site_creation'),
-    url(r'^v2/compile_sass/', api_v2.CompileSassView.as_view(), name='tahoe_compile_sass'),
+    url(r'^v2/compile-sass/', api_v2.CompileSassView.as_view(), name='tahoe_compile_sass'),
     url(r'^v2/create-site/', api_v2.TahoeSiteCreateView.as_view(), name='tahoe_site_creation_v2'),
     url(r'^', include(router.urls)),
 ]


### PR DESCRIPTION
### Changes

 - Never throw 500 exception on Sass compile errors
 - Return clear status with messages via CompileSassView and SiteCreateView of Tahoe 2.0 APIs
   * `successful_sass_compile`: boolean
   * `sass_compile_message`: Human readable message, with the sass compile error if any.
 - Return the compile error message in API response
 - Log the errors via `info`, and `warning` but not `exception` since the compile errors aren't relevant to Sentry
 - Exceptions other than `sass.CompileError` will still cause 500 error (backward compatible change)

### Incompatible changes
 - Save sites will never fail due to compile error, not that we like the failure but it's a noticeable change.
 - Now the compile sass view uses the url `/appsembler/api/v2/compile-sass/`