### PR TITLE
Use tahoe-sites.api - Patch 01

### DIFF
--- a/cms/djangoapps/appsembler_tiers/views.py
+++ b/cms/djangoapps/appsembler_tiers/views.py
@@ -5,8 +5,7 @@ Studio views for the tiers app.
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
-
-from openedx.core.djangoapps.appsembler.sites.utils import get_single_user_organization
+from tahoe_sites.api import get_organization_for_user
 
 
 class SiteUnavailableRedirectView(TemplateView):
@@ -19,7 +18,7 @@ class SiteUnavailableRedirectView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(SiteUnavailableRedirectView, self).get_context_data(**kwargs)
-        context['organization'] = get_single_user_organization(self.request.user)
+        context['organization'] = get_organization_for_user(self.request.user)
         return context
 
     @method_decorator(login_required)

--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -13,10 +13,10 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods, require_POST
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator
+from tahoe_sites.api import get_organization_for_user
 
 from course_creators.views import user_requested_access
 from edxmako.shortcuts import render_to_response
-from openedx.core.djangoapps.appsembler.sites.utils import get_single_user_organization
 from student import auth
 from student.auth import STUDIO_EDIT_ROLES, STUDIO_VIEW_USERS, get_user_permissions
 from student.models import CourseEnrollment
@@ -131,7 +131,7 @@ def _course_team_user(request, course_key, email):
                 #   organization from the requesting user. This is secure given the
                 #   `get_user_permissions` check above. Still we're not using this softer
                 #   check for courses because security isn't fully reviewed.
-                organization = get_single_user_organization(request.user)
+                organization = get_organization_for_user(request.user)
             else:
                 organization = Organization.objects.get(organizationcourse__course_id=course_key)
             user = organization.userorganizationmapping_set.get(user__email=email).user

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -24,9 +24,8 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
 from organizations.models import Organization
-from tahoe_sites.api import get_site_by_organization
+from tahoe_sites.api import get_organization_for_user, get_site_by_organization
 
-from openedx.core.djangoapps.appsembler.sites.utils import get_single_user_organization
 from openedx.core.djangoapps.waffle_utils import WaffleSwitch
 from openedx.core.lib.courses import clean_course_id
 from student import STUDENT_WAFFLE_NAMESPACE
@@ -533,7 +532,7 @@ class RegistrationAdmin(admin.ModelAdmin):
     def organization(self, obj):
         """ Show the organization name. """
         try:
-            org = get_single_user_organization(obj.user)
+            org = get_organization_for_user(obj.user)
         except Organization.DoesNotExist:
             return None
 
@@ -545,7 +544,7 @@ class RegistrationAdmin(admin.ModelAdmin):
             return 'Learner is active.'
 
         try:
-            organization = get_single_user_organization(obj.user)
+            organization = get_organization_for_user(obj.user)
             site = get_site_by_organization(organization)
         except Organization.DoesNotExist:
             return 'Error: missing organization.'

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -24,11 +24,9 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
 from organizations.models import Organization
+from tahoe_sites.api import get_site_by_organization
 
-from openedx.core.djangoapps.appsembler.sites.utils import (
-    get_single_user_organization,
-    get_site_by_organization,
-)
+from openedx.core.djangoapps.appsembler.sites.utils import get_single_user_organization
 from openedx.core.djangoapps.waffle_utils import WaffleSwitch
 from openedx.core.lib.courses import clean_course_id
 from student import STUDENT_WAFFLE_NAMESPACE

--- a/common/djangoapps/student/tests/test_tahoe_admin.py
+++ b/common/djangoapps/student/tests/test_tahoe_admin.py
@@ -7,7 +7,7 @@ from organizations.models import Organization
 from student.admin import RegistrationAdmin
 
 
-@patch('student.admin.get_single_user_organization', Mock(side_effect=Organization.DoesNotExist))
+@patch('student.admin.get_organization_for_user', Mock(side_effect=Organization.DoesNotExist))
 def test_activation_link_no_org():
     """
     Missing organizations are handled gracefully.
@@ -28,7 +28,7 @@ def test_activation_link_learner_is_active():
     assert link == 'Learner is active.'
 
 
-@patch('student.admin.get_single_user_organization', Mock())
+@patch('student.admin.get_organization_for_user', Mock())
 @patch('student.admin.get_site_by_organization', Mock(return_value=Mock(domain='somesite.org')))
 def test_activation_link():
     """

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -7,10 +7,7 @@ import logging
 from django.conf import settings
 from django.contrib.auth.models import User
 
-from openedx.core.djangoapps.appsembler.sites.utils import (
-    get_current_organization,
-    get_single_user_organization
-)
+from openedx.core.djangoapps.appsembler.sites.utils import get_current_organization
 
 logger = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -39,17 +39,11 @@ def get_site_config_for_event(event_props):
     Return a SiteConfiguration object if found; otherwise, None.
 
     django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet
-
-    We get the site matching the org direcly from the organization object
-    instead of calling 'appsembler.sites.utils.get_site_by_organization'. The
-    problem is that importing 'appsembler.sites.utils' in this module at the
-    module level causes the following exception:
-
-        `django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet`
     """
 
     # try first via request obj in thread
     from organizations.models import Organization
+    from tahoe_sites.api import get_site_by_organization
 
     site_configuration = get_current_site_configuration()
     if not site_configuration:
@@ -71,11 +65,7 @@ def get_site_config_for_event(event_props):
                     "There isn't and org, course_key or course_id attribute set in the "
                     "segment event, so we couldn't determine the site."
                 )
-            # Same logic as in 'appsembler.sites.utils.get_site_by_organization'
-            # See function docstring for additional comments
-            assert org.sites.count() == 1, 'Should have one and only one site.'
-            site = org.sites.all()[0]
-            site_configuration = site.configuration
+            site_configuration = get_site_by_organization(org).configuration
         except (
             AttributeError,
             TypeError,

--- a/openedx/core/djangoapps/appsembler/sites/admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/admin.py
@@ -13,11 +13,11 @@ from student.admin import UserAdmin
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
 from organizations.models import UserOrganizationMapping
+from tahoe_sites.api import get_organization_for_user
 
 from openedx.core.djangoapps.appsembler.sites.forms import MakeAMCAdminForm
 from openedx.core.djangoapps.appsembler.sites.utils import (
     get_amc_tokens,
-    get_single_user_organization,
     make_amc_admin,
 )
 
@@ -47,7 +47,7 @@ class TahoeUserAdmin(UserAdmin, HijackUserAdminMixin):
         user = self.get_object(request, user_id)
 
         try:
-            current_org = get_single_user_organization(user)
+            current_org = get_organization_for_user(user)
             current_org_name = current_org.name
         except (UserOrganizationMapping.DoesNotExist, MultipleObjectsReturned):
             current_org_name = ''

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -49,15 +49,6 @@ def get_lms_link_from_course_key(base_lms_url, course_key):
     return base_lms_url
 
 
-@beeline.traced(name="get_site_by_organization")
-def get_site_by_organization(org):
-    """
-    Get the site matching the organization, throws an error if there's more than one site.
-    """
-    assert org.sites.count() == 1, 'Should have one and only one site.'
-    return org.sites.all()[0]
-
-
 def _get_active_tiers_uuids():
     """
     Get active Tier organiation UUIDs from the Tiers (AMC Postgres) database.

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -25,6 +25,7 @@ from django.utils.text import slugify
 from organizations import api as org_api
 from organizations import models as org_models
 from organizations.models import UserOrganizationMapping, Organization
+from tahoe_sites.api import get_organization_for_user
 
 from openedx.core.lib.api.api_key_permissions import is_request_has_valid_api_key
 from openedx.core.lib.log_utils import audit_log
@@ -187,17 +188,6 @@ def reset_amc_tokens(user, access_token=None, refresh_token=None):
     refresh.save()
 
     return get_amc_tokens(user)
-
-
-@beeline.traced(name="get_single_user_organization")
-def get_single_user_organization(user):
-    """
-    Finds the single organization the user is associated with.
-
-    If there's more than one, an exception is thrown.
-    """
-    uom = UserOrganizationMapping.objects.get(user=user)
-    return uom.organization
 
 
 @beeline.traced(name="make_amc_admin")

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -35,11 +35,11 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
 from six import iteritems, text_type
 from social_django.models import UserSocialAuth
+from tahoe_sites.api import get_organization_for_user
 from wiki.models import ArticleRevision
 from wiki.models.pluginbase import RevisionPluginRevision
 
 from entitlements.models import CourseEntitlement
-from openedx.core.djangoapps.appsembler.sites.utils import get_single_user_organization
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.api_admin.models import ApiAccessRequest
 from openedx.core.djangoapps.course_groups.models import UnregisteredLearnerCohortAssignments
@@ -492,7 +492,7 @@ class DeactivateLogoutView(APIView):
         profile = user.profile
         meta = profile.get_meta()
 
-        organization = get_single_user_organization(user)
+        organization = get_organization_for_user(user)
 
         # Store the original email in the case of Account Deletion cancellation is needed
         # This value will be removed when the pipeline is executed, so it won't

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -8,5 +8,5 @@ psycopg2-binary==2.8.3
 django-hijack==2.1.10
 django-hijack-admin==2.1.10
 honeycomb-beeline==2.12.1
-tahoe-sites==0.1.2
+tahoe-sites==0.1.5
 site-configuration-client==0.1.3


### PR DESCRIPTION
## Change description

* Use `tahoe-sites==0.1.5`
* Use `tahoe-sites.apis.get_site_by_organization` instead of repeating the logic inside the repo
* Use `tahoe-sites.apis.get_organization_for_user` instead of repeating the logic inside the repo


## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
