### PR TITLE
fix: scope isn't correct

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/tests/test_api_v2_views.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_api_v2_views.py
@@ -20,7 +20,7 @@ from organizations.tests.factories import OrganizationFactory
 
 
 @pytest.fixture
-def site_with_org(scope='function'):
+def site_with_org():
     org = OrganizationFactory.create()
     assert org.edx_uuid, 'Should have valid uuid'
     site = Site.objects.create(domain='fake-site')


### PR DESCRIPTION
it did nothing, and could break

correct scope would be set via `@pytest.fixture(scope='function')`