### PR TITLE
IdP tests fixes

### DIFF
--- a/openedx/core/djangoapps/site_configuration/tahoe_idp_helpers.py
+++ b/openedx/core/djangoapps/site_configuration/tahoe_idp_helpers.py
@@ -16,7 +16,4 @@ def is_tahoe_idp_enabled():
     Tahoe: Check if tahoe-idp package is enabled for the current site (or cluster-wide).
     """
     global_flag = settings.FEATURES.get('ENABLE_TAHOE_IDP', False)
-    # TODO: Remove `ENABLE_TAHOE_IDP` once we update Product Signup
-    legacy = config_client_api.get_admin_value('ENABLE_TAHOE_IDP', default=global_flag)
-    new = config_client_api.get_admin_value('ENABLE_TAHOE_IDP', default=global_flag)
-    return legacy or new
+    return config_client_api.get_admin_value('ENABLE_TAHOE_IDP', default=global_flag)

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_idp_helpers.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_idp_helpers.py
@@ -8,17 +8,12 @@ from site_config_client.openedx.test_helpers import override_site_config
 from openedx.core.djangoapps.site_configuration import tahoe_idp_helpers
 
 
-@pytest.mark.parametrize('case', [
-    {'new_flag': True, 'should_be_enabled': True, 'message': 'new flag should enable it'},
-    {'old_flag': True, 'should_be_enabled': True, 'message': 'old legacy flag should enable it'},
-    {'global_flag': True, 'should_be_enabled': True, 'message': 'cluster-wide flag should enable it'},
-    {'should_be_enabled': False, 'message': 'When no flag is enabled, the feature should be disabled'},
+@pytest.mark.parametrize('global_flags,site_flags,should_be_enabled,message', [
+    ({}, {'ENABLE_TAHOE_IDP': True}, True, 'site-flag should enable it'),
+    ({'ENABLE_TAHOE_IDP': True}, {}, True, 'cluster-wide flag should enable it'),
+    ({}, {}, False, 'When no flag is enabled, the feature should be disabled'),
 ])
-def test_is_tahoe_idp_enabled(case, settings, monkeypatch):
-    new_flag = case.get('new_flag', False)  # All values default to False, None.
-    old_flag = case.get('old_flag', False)
-    global_flag = case.get('global_flag', False)
-
-    monkeypatch.setitem(settings.FEATURES, 'ENABLE_TAHOE_IDP', global_flag)
-    with override_site_config('admin', ENABLE_TAHOE_IDP=new_flag, ENABLE_TAHOE_IDP=old_flag):
-        assert tahoe_idp_helpers.is_tahoe_idp_enabled() == case['should_be_enabled'], case['message']
+def test_is_tahoe_idp_enabled(settings, global_flags, site_flags, should_be_enabled, message):
+    settings.FEATURES = global_flags
+    with override_site_config('admin', **site_flags):
+        assert tahoe_idp_helpers.is_tahoe_idp_enabled() == should_be_enabled, message

--- a/tox.ini
+++ b/tox.ini
@@ -126,12 +126,17 @@ commands =
         lms/djangoapps/instructor/ \
         lms/djangoapps/verify_student/tests/test_services.py  \
         openedx/core/djangoapps/appsembler \
-        openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+        openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py \
+        openedx/core/djangoapps/site_configuration/tests/test_tahoe_idp_helpers.py
 
 [testenv:lms-2]
 commands =
     pytest {env:PYTEST_ARGS} \
+        lms/djangoapps/tests/ \
+        openedx/core/djangoapps/credentials/tests/test_tahoe_utils.py \
         openedx/core/djangoapps/user_api/ \
+        openedx/core/djangoapps/user_authn/views/tests/test_tahoe_idp_reset_password.py  \
+        openedx/core/djangoapps/user_authn/views/tests/test_tahoe_register_user_signal_sso.py  \
         openedx/features/course_experience/utils.py \
         lms/djangoapps/certificates/tests/
 


### PR DESCRIPTION
otherwise staging deployment fails due to syntax error in a previously unused test.