### PR TITLE
Sass Compile: Don't throw exception on missing `css_overrides_file`

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -62,9 +62,6 @@ def plugin_settings(settings):
     settings.HIJACK_ALLOW_GET_REQUESTS = True
     settings.HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'
 
-    # This flag helps to avoid throwing useless exceptions during testing
-    settings.TAHOE_SILENT_MISSING_CSS_CONFIG = False
-
     # This flag should be removed when we fully migrate all of Tahoe fork to Juniper
     # until then, instead of commenting out code, this flag should be used so we can easily find
     # and fix test issues

--- a/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
@@ -16,8 +16,6 @@ def plugin_settings(settings):
     settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'] = \
         getenv('TEST_APPSEMBLER_MULTI_TENANT_EMAILS', 'false') == 'true'
 
-    settings.TAHOE_SILENT_MISSING_CSS_CONFIG = True  # see ./common.py
-
     settings.TAHOE_ENABLE_CUSTOM_ERROR_VIEW = False  # see ./common.py
     settings.CUSTOMER_THEMES_BACKEND_OPTIONS = {}
 

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -208,6 +208,21 @@ def test_site_configuration_compile_sass_on_save_fail_gracefully(caplog, clean_s
 
 
 @pytest.mark.django_db
+def test_site_configuration_compile_sass_missing_override_file(caplog, clean_site_configuration_factory):
+    """
+    Ensure save() is successful on sass compile errors.
+    """
+    caplog.set_level(logging.INFO)
+    site_config = clean_site_configuration_factory(
+        site=Site.objects.create(domain='test.com'),
+    )
+    sass_status = site_config.compile_microsite_sass()
+    assert not sass_status['successful_sass_compile'], 'Should fail due to missing css_overrides_file'
+    assert 'Skipped compiling due to missing `css_overrides_file`' == sass_status['sass_compile_message']
+    assert 'missing `css_overrides_file`' in caplog.text, 'Should log failures instead of throwing an exception'
+
+
+@pytest.mark.django_db
 @patch('openedx.core.djangoapps.appsembler.sites.utils.compile_sass',
        Mock(side_effect=CompileError('CSS is not working -- Omar')))
 def test_site_configuration_compile_sass_failure(caplog, clean_site_configuration_factory):


### PR DESCRIPTION
More improvement for the Sass Compile system we have. Otherwise, it's noisy and fails on staging with needless 500 errors.