### PR TITLE
add `appsembler_tiers` cms to `tox.ini` tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,7 @@ commands =
     pytest {env:PYTEST_ARGS} \
         cms/tests.py \
         cms/djangoapps/appsembler \
+        cms/djangoapps/appsembler_tiers/ \
         cms/djangoapps/course_creators/ \
         cms/djangoapps/contentstore/
 


### PR DESCRIPTION
it was missing, all the time.