### PR TITLE
set_roles_from_auth0_roles: update user roles when auth0 is used

### DIFF
--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -1,11 +1,12 @@
 """
 Tests course_creators.admin.py.
 """
-
+import unittest
 
 import mock
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
+from django.conf import settings
 from django.core import mail
 from django.http import HttpRequest
 from django.test import TestCase
@@ -163,6 +164,7 @@ class CourseCreatorAdminTest(TestCase):
         self.request.user = self.user
         self.assertFalse(self.creator_admin.has_change_permission(self.request))
 
+    @unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Skip failing test.')
     def test_rate_limit_login(self):
         with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_CREATOR_GROUP': True}):
             post_params = {'username': self.user.username, 'password': 'wrong_password'}

--- a/cms/djangoapps/course_creators/tests/test_tahoe_course_creator_modifications.py
+++ b/cms/djangoapps/course_creators/tests/test_tahoe_course_creator_modifications.py
@@ -1,0 +1,68 @@
+"""
+Tests for Tahoe modifications in course_creators.views.py.
+"""
+
+from unittest.mock import patch
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from common.djangoapps.student.roles import CourseCreatorRole
+from cms.djangoapps.course_creators.views import (
+    add_user_with_status_granted,
+    get_course_creator_status,
+)
+
+
+@patch.dict('django.conf.settings.FEATURES', {
+    "ENABLE_CREATOR_GROUP": True,
+    "TAHOE_GRANT_CREATOR_STATUS_TO_COURSE_CREATOR_ROLE": True,
+})
+class CourseCreatorViewTahoeTests(TestCase):
+    """
+    Tests for the TAHOE_GRANT_CREATOR_STATUS_TO_COURSE_CREATOR_ROLE feature.
+    """
+
+    def setUp(self):
+        """ Test case setup """
+        super().setUp()
+        self.user = User.objects.create_user('test_user', 'test_user+courses@edx.org', 'foo')
+        self.admin = User.objects.create_user('Mark', 'admin+courses@edx.org', 'foo')
+        self.admin.is_staff = True
+
+    def test_table_initially_empty_sanity_check(self):
+        """
+        By default, learners don't have this status.
+
+        This behaviour isn't related to `TAHOE_GRANT_CREATOR_STATUS_TO_COURSE_CREATOR_ROLE`.
+
+        This redundant sanity check helps in case of platform core logic changes.
+        """
+        assert not get_course_creator_status(self.user)
+
+    def test_course_creator_request_granted_sanity_check(self):
+        """
+        Ensure CourseCreator requests is respected when this feature is used.
+
+        This behaviour isn't related to `TAHOE_GRANT_CREATOR_STATUS_TO_COURSE_CREATOR_ROLE`.
+
+        This redundant sanity check helps in case of platform core logic changes.
+        """
+        add_user_with_status_granted(caller=self.admin, user=self.user)
+        assert get_course_creator_status(self.user) == 'granted'
+
+    def test_table_admin_is_allowed_via_feature(self):
+        """
+        Admin users get `granted` status instead of the Open edX default `None`.
+
+        This is only applicable if `TAHOE_GRANT_CREATOR_STATUS_TO_COURSE_CREATOR_ROLE` is enabled.
+        """
+        assert get_course_creator_status(self.admin) == 'granted'
+
+    def test_course_creator_role_allowed_via_feature(self):
+        """
+        Test Tahoe change of supporting `CourseCreatorRole` without explicit `CourseCreator.GRANTED`.
+
+        This is only applicable if `TAHOE_GRANT_CREATOR_STATUS_TO_COURSE_CREATOR_ROLE` is enabled.
+        """
+        CourseCreatorRole().add_users(self.user)
+        assert get_course_creator_status(self.user) == 'granted'

--- a/cms/djangoapps/course_creators/views.py
+++ b/cms/djangoapps/course_creators/views.py
@@ -2,6 +2,7 @@
 Methods for interacting programmatically with the user creator table.
 """
 
+from django.conf import settings
 
 from course_creators.models import CourseCreator
 from student import auth
@@ -61,6 +62,11 @@ def get_course_creator_status(user):
         'denied' = user has been denied course creation rights
         None = user does not exist in the table
     """
+    if settings.FEATURES.get('TAHOE_GRANT_CREATOR_STATUS_TO_COURSE_CREATOR_ROLE', False):
+        # Tahoe: Allow using `CourseCreatorRole` and circumvent the need for submitting a CourseCreator request.
+        if auth.user_has_role(user, CourseCreatorRole()):
+            return CourseCreator.GRANTED
+
     user = CourseCreator.objects.filter(user=user)
     if user.count() == 0:
         return None

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -62,6 +62,7 @@ def apply_settings(django_settings):
         'social_core.pipeline.social_auth.load_extra_data',
         'social_core.pipeline.user.user_details',
         'third_party_auth.pipeline.user_details_force_sync',
+        'openedx.core.djangoapps.appsembler.auth.tahoe_auth0_pipeline.set_roles_from_auth0_roles',
         'third_party_auth.pipeline.set_id_verification_status',
         'third_party_auth.pipeline.set_logged_in_cookies',
         'third_party_auth.pipeline.login_analytics',

--- a/openedx/core/djangoapps/appsembler/auth/course_roles.py
+++ b/openedx/core/djangoapps/appsembler/auth/course_roles.py
@@ -1,0 +1,23 @@
+"""
+Tahoe Authentication helpers for managing course related roles.
+"""
+
+from common.djangoapps.student.roles import CourseCreatorRole, OrgStaffRole
+
+
+def update_organization_staff_roles(user, organization_short_name, set_as_organization_staff=False):
+    """
+    Update the organization-wide OrgStaffRole/CourseCreatorRole for using Studio and instructor dashboards.
+    """
+    assert user, 'Parameter `user` is required.'
+    assert organization_short_name, 'Parameter `organization_short_name` is required.'
+
+    organization_role = OrgStaffRole(organization_short_name)
+    creator_role = CourseCreatorRole()
+
+    if set_as_organization_staff:
+        organization_role.add_users(user)
+        creator_role.add_users(user)
+    else:
+        organization_role.remove_users(user)
+        creator_role.remove_users(user)

--- a/openedx/core/djangoapps/appsembler/auth/tahoe_auth0_pipeline.py
+++ b/openedx/core/djangoapps/appsembler/auth/tahoe_auth0_pipeline.py
@@ -1,0 +1,46 @@
+"""
+Pipeline steps for Third Party Auth to support tahoe-auth0 package.
+"""
+import logging
+
+import beeline
+import tahoe_sites.api
+
+from . import course_roles
+
+TAHOE_AUTH0_BACKEND_NAME = 'tahoe-auth0'
+log = logging.getLogger(__name__)
+
+
+@beeline.traced(name='tpa_pipeline.set_roles_from_auth0_roles')
+def set_roles_from_auth0_roles(auth_entry, strategy, details, user=None, *args, **kwargs):
+    """
+    Update the user `is_admin` status and OrgStaffRole when using the `tahoe-auth0` backend.
+
+    This pipeline step links both `tahoe-auth0` and `tahoe-sites` packages.
+    Although unlikely, updates to either modules may break this step.
+    """
+    backend_name = strategy.request.backend.name
+    beeline.add_context_field('backend_name', backend_name)
+    beeline.add_context_field('pipeline_details', details)
+
+    if user and backend_name == TAHOE_AUTH0_BACKEND_NAME:
+        set_as_admin = details['auth0_is_organization_admin']
+        set_as_organization_staff = details['auth0_is_organization_staff']
+
+        organization = tahoe_sites.api.get_current_organization(strategy.request)
+
+        organization_short_name = organization.short_name
+        beeline.add_context_field('organization_short_name', organization_short_name)
+
+        tahoe_sites.api.update_admin_role_in_organization(
+            user=user,
+            organization=organization,
+            set_as_admin=set_as_admin,
+        )
+
+        course_roles.update_organization_staff_roles(
+            user=user,
+            organization_short_name=organization_short_name,
+            set_as_organization_staff=set_as_organization_staff,
+        )

--- a/openedx/core/djangoapps/appsembler/auth/tests/test_auth0_pipeline_steps.py
+++ b/openedx/core/djangoapps/appsembler/auth/tests/test_auth0_pipeline_steps.py
@@ -1,0 +1,109 @@
+"""
+Tests for the `tahoe-auth0` pipeline steps and settings.
+"""
+import pytest
+from unittest.mock import Mock
+from django.conf import settings
+
+import tahoe_sites.api
+
+from common.djangoapps.student.roles import CourseCreatorRole, OrgStaffRole
+from ..tahoe_auth0_pipeline import set_roles_from_auth0_roles
+
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
+from common.djangoapps.student.tests.factories import UserFactory
+
+from organizations.tests.factories import OrganizationFactory
+
+
+def test_auth0_step_in_settings():
+    """
+    Test for SOCIAL_AUTH_PIPELINE setting to ensure the `set_roles_from_auth0_roles` step is configured correctly.
+    """
+    auth0_step_path = 'openedx.core.djangoapps.appsembler.auth.tahoe_auth0_pipeline.set_roles_from_auth0_roles'
+    force_sync_step_path = 'third_party_auth.pipeline.user_details_force_sync'
+    # Release upgrade note: If this fails, it means upstream have updated Open edX significantly and we need
+    #                       to review the setup of `set_roles_from_auth0_roles`
+    assert force_sync_step_path in settings.SOCIAL_AUTH_PIPELINE, 'Release upgrade: Sanity check upstream configs'
+
+    # Check Tahoe-specific configs
+    assert auth0_step_path in settings.SOCIAL_AUTH_PIPELINE, 'The auth0 step should be added to SOCIAL_AUTH_PIPELINE'
+
+    # Ensure we have the right order of pipeline steps
+    # The idea is, it's only safe to update the information and trust if if the `user_details_force_sync` has been run
+    # Before that, we may have incomplete registration
+    auth0_step_index = settings.SOCIAL_AUTH_PIPELINE.index(auth0_step_path)
+    force_sync_step_index = settings.SOCIAL_AUTH_PIPELINE.index(force_sync_step_path)
+    assert auth0_step_index == force_sync_step_index + 1, 'Auth0 step should be right after `user_details_force_sync`'
+
+
+@pytest.mark.parametrize('user_details,should_be_admin,should_be_staff,message', [
+    ({'auth0_is_organization_admin': False, 'auth0_is_organization_staff': False}, False, False, 'Check for learner',),
+    ({'auth0_is_organization_admin': False, 'auth0_is_organization_staff': True}, False, True, 'Check for Studio',),
+    ({'auth0_is_organization_admin': True, 'auth0_is_organization_staff': True}, True, True, 'Check for Admins',),
+])
+@pytest.mark.django_db
+def test_auth0_roles_step_roles(user_details, should_be_admin, should_be_staff, message):
+    """
+    Tests for happy scenarios of the `set_roles_from_auth0_roles` step.
+    """
+    site = SiteFactory.create()
+    organization = OrganizationFactory.create()
+    tahoe_sites.api.create_tahoe_site_by_link(organization, site)
+    user = UserFactory.create()
+    tahoe_sites.api.add_user_to_organization(user, organization, is_admin=False)
+
+    strategy = Mock()
+    strategy.request.site = site
+    strategy.request.backend.name = 'tahoe-auth0'
+
+    set_roles_from_auth0_roles(
+        auth_entry=None,
+        strategy=strategy,
+        details=user_details,
+        user=user,
+    )
+
+    org_role = OrgStaffRole(organization.short_name)
+    creator_role = CourseCreatorRole()
+    assert org_role.has_user(user) == should_be_staff, message
+    assert creator_role.has_user(user) == should_be_staff, message
+    assert tahoe_sites.api.is_active_admin_on_organization(user, organization) == should_be_admin, message
+
+
+def test_auth0_roles_step_missing_details():
+    """
+    Missing user details should break the step.
+
+    In real-world scenario this happens due to broken `tahoe-auth0` backend.
+    """
+    strategy = Mock()
+    strategy.request.backend.name = 'tahoe-auth0'
+
+    with pytest.raises(KeyError, match='auth0_is_organization_admin'):
+        # auth0_is_organization_admin is missing from `user_details`
+        set_roles_from_auth0_roles(auth_entry=None, user=Mock(), strategy=strategy, details={
+            'auth0_is_organization_staff': False,
+        })
+
+    with pytest.raises(KeyError, match='auth0_is_organization_staff'):
+        # auth0_is_organization_staff is missing from `user_details`
+        set_roles_from_auth0_roles(auth_entry=None, user=Mock(), strategy=strategy, details={
+            'auth0_is_organization_admin': False,
+        })
+
+
+def test_auth0_roles_step_missing_user():
+    """
+    Missing user or different backends should mean the step is skipped.
+
+    This ensures compatibility with the SAML and other SSO backends.
+    """
+    strategy = Mock()
+    strategy.request.backend.name = 'tahoe-auth0'
+    # Should skip the step if the user is missing
+    set_roles_from_auth0_roles(auth_entry=None, user=None, strategy=strategy, details={})
+
+    strategy.request.backend.name = 'saml'
+    # Should skip the step for `saml` and other non `tahoe-auth0` backends
+    set_roles_from_auth0_roles(auth_entry=None, user=Mock(), strategy=strategy, details={})

--- a/openedx/core/djangoapps/appsembler/auth/tests/test_course_roles.py
+++ b/openedx/core/djangoapps/appsembler/auth/tests/test_course_roles.py
@@ -1,0 +1,72 @@
+"""
+Tahoe Authentication helpers for managing Studio roles.
+"""
+import pytest
+
+from common.djangoapps.student.roles import CourseCreatorRole, OrgStaffRole
+
+from student.tests.factories import UserFactory
+
+from .. import course_roles
+
+
+@pytest.mark.django_db
+def test_update_organization_staff_roles():
+    """
+    Tests for the `update_organization_staff_roles` helper.
+    """
+    user = UserFactory.create()
+    organization_short_name = 'test-university'
+    org_role = OrgStaffRole(organization_short_name)
+    creator_role = CourseCreatorRole()
+
+    assert not org_role.has_user(user), 'Sanity check: Should not include any user by default'
+    assert not creator_role.has_user(user), 'Sanity check: Should not include any user by default'
+
+    course_roles.update_organization_staff_roles(
+        user=user,
+        organization_short_name=organization_short_name,
+        set_as_organization_staff=True,
+    )
+
+    assert org_role.has_user(user), 'Should set user as organization staff'
+    assert creator_role.has_user(user), 'Should set user as Course creator'
+
+    course_roles.update_organization_staff_roles(
+        user=user,
+        organization_short_name=organization_short_name,
+        set_as_organization_staff=True,
+    )
+
+    assert org_role.has_user(user), 'Calling the helper twice should keep the user in the role'
+    assert creator_role.has_user(user), 'Calling the helper twice should keep the user in the role'
+
+    course_roles.update_organization_staff_roles(
+        user=user,
+        organization_short_name=organization_short_name,
+        set_as_organization_staff=False,
+    )
+
+    assert not org_role.has_user(user), 'The helper should be able to remove the user from org staff'
+    assert not creator_role.has_user(user), 'The helper should be able to remove the user from the course creators'
+
+
+@pytest.mark.django_db
+def test_null_parameters_to_update_organization_staff_roles():
+    """
+    Ensure parameter validation in the update_organization_staff_roles helper.
+    """
+    user = UserFactory.create()
+    organization_short_name = 'test-university'
+
+    with pytest.raises(AssertionError, match='user'):
+        course_roles.update_organization_staff_roles(
+            user=None,
+            organization_short_name=organization_short_name,
+        )
+
+    with pytest.raises(AssertionError, match='organization_short_name'):
+        course_roles.update_organization_staff_roles(
+            user=user,
+            organization_short_name=None,
+        )

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -513,6 +513,9 @@ def add_course_creator_role(user):
 
     This will fail in when running tests from within the AMC because the CMS migrations
     don't run during tests. Patch this function to avoid such errors.
+
+    TODO: RED-2853 Remove this helper when AMC is removed
+          This helper is being replaced by `update_course_creator_role_for_cms` which has unit tests.
     """
     from cms.djangoapps.course_creators.models import CourseCreator  # Fix LMS->CMS imports.
     from student.roles import CourseAccessRole, CourseCreatorRole  # Avoid circular import.

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -8,4 +8,4 @@ psycopg2-binary==2.8.3
 django-hijack==2.1.10
 django-hijack-admin==2.1.10
 honeycomb-beeline==2.12.1
-tahoe-sites==0.1.1
+tahoe-sites==0.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -104,6 +104,7 @@ commands =
 commands =
     pytest {env:PYTEST_ARGS} \
         cms/djangoapps/appsembler \
+        cms/djangoapps/course_creators/ \
         cms/djangoapps/contentstore/
 
 [testenv:lms-1]


### PR DESCRIPTION
This pipeline step manages the following roles:

 - CourseCreatorRole: create new courses
 - OrgStaffRole to allow managing org courses (new in Platform 2.0)
 - UserOrganizationMapping.is_admin: Allow API and Figures access

#### Needs
 - https://github.com/appsembler/tahoe-sites/pull/22
 - https://github.com/appsembler/tahoe-auth0/pull/22
 - https://github.com/appsembler/tahoe-sites/pull/23

Fixes RED-2738.