### PR TITLE
Support `secret` and `admin` settings

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -148,7 +148,7 @@ class DefaultMultipleSegmentClient(object):
             event_props = args[2]
             siteconfig = utils.get_site_config_for_event(event_props)
             if siteconfig:
-                site_segment_key = siteconfig.get_value('SEGMENT_KEY', None)
+                site_segment_key = siteconfig.get_secret_value('SEGMENT_KEY')
         except (IndexError, exceptions.EventProcessingError):
             try:
                 event_name = args[1]

--- a/common/djangoapps/track/views/segmentio.py
+++ b/common/djangoapps/track/views/segmentio.py
@@ -286,7 +286,7 @@ def send_event(request, method, **params):
     # analytics library format.
     url = 'https://api.segment.io/v1/{0}'.format(method)
     main_response = requests.post(url, json=data)
-    segment_key = helpers.get_value('SEGMENT_KEY', None)
+    segment_key = helpers.get_current_site_configuration().get_secret_value('SEGMENT_KEY')
     if segment_key:
         data['writeKey'] = segment_key
         data['messageId'] = 'ajs-' + uuid.uuid4().hex

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_api_v2_views.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_api_v2_views.py
@@ -19,12 +19,8 @@ from rest_framework.authtoken.models import Token
 import tahoe_sites.api
 
 from common.djangoapps.student.tests.factories import UserFactory
-from openedx.core.djangoapps.appsembler.sites import (
-    site_config_client_helpers as client_helpers,
-)
 
 from openedx.core.djangoapps.appsembler.sites import api_v2
-
 
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
 from organizations.tests.factories import OrganizationFactory
@@ -72,8 +68,7 @@ def test_v2_views_security_classes(api_v2_view):
 
 
 @pytest.mark.django_db
-def test_compile_sass_view(client, monkeypatch, site_with_uuid, superuser_with_token):
-    monkeypatch.setattr(client_helpers, 'CONFIG_CLIENT_INSTALLED', True)
+def test_compile_sass_view(client, site_with_uuid, superuser_with_token):
     _, api_token = superuser_with_token
     site, site_uuid = site_with_uuid
     site_configuration = SiteConfigurationFactory.build(
@@ -93,9 +88,8 @@ def test_compile_sass_view(client, monkeypatch, site_with_uuid, superuser_with_t
 
 
 @pytest.mark.django_db
-def test_compile_sass_view_site_not_found(client, monkeypatch, superuser_with_token):
+def test_compile_sass_view_site_not_found(client, superuser_with_token):
     _, api_token = superuser_with_token
-    monkeypatch.setattr(client_helpers, 'CONFIG_CLIENT_INSTALLED', True)
     url = reverse('tahoe_compile_sass')
     data = {'site_uuid': 'ee9894a6-898e-11ec-ab4d-9779d2628f5b'}
     response = client.post(url, data=data, HTTP_AUTHORIZATION='Token {}'.format(api_token))

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -118,7 +118,7 @@ class SiteConfiguration(models.Model):
                 if self.api_adapter:
                     # Tahoe: Use `SiteConfigAdapter` if available.
                     beeline.add_context_field('value_source', 'site_config_service')
-                    return self.api_adapter.get_value(name, default)
+                    return self.api_adapter.get_value_of_type(self.api_adapter.TYPE_SETTING, name, default)
                 else:
                     beeline.add_context_field('value_source', 'django_model')
                     return self.site_values.get(name, default)
@@ -144,11 +144,56 @@ class SiteConfiguration(models.Model):
             Page content `dict`.
         """
         if self.api_adapter:
+            # Tahoe: Use `SiteConfigAdapter` if available.
             beeline.add_context_field('page_source', 'site_config_service')
-            return self.api_adapter.get_amc_v1_page(name, default)
+            return self.api_adapter.get_value_of_type(self.api_adapter.TYPE_PAGE, name, default)
         else:
             beeline.add_context_field('page_source', 'django_model')
             return self.page_elements.get(name, default)
+
+    @beeline.traced('site_config.get_admin_setting')
+    def get_admin_setting(self, name, default=None):
+        """
+        Tahoe: Get `admin` setting from the site configuration service.
+
+        If SiteConfiguration adapter isn't in use, fallback to the deprecated `SiteConfiguration.site_values` field.
+
+        Args:
+            name (str): Name of the setting to fetch.
+            default: default value to return if setting is not found in the configuration.
+
+        Returns:
+            Value for the given key or returns `None` if not configured.
+        """
+        if self.api_adapter:
+            # Tahoe: Use `SiteConfigAdapter` if available.
+            beeline.add_context_field('setting_source', 'site_config_service')
+            return self.api_adapter.get_value_of_type(self.api_adapter.TYPE_ADMIN, name, default)
+        else:
+            beeline.add_context_field('setting_source', 'django_model')
+            return self.site_values.get(name, default)
+
+    @beeline.traced('site_config.get_secret_value')
+    def get_secret_value(self, name, default=None):
+        """
+        Tahoe: Get `secret` value from the site configuration service.
+
+        If SiteConfiguration adapter isn't in use, fallback to the deprecated `SiteConfiguration.site_values` field.
+
+        Args:
+            name (str): Name of the secret to fetch.
+            default: default value to return if secret is not found in the configuration.
+
+        Returns:
+            Value for the given key or returns `None` if not configured.
+        """
+        if self.api_adapter:
+            # Tahoe: Use `SiteConfigAdapter` if available.
+            beeline.add_context_field('setting_source', 'site_config_service')
+            return self.api_adapter.get_value_of_type(self.api_adapter.TYPE_SECRET, name, default)
+        else:
+            beeline.add_context_field('setting_source', 'django_model')
+            return self.site_values.get(name, default)
 
     @classmethod
     def get_configuration_for_org(cls, org, select_related=None):

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -9,3 +9,4 @@ django-hijack==2.1.10
 django-hijack-admin==2.1.10
 honeycomb-beeline==2.12.1
 tahoe-sites==0.1.2
+site-configuration-client==0.1.3


### PR DESCRIPTION
 - Needs https://github.com/appsembler/site-configuration-client/pull/51 which is included `site-configuration-client==0.1.2`
 - Needs https://github.com/appsembler/site-configuration-client/pull/56 which is included `site-configuration-client==0.1.3`