### PR TITLE
fix: YouTube video transcrips Import

### DIFF
--- a/cms/djangoapps/contentstore/features/transcripts.py
+++ b/cms/djangoapps/contentstore/features/transcripts.py
@@ -45,6 +45,7 @@ TRANSCRIPTS_BUTTONS = {
     'download_to_edit': ('.setting-download', 'Download Transcript for Editing'),
     'disabled_download_to_edit': ('.setting-download.is-disabled', 'Download Transcript for Editing'),
     'upload_new_timed_transcripts': ('.setting-upload', 'Upload New Transcript'),
+    'download_youtube_transcripts': ('.setting-download-youtube-transcript', 'Download YouTube Transcript'),
     'replace': ('.setting-replace', 'Yes, replace the edX transcript with the YouTube transcript'),
     'choose': ('.setting-choose', 'Timed Transcript from {}'),
     'use_existing': ('.setting-use-existing', 'Use Current Transcript'),

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -87,7 +87,7 @@ def upload_transcripts(request):
     except (InvalidKeyError, ItemNotFoundError):
         return error_response(response, "Can't find item by locator.")
 
-    if 'transcript-file' not in request.FILES:
+    if 'transcript-file' not in request.FILES and not request.POST.get('transcript-file'):
         return error_response(response, 'POST data without "file" form data.')
 
     video_list = request.POST.get('video_list')
@@ -99,9 +99,13 @@ def upload_transcripts(request):
     except ValueError:
         return error_response(response, 'Invalid video_list JSON.')
 
-    # Used utf-8-sig encoding type instead of utf-8 to remove BOM(Byte Order Mark), e.g. U+FEFF
-    source_subs_filedata = request.FILES['transcript-file'].read().decode('utf-8-sig')
-    source_subs_filename = request.FILES['transcript-file'].name
+    if 'transcript-file' in request.FILES:
+        # Used utf-8-sig encoding type instead of utf-8 to remove BOM(Byte Order Mark), e.g. U+FEFF
+        source_subs_filedata = request.FILES['transcript-file'].read().decode('utf-8-sig')
+        source_subs_filename = request.FILES['transcript-file'].name
+    elif request.POST.get('transcript-file') and request.POST.get('transcript-name'):
+        source_subs_filedata = request.POST.get('transcript-file').encode('utf-8')
+        source_subs_filename = request.POST.get('transcript-name')
 
     if '.' not in source_subs_filename:
         return error_response(response, "Undefined file extension.")

--- a/cms/static/js/views/video/transcripts/message_manager.js
+++ b/cms/static/js/views/video/transcripts/message_manager.js
@@ -6,231 +6,293 @@ define(
     ],
 function($, Backbone, _, Utils, FileUploader, gettext) {
     var MessageManager = Backbone.View.extend({
-        tagName: 'div',
-        elClass: '.wrapper-transcripts-message',
-        invisibleClass: 'is-invisible',
+      tagName: "div",
+      elClass: ".wrapper-transcripts-message",
+      invisibleClass: "is-invisible",
 
-        events: {
-            'click .setting-import': 'importHandler',
-            'click .setting-replace': 'replaceHandler',
-            'click .setting-choose': 'chooseHandler',
-            'click .setting-use-existing': 'useExistingHandler'
-        },
+      events: {
+        "click .setting-import": "importHandler",
+        "click .setting-replace": "replaceHandler",
+        "click .setting-choose": "chooseHandler",
+        "click .setting-use-existing": "useExistingHandler",
+        "click .setting-download-youtube-transcript":
+          "downloadYoutubeTranscriptHandler",
+      },
 
-        // Pre-defined dict with anchors to status templates.
-        templates: {
-            not_found: '#transcripts-not-found',
-            found: '#transcripts-found',
-            import: '#transcripts-import',
-            replace: '#transcripts-replace',
-            uploaded: '#transcripts-uploaded',
-            use_existing: '#transcripts-use-existing',
-            choose: '#transcripts-choose'
-        },
+      // Pre-defined dict with anchors to status templates.
+      templates: {
+        not_found: "#transcripts-not-found",
+        found: "#transcripts-found",
+        import: "#transcripts-import",
+        replace: "#transcripts-replace",
+        uploaded: "#transcripts-uploaded",
+        use_existing: "#transcripts-use-existing",
+        choose: "#transcripts-choose",
+      },
 
-        initialize: function(options) {
-            _.bindAll(this,
-                'importHandler', 'replaceHandler', 'chooseHandler', 'useExistingHandler', 'showError', 'hideError'
-            );
+      initialize: function (options) {
+        _.bindAll(
+          this,
+          "importHandler",
+          "replaceHandler",
+          "chooseHandler",
+          "useExistingHandler",
+          "showError",
+          "hideError"
+        );
 
-            this.options = _.extend({}, options);
+        this.options = _.extend({}, options);
 
-            this.component_locator = this.$el.closest('[data-locator]').data('locator');
+        this.component_locator = this.$el
+          .closest("[data-locator]")
+          .data("locator");
 
-            this.fileUploader = new FileUploader({
-                el: this.$el,
-                messenger: this,
-                component_locator: this.component_locator,
-                videoListObject: this.options.parent
-            });
-        },
+        this.fileUploader = new FileUploader({
+          el: this.$el,
+          messenger: this,
+          component_locator: this.component_locator,
+          videoListObject: this.options.parent,
+        });
+      },
 
-        render: function(template_id, params) {
-            var tplHtml = $(this.templates[template_id]).text(),
-                videoList = this.options.parent.getVideoObjectsList(),
-            // Change list representation format to more convenient and group
-            // them by video property.
-            //                  Before:
-            // [
-            //      {mode: `html5`, type: `mp4`, video: `video_name_1`},
-            //      {mode: `html5`, type: `webm`, video: `video_name_2`}
-            // ]
-            //                  After:
-            // {
-            //      `video_name_1`: [{mode: `html5`, type: `webm`, ...}],
-            //      `video_name_2`: [{mode: `html5`, type: `mp4`, ...}]
-            // }
-                groupedList = _.groupBy(
-                    videoList,
-                    function(value) {
-                        return value.video;
-                    }
-                ),
-                html5List = (params) ? params.html5_local : [],
-                template;
+      render: function (template_id, params) {
+        var tplHtml = $(this.templates[template_id]).text(),
+          videoList = this.options.parent.getVideoObjectsList(),
+          // Change list representation format to more convenient and group
+          // them by video property.
+          //                  Before:
+          // [
+          //      {mode: `html5`, type: `mp4`, video: `video_name_1`},
+          //      {mode: `html5`, type: `webm`, video: `video_name_2`}
+          // ]
+          //                  After:
+          // {
+          //      `video_name_1`: [{mode: `html5`, type: `webm`, ...}],
+          //      `video_name_2`: [{mode: `html5`, type: `mp4`, ...}]
+          // }
+          groupedList = _.groupBy(videoList, function (value) {
+            return value.video;
+          }),
+          html5List = params ? params.html5_local : [],
+          template;
 
-            if (!tplHtml) {
-                console.error('Couldn\'t load Transcripts status template');
+        if (!tplHtml) {
+          console.error("Couldn't load Transcripts status template");
 
-                return this;
-            }
-
-            template = _.template(tplHtml);
-
-            this.$el.find('.transcripts-status')
-                .removeClass('is-invisible')
-                .find(this.elClass).html(template({
-                    component_locator: encodeURIComponent(this.component_locator),
-                    html5_list: html5List,
-                    grouped_list: groupedList,
-                    subs_id: (params) ? params.subs : ''
-                }));
-
-            this.fileUploader.render();
-
-            return this;
-        },
-
-        /**
-        * @function
-        *
-        * Shows error message.
-        *
-        * @param {string} err Error message that will be shown
-        *
-        * @param {boolean} hideButtons Hide buttons
-        *
-        */
-        showError: function(err, hideButtons) {
-            var $error = this.$el.find('.transcripts-error-message');
-
-            if (err) {
-                // Hide any other error messages.
-                this.hideError();
-
-                $error
-                    .html(gettext(err))
-                    .removeClass(this.invisibleClass);
-
-                if (hideButtons) {
-                    this.$el.find('.wrapper-transcripts-buttons')
-                        .addClass(this.invisibleClass);
-                }
-            }
-        },
-
-        /**
-        * @function
-        *
-        * Hides error message.
-        *
-        */
-        hideError: function() {
-            this.$el.find('.transcripts-error-message')
-                .addClass(this.invisibleClass);
-
-            this.$el.find('.wrapper-transcripts-buttons')
-                .removeClass(this.invisibleClass);
-        },
-
-        /**
-        * @function
-        *
-        * Handle import button.
-        *
-        * @params {object} event Event object.
-        *
-        */
-        importHandler: function(event) {
-            event.preventDefault();
-
-            this.processCommand('replace', gettext('Error: Import failed.'));
-        },
-
-        /**
-        * @function
-        *
-        * Handle replace button.
-        *
-        * @params {object} event Event object.
-        *
-        */
-        replaceHandler: function(event) {
-            event.preventDefault();
-
-            this.processCommand('replace', gettext('Error: Replacing failed.'));
-        },
-
-        /**
-        * @function
-        *
-        * Handle choose buttons.
-        *
-        * @params {object} event Event object.
-        *
-        */
-        chooseHandler: function(event) {
-            event.preventDefault();
-
-            var videoId = $(event.currentTarget).data('video-id');
-
-            this.processCommand('choose', gettext('Error: Choosing failed.'), videoId);
-        },
-
-        /**
-        * @function
-        *
-        * Handle `use existing` button.
-        *
-        * @params {object} event Event object.
-        *
-        */
-        useExistingHandler: function(event) {
-            event.preventDefault();
-
-            this.processCommand('rename', gettext('Error: Choosing failed.'));
-        },
-
-        /**
-        * @function
-        *
-        * Decorator for `command` function in the Utils.
-        *
-        * @params {string} action Action that will be invoked on server. Is a part
-        *                         of url.
-        *
-        * @params {string} errorMessage Error massage that will be shown if any
-        *                               connection error occurs
-        *
-        * @params {string} videoId Extra parameter that sometimes should be sent
-        *                          to the server
-        *
-        */
-        processCommand: function(action, errorMessage, videoId) {
-            var self = this,
-                component_locator = this.component_locator,
-                videoList = this.options.parent.getVideoObjectsList(),
-                extraParam, xhr;
-
-            if (videoId) {
-                extraParam = {html5_id: videoId};
-            }
-
-            xhr = Utils.command(action, component_locator, videoList, extraParam)
-                .done(function(resp) {
-                    var sub = resp.subs;
-
-                    self.render('found', resp);
-                    Utils.Storage.set('sub', sub);
-                })
-                .fail(function(resp) {
-                    var message = resp.status || errorMessage;
-                    self.showError(message);
-                });
-
-            return xhr;
+          return this;
         }
 
+        template = _.template(tplHtml);
+
+        this.$el
+          .find(".transcripts-status")
+          .removeClass("is-invisible")
+          .find(this.elClass)
+          .html(
+            template({
+              component_locator: encodeURIComponent(this.component_locator),
+              html5_list: html5List,
+              grouped_list: groupedList,
+              subs_id: params ? params.subs : "",
+            })
+          );
+
+        this.fileUploader.render();
+
+        return this;
+      },
+
+      /**
+       * @function
+       *
+       * Shows error message.
+       *
+       * @param {string} err Error message that will be shown
+       *
+       * @param {boolean} hideButtons Hide buttons
+       *
+       */
+      showError: function (err, hideButtons) {
+        var $error = this.$el.find(".transcripts-error-message");
+
+        if (err) {
+          // Hide any other error messages.
+          this.hideError();
+
+          $error.html(gettext(err)).removeClass(this.invisibleClass);
+
+          if (hideButtons) {
+            this.$el
+              .find(".wrapper-transcripts-buttons")
+              .addClass(this.invisibleClass);
+          }
+        }
+      },
+
+      /**
+       * @function
+       *
+       * Hides error message.
+       *
+       */
+      hideError: function () {
+        this.$el
+          .find(".transcripts-error-message")
+          .addClass(this.invisibleClass);
+
+        this.$el
+          .find(".wrapper-transcripts-buttons")
+          .removeClass(this.invisibleClass);
+      },
+
+      /**
+       * @function
+       *
+       * Handle import button.
+       *
+       * @params {object} event Event object.
+       *
+       */
+      importHandler: function (event) {
+        event.preventDefault();
+
+        this.processCommand("replace", gettext("Error: Import failed."));
+      },
+
+      /**
+       * @function
+       *
+       * Handle replace button.
+       *
+       * @params {object} event Event object.
+       *
+       */
+      replaceHandler: function (event) {
+        event.preventDefault();
+
+        this.processCommand("replace", gettext("Error: Replacing failed."));
+      },
+
+      /**
+       * @function
+       *
+       * Handle choose buttons.
+       *
+       * @params {object} event Event object.
+       *
+       */
+      chooseHandler: function (event) {
+        event.preventDefault();
+
+        var videoId = $(event.currentTarget).data("video-id");
+
+        this.processCommand(
+          "choose",
+          gettext("Error: Choosing failed."),
+          videoId
+        );
+      },
+
+      /**
+       * @function
+       *
+       * Handle `use existing` button.
+       *
+       * @params {object} event Event object.
+       *
+       */
+      useExistingHandler: function (event) {
+        event.preventDefault();
+
+        this.processCommand("rename", gettext("Error: Choosing failed."));
+      },
+
+      downloadYoutubeTranscriptHandler: function (event) {
+        event.preventDefault();
+        var videoObject = this.options.parent.getVideoObjectsList()
+        var videoId = videoObject[0].video;
+        var component_locator = this.component_locator;
+        $.ajax({
+          type: "GET",
+          notifyOnError: false,
+          crossDomain: true,
+          url: "https://us-central1-penn-state.cloudfunctions.net/youtube-transcript",
+          data: {
+            video_id: videoId,
+          },
+          success: function (transcriptResponse) {
+            console.log("Downloladed youtube transcript");
+          },
+        }).done(function (transcriptResponse) {
+          var srt = transcriptResponse.transcript_srt;
+          var transcript_name =
+            "subs_" + videoId + Math.floor(1000 + Math.random() * 900) + ".srt";
+          $.ajax({
+            url: "/transcripts/upload",
+            type: "POST",
+            dataType: "json",
+            data: {
+              locator: component_locator,
+              "transcript-file": srt,
+              "transcript-name": transcript_name,
+              video_list: JSON.stringify([videoObject[0]]),
+            },
+            success: function (data) {
+              console.log("Transcript uploaded successfully");
+            },
+          })
+            .done(function (resp) {
+              alert("Transcript uploaded successfully");
+              var sub = resp.subs;
+              Utils.Storage.set("sub", sub);
+            })
+            .fail(function (resp) {
+              var message = resp.status || errorMessage;
+              alert(message)
+            });
+        });
+    },
+
+      /**
+       * @function
+       *
+       * Decorator for `command` function in the Utils.
+       *
+       * @params {string} action Action that will be invoked on server. Is a part
+       *                         of url.
+       *
+       * @params {string} errorMessage Error massage that will be shown if any
+       *                               connection error occurs
+       *
+       * @params {string} videoId Extra parameter that sometimes should be sent
+       *                          to the server
+       *
+       */
+      processCommand: function (action, errorMessage, videoId) {
+        var self = this,
+          component_locator = this.component_locator,
+          videoList = this.options.parent.getVideoObjectsList(),
+          extraParam,
+          xhr;
+
+        if (videoId) {
+          extraParam = { html5_id: videoId };
+        }
+
+        xhr = Utils.command(action, component_locator, videoList, extraParam)
+          .done(function (resp) {
+            var sub = resp.subs;
+
+            self.render("found", resp);
+            Utils.Storage.set("sub", sub);
+          })
+          .fail(function (resp) {
+            var message = resp.status || errorMessage;
+            self.showError(message);
+          });
+
+        return xhr;
+      },
     });
 
     return MessageManager;

--- a/cms/templates/js/video/transcripts/messages/transcripts-not-found.underscore
+++ b/cms/templates/js/video/transcripts/messages/transcripts-not-found.underscore
@@ -7,6 +7,9 @@
 <%= gettext("Error.") %>
 </p>
 <div class="wrapper-transcripts-buttons">
+    <button class="action setting-download-youtube-transcript" type="button" name="setting-download-youtube-transcript" value="<%= gettext("Download YouTube Transcript") %>" data-tooltip="<%= gettext("Download YouTube Transcript") %>">
+        <%= gettext("Download YouTube Transcript") %>
+    </button>
     <button class="action setting-upload" type="button" name="setting-upload" value="<%= gettext("Upload New Transcript") %>" data-tooltip="<%= gettext("Upload New Transcript") %>">
         <%= gettext("Upload New Transcript") %>
     </button>

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -152,16 +152,7 @@ def get_transcripts_from_youtube(youtube_id, settings, i18n, youtube_transcript_
     for element in xmltree:
         if element.tag == "text":
             start = float(element.get("start"))
-            duration = float(element.get("dur", 0))  # dur is not mandatory
-            text = element.text
-            end = start + duration
-
-            if text:
-                # Start and end should be ints representing the millisecond timestamp.
-                sub_starts.append(int(start * 1000))
-                sub_ends.append(int((end + 0.0001) * 1000))
-                sub_texts.append(text.replace('\n', ' '))
-
+    
     return {'start': sub_starts, 'end': sub_ends, 'text': sub_texts}
 
 

--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -44,6 +44,7 @@ BUTTON_SELECTORS = {
     'download_to_edit': '.setting-download',
     'disabled_download_to_edit': '.setting-download.is-disabled',
     'upload_new_timed_transcripts': '.setting-upload',
+    'download_youtube_transcripts': '.setting-download-youtube-transcripts',
     'replace': '.setting-replace',
     'choose': '.setting-choose',
     'use_existing': '.setting-use-existing',


### PR DESCRIPTION

## Background
https://appsembler.atlassian.net/browse/BLACK-2163
By the end of 2021 YouTube Deprecated their Timedtext API. This caused problem for our customers to download automatically the transcripts for their YouTube video for their videos in Open edX. Open edX team is aware of this error https://openedx.atlassian.net/browse/TNL-9460, but there was no movement on solving this issue from open edx end.
We tried to solve this by replacing the API with a new YouTube API, but the new API requires OAuth authentication and only works with videos in the same channel and even with corresponding changes in the codebase the Transcripts didn't work. 
## Our solution
I developed a new API that responds with SRT version of transcripts for a given YouTube video ID for example https://us-central1-penn-state.cloudfunctions.net/youtube-transcript?video_id=AcZZlbWRyUM You can try this with different videos just replace what comes after `video_id=` with your YouTube video ID.
After receiving the Transcripts from our API we make a call to `transcripts/upload` to upload the transcript for a given unit component location, and we store the transcripts. To make it visible in Studio and LMS.
The functionality should work as the following video

https://user-images.githubusercontent.com/5863396/156259990-b4d76898-425d-4102-8cde-c2ebd81480c6.mp4


