### PR TITLE
Disable api-docs URL - RED-2861

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -407,6 +407,7 @@ FEATURES = {
     # .. toggle_status: supported
     'DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO': True,
     'TAHOE_STUDIO_LOCAL_LOGIN': False,
+    'TAHOE_ENABLE_API_DOCS_URLS': False,  # RED-2861
 }
 
 ENABLE_JASMINE = False

--- a/cms/tests.py
+++ b/cms/tests.py
@@ -1,0 +1,16 @@
+""" Api Doc test """
+from django.conf import settings
+from django.test import TestCase
+
+
+class TestAPIDoc(TestCase):
+    """
+    Api Doc test
+    """
+    def test_api_docs(self):
+        """
+        Tests that requests to the `/api-docs/` endpoint do not raise an exception.
+        """
+        response = self.client.get('/api-docs/')
+        self.assertFalse(settings.FEATURES.get('TAHOE_ENABLE_API_DOCS_URLS'))
+        self.assertEqual(404, response.status_code)  # Tahoe: Changed from `200`

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -287,7 +287,8 @@ if settings.TAHOE_ENABLE_CUSTOM_ERROR_VIEW:
     ]
 
 # API docs.
-urlpatterns += make_docs_urls(api_info)
+if settings.FEATURES.get('TAHOE_ENABLE_API_DOCS_URLS', False):
+    urlpatterns += make_docs_urls(api_info)
 
 if 'openedx.testing.coverage_context_listener' in settings.INSTALLED_APPS:
     urlpatterns += [

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -478,6 +478,8 @@ FEATURES = {
     # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
+
+    'TAHOE_ENABLE_API_DOCS_URLS': False,  # RED-2861
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -28,4 +28,5 @@ class LmsModuleTests(TestCase):
         Tests that requests to the `/api-docs/` endpoint do not raise an exception.
         """
         response = self.client.get('/api-docs/')
-        self.assertEqual(200, response.status_code)
+        self.assertFalse(settings.FEATURES.get('TAHOE_ENABLE_API_DOCS_URLS'))
+        self.assertEqual(404, response.status_code)  # Tahoe: Changed from `200`

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -988,7 +988,8 @@ if settings.BRANCH_IO_KEY:
     ]
 
 # API docs.
-urlpatterns += make_docs_urls(api_info)
+if settings.FEATURES.get('TAHOE_ENABLE_API_DOCS_URLS', False):
+    urlpatterns += make_docs_urls(api_info)
 
 # edx-drf-extensions csrf app
 urlpatterns += [

--- a/tox.ini
+++ b/tox.ini
@@ -103,6 +103,7 @@ commands =
 [testenv:studio]
 commands =
     pytest {env:PYTEST_ARGS} \
+        cms/tests.py \
         cms/djangoapps/appsembler \
         cms/djangoapps/course_creators/ \
         cms/djangoapps/contentstore/
@@ -111,6 +112,7 @@ commands =
 commands =
     pytest {env:PYTEST_ARGS} \
         common/djangoapps/util/tests/test_db.py::MigrationTests  \
+        lms/tests.py \
         lms/djangoapps/appsembler_tiers \
         lms/djangoapps/certificates/tests/test_webview_appsembler_changes.py  \
         lms/djangoapps/course_api/ \


### PR DESCRIPTION
## Change description

Disable api-docs URL because of a possible XSS security issue. Details in RED-2861

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/RED-2861

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
