### PR TITLE
breaking: disable logistration forms when auth0 enabled

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -49,6 +49,9 @@ from student.models import (
 )
 from util.password_policy_validators import normalize_password
 
+from openedx.core.djangoapps.site_configuration import tahoe_auth0_helpers
+
+
 # Enumeration of per-course verification statuses
 # we display on the student dashboard.
 VERIFY_STATUS_NEED_TO_VERIFY = "verify_need_to_verify"
@@ -273,6 +276,11 @@ def get_next_url_for_login_page(request):
         "THIRD_PARTY_AUTH_HINT",
         settings.FEATURES.get("THIRD_PARTY_AUTH_HINT", '')
     )
+
+    if tahoe_auth0_helpers.is_tahoe_auth0_enabled() and not tpa_hint:
+        # Tahoe: Disable login/registration forms when Auth0 is enabled.
+        tpa_hint = tahoe_auth0_helpers.TAHOE_AUTH0_BACKEND_NAME
+
     if tpa_hint:
         # Don't add tpa_hint if we're already in the TPA pipeline (prevent infinite loop),
         # and don't overwrite any existing tpa_hint params (allow tpa_hint override).

--- a/common/djangoapps/student/tests/test_tahoe_auth0_feature_with_helpers.py
+++ b/common/djangoapps/student/tests/test_tahoe_auth0_feature_with_helpers.py
@@ -1,0 +1,63 @@
+""" Test Student helpers with Auth0 """
+
+import ddt
+from django.conf import settings
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+from mock import patch
+
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
+from student.helpers import get_next_url_for_login_page
+
+from site_config_client.openedx.test_helpers import override_site_config
+
+
+@ddt.ddt
+class TestAuth0DisablingLogistrationForm(TestCase):
+    """Disable login/registration forms when Auth0 is enabled."""
+
+    def setUp(self):
+        super().setUp()
+        self.request_factory = RequestFactory()
+
+    @patch('student.helpers.third_party_auth.pipeline.get')
+    @ddt.data(
+        {
+            'http_method': 'GET',
+            'running_pipeline': False,
+        },
+        {
+            'http_method': 'POST',
+            'running_pipeline': False,
+        },
+    )
+    @ddt.unpack
+    @with_site_configuration()
+    def test_third_party_auth_hint(self, mock_get_pipeline, http_method, running_pipeline):
+        mock_get_pipeline.return_value = running_pipeline
+
+        next_url = '/dashboard'
+        if http_method == 'GET':
+            request = self.request_factory.get(settings.LOGIN_URL + "?next={url}".format(url=next_url))
+        else:
+            assert http_method == 'POST', 'Sanity check: Only `GET` and `POST` are supported'
+            request = self.request_factory.post(settings.LOGIN_URL, {'next': next_url})
+
+        request.META['HTTP_ACCEPT'] = 'text/html'
+        middleware = SessionMiddleware()
+        middleware.process_request(request)  # Annotate the request object with a session
+        request.session.save()
+
+        with override_site_config('admin', ENABLE_TAHOE_AUTH0=True):
+            auth0_next = get_next_url_for_login_page(request)
+        assert auth0_next == '/dashboard?tpa_hint=tahoe-auth0', 'tahoe-auth0 is used when `is_tahoe_auth0_enabled`'
+
+        with override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT='oa2-google-oauth2')):
+            with override_site_config('admin', ENABLE_TAHOE_AUTH0=True):
+                tpa_hinted_next = get_next_url_for_login_page(request)
+        assert tpa_hinted_next == '/dashboard?tpa_hint=oa2-google-oauth2', 'THIRD_PARTY_AUTH_HINT overrides tahoe-auth0'
+
+        default_next = get_next_url_for_login_page(request)
+        assert default_next == '/dashboard', 'Sanity check: Should provide no tpa_hint by default'

--- a/openedx/core/djangoapps/site_configuration/tahoe_auth0_helpers.py
+++ b/openedx/core/djangoapps/site_configuration/tahoe_auth0_helpers.py
@@ -5,15 +5,14 @@ Helper module for Tahoe Auth0.
 """
 from django.conf import settings
 
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from site_config_client.openedx import api as config_client_api
+
+TAHOE_AUTH0_BACKEND_NAME = 'tahoe-auth0'
 
 
 def is_tahoe_auth0_enabled():
     """
     Tahoe: Check if tahoe-auth0 package is enabled for the current site (or cluster-wide).
     """
-    is_enabled = configuration_helpers.get_value(
-        'ENABLE_TAHOE_AUTH0',
-        settings.FEATURES.get('ENABLE_TAHOE_AUTH0', False),
-    )
-    return is_enabled
+    global_flag = settings.FEATURES.get('ENABLE_TAHOE_AUTH0', False)
+    return config_client_api.get_admin_value('ENABLE_TAHOE_AUTH0', default=global_flag)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -29,6 +29,7 @@ from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_un
 from student.models import PendingEmailChange, UserProfile
 from student.tests.factories import TEST_PASSWORD, UserFactory
 
+from site_config_client.openedx.test_helpers import override_site_config
 from .. import ALL_USERS_VISIBILITY, CUSTOM_VISIBILITY, PRIVATE_VISIBILITY
 
 TEST_PROFILE_IMAGE_UPLOADED_AT = datetime.datetime(2002, 1, 9, 15, 43, 1, tzinfo=pytz.UTC)

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -24,5 +24,5 @@ https://github.com/edx-solutions/xblock-google-drive/archive/589d9f51f9b.tar.gz 
 django-tiers==0.2.4
 tahoe-sites==0.1.5
 tahoe-lti==0.3.0
-site-configuration-client==0.1.4
+site-configuration-client==0.1.5
 


### PR DESCRIPTION
 - Jira: RED-2737.
 - Related upstream PR: https://github.com/openedx/edx-platform/pull/15587 (included in Juniper)


### Breaking changes

 - Now needs `admin` configuration for added safety instead of the usual `get_value` which is customer writable
 - Needs update from the Product Signup service (Matej)

### TODO

 - [ ] Test in devstack
 - [ ] Communicate to Matej and update the Product Signup feature