### PR TITLE
bump site-configuration-client==0.1.4

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -24,5 +24,5 @@ https://github.com/edx-solutions/xblock-google-drive/archive/589d9f51f9b.tar.gz 
 django-tiers==0.2.4
 tahoe-sites==0.1.5
 tahoe-lti==0.3.0
-site-configuration-client==0.1.3
+site-configuration-client==0.1.4
 


### PR DESCRIPTION
fixes a deploy error in tahoe-auth0