### PR TITLE
WIP: Fix prereq bug in studio

### DIFF
--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -265,14 +265,12 @@ class TestStaffMasqueradeAsStudent(StaffMasqueradeTestCase):
         self.update_masquerade(role='staff')
         self.verify_show_answer_present(True)
 
-    @patch.dict("django.conf.settings.FEATURES",
-    {'ENABLE_PREREQUISITE_COURSES': True})
+    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
     def test_staff_masquerade_prereq_course(self):
         """
         Test that Staff user can masquerade as a student for a course with prereq.
         """
         self.update_masquerade(role='student')
-
 
 
 @ddt.ddt
@@ -357,8 +355,7 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         u'fôô@bar',  # Unicode username with @, which is what the ENABLE_UNICODE_USERNAME feature allows
     )
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
-    @patch.dict("django.conf.settings.FEATURES",
-    {'ENABLE_PREREQUISITE_COURSES': True})
+    @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
     def test_masquerade_as_specific_student(self, username):
         """
         Test masquerading as a specific user.


### PR DESCRIPTION
## [RED-2584](https://appsembler.atlassian.net/browse/RED-2584)

### Background
There is a bug in studio where a `staff` user is unable to view the course as a `student` when the course has prerequisites.

### Debugging Steps

- Add prerequisite setting to test case: this resulted in the test failing and and revealed a new error

```
# added prereq to test
   @patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
```

```
# new error
milestones.models.MilestoneRelationshipType.DoesNotExist: 
MilestoneRelationshipType matching query does not exist.
```

- [MilestoneRelationshipType](https://github.com/openedx/edx-milestones/blob/master/milestones/models.py#L38-L74) : links course prerequisites to the student 

- Update test by creating `MilestoneRelationshipType` object to test course, and calling Milestone apis (`api.add_milestone` and `api.add_user_milestone`) to link milestone with student


### Questions
- @OmarIthawi are we able to convert the test `course.id` ➡️  course key? I am getting an error on this line [here](https://github.com/appsembler/edx-platform/blob/esther/fix-prereq-bug/lms/djangoapps/courseware/tests/test_masquerade.py#L366):
 ```
# Test Error:
cls = <class 'opaque_keys.edx.keys.CourseKey'>
serialized = CourseDescriptorWithMixins(CombinedSystem(None, CachingDescriptorSystem(<xmodule.modulestore.mongo.draft.DraftModuleSt...un_0'), usage_id=BlockUsageLocator(CourseLocator('org.0', 'masquerade-test', 'Run_0', None, None), 'course', 'Run_0')))

    @classmethod
    def _separate_namespace(cls, serialized):
        """
        Return the namespace from a serialized :class:`OpaqueKey`, and
        the rest of the key.
    
        Args:
            serialized (unicode): A serialized :class:`OpaqueKey`.
    
        Raises:
            MissingNamespace: Raised when no namespace can be
                extracted from `serialized`.
        """
>       namespace, __, rest = serialized.partition(cls.NAMESPACE_SEPARATOR)
E       AttributeError: 'CourseDescriptorWithMixins' object has no attribute 'partition
```