### PR TITLE
chore: bump xblock-poll version to 1.11.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -37,7 +37,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.3.3#egg=recommender-xblock==1
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@3f09dda40d912735ccbe8781215e8f50b3af368f#egg=xblock-poll==1.11.0  # via -r requirements/edx/github.in  # Tahoe: bumped from 1.5.1
 git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu


### PR DESCRIPTION
DHIS2 reported the survey download result button is not working and seems the poll xblock version is behind. https://appsembler.atlassian.net/browse/BLACK-2353