### PR TITLE
fix: log a single line warning in case of video_transcrip NotFound instead of long detailed exception

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -348,8 +348,13 @@ class VideoStudentViewHandlers(object):
                     mimetype,
                     add_attachment_header=False
                 )
-            except NotFoundError:
-                log.exception('[Translation Dispatch] %s', self.location)
+            except NotFoundError as exc:
+                edx_video_id = clean_video_id(self.edx_video_id)
+                log.warning(
+                    '[Translation Dispatch] %s: %s',
+                    self.location,
+                    exc if is_bumper else f'Transcript not found for {edx_video_id}, lang: {self.transcript_language}',
+                )
                 response = self.get_static_transcript(request, transcripts)
 
         elif dispatch == 'download':

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -350,10 +350,14 @@ class VideoStudentViewHandlers(object):
                 )
             except NotFoundError as exc:
                 edx_video_id = clean_video_id(self.edx_video_id)
+                not_found_message = 'Transcript not found for {edx_video_id}, lang: {transcript_language}'.format(
+                    edx_video_id=edx_video_id,
+                    transcript_language=self.transcript_language,
+                )
                 log.warning(
                     '[Translation Dispatch] %s: %s',
                     self.location,
-                    exc if is_bumper else f'Transcript not found for {edx_video_id}, lang: {self.transcript_language}',
+                    exc if is_bumper else not_found_message,
                 )
                 response = self.get_static_transcript(request, transcripts)
 


### PR DESCRIPTION
Fixes RED-2796. Thanks Anders for the great find.

Cherry picks:

 - https://github.com/openedx/edx-platform/pull/28552