### PR TITLE
update file name

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/tests/test_api_v2_views.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_api_v2_views.py
@@ -99,7 +99,7 @@ def test_tahoe_site_create_view(client, site_params):
 @patch('openedx.core.djangoapps.appsembler.sites.utils.compile_sass', Mock(return_value='I am working CSS'))
 def test_compile_sass_file(caplog, site_with_org):
     """
-    Test that main-v2.scss file used when `THEME_VERSION` == tahoe-v2
+    Test that _main-v2.scss file used when `THEME_VERSION` == tahoe-v2
     """
     site, org = site_with_org
     site_config = SiteConfigurationFactory.build(
@@ -114,5 +114,5 @@ def test_compile_sass_file(caplog, site_with_org):
     sass_status = site_config.compile_microsite_sass()
     assert sass_status['successful_sass_compile']
     assert 'Sass compile finished successfully' in sass_status['sass_compile_message']
-    assert 'main-v2.scss' in sass_status['scss_file_used'], 'Use `main-v2.scss` due to THEME_VERSION`'
+    assert '_main-v2.scss' in sass_status['scss_file_used'], 'Use `_main-v2.scss` due to THEME_VERSION`'
     assert 'main.scss' not in sass_status['scss_file_used']

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -265,7 +265,7 @@ class SiteConfiguration(models.Model):
 
         theme_version = self.get_value('THEME_VERSION', 'amc-v1')
         if theme_version == 'tahoe-v2':
-            scss_file = 'main-v2.scss'
+            scss_file = '_main-v2.scss'
         else:
             # TODO: Deprecated. Remove once all sites are migrated to Tahoe 2.0 structure.
             scss_file = 'main.scss'

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -258,7 +258,7 @@ def test_site_configuration_compile_sass_success(caplog, clean_site_configuratio
     assert sass_status['successful_sass_compile']
     assert 'Sass compile finished successfully' in sass_status['sass_compile_message']
     assert 'main.scss' in sass_status['scss_file_used'], 'Should use the default file'
-    assert 'main-v2.scss' not in sass_status['scss_file_used']
+    assert '_main-v2.scss' not in sass_status['scss_file_used']
 
 
 @override_settings(


### PR DESCRIPTION
## Update SCSS file name
Updated `main-v2.scss` ➡️  `_main-v2.scss` due to paver errors.
Matej added `_` in front of file name so it'll be skipped by Paver here: https://github.com/appsembler/edx-theme-codebase/pull/189