### PR TITLE
Adds 'date_joined' to the Tahoe User API

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/tests/test_user_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_user_api.py
@@ -1,8 +1,10 @@
 
 import unittest
+from datetime import datetime
 
 from django.contrib.sites.models import Site
 from django.urls import resolve, reverse
+from django.utils.timezone import utc
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory, force_authenticate
 
@@ -34,7 +36,15 @@ class UserIndexViewSetTest(TestCase):
     # Fixtures to be used for filtering
     JANE_DUE_USERNAME = 'jane.due'
     JANE_DUE_EMAIL = '{username}@user.api.example.com'.format(username=JANE_DUE_USERNAME)
+    JANE_DUE_DATE_JOINED = datetime.strptime('2021-02-10T12:13:14',
+                                             '%Y-%m-%dT%H:%M:%S').replace(tzinfo=utc)
     NON_USER_EMAIL = 'not.for.a.user@user.api.example.com'
+    OTHER_DATE_JOINED = [
+        datetime.strptime('2021-06-07T12:13:14',
+                          '%Y-%m-%dT%H:%M:%S').replace(tzinfo=utc),
+        datetime.strptime('2021-10-10T12:13:14',
+                          '%Y-%m-%dT%H:%M:%S').replace(tzinfo=utc)
+    ]
 
     def setUp(self):
         """
@@ -56,9 +66,11 @@ class UserIndexViewSetTest(TestCase):
 
         # Set up users and enrollments for 'my site'
         self.my_site_users = [
-            UserFactory.create(email=self.JANE_DUE_EMAIL, username=self.JANE_DUE_USERNAME),
-            UserFactory.create(),
-            UserFactory.create(),
+            UserFactory.create(email=self.JANE_DUE_EMAIL,
+                               username=self.JANE_DUE_USERNAME,
+                               date_joined=self.JANE_DUE_DATE_JOINED),
+            UserFactory.create(date_joined=self.OTHER_DATE_JOINED[0]),
+            UserFactory.create(date_joined=self.OTHER_DATE_JOINED[1]),
         ]
 
         for user in self.my_site_users:
@@ -132,6 +144,26 @@ class UserIndexViewSetTest(TestCase):
         if expected_count:
             # Ignore the email case
             assert results[0]['email'].lower() == email.lower(), msg
+
+    def test_filter_by_date_joined(self):
+        """Test the date_joined filters matching.
+        """
+        expected_date_joined = self.my_site_users[0].date_joined.strftime('%Y-%m-%dT%H:%M:%SZ')
+        expected_count = 1
+        msg = 'Should find Jane in the users'
+        date_joined_filter = self.my_site_users[0].date_joined.date()
+        url = reverse('tahoe-api:v1:users-list')
+        request = APIRequestFactory().get(url, {'date_joined': date_joined_filter})
+        request.META['HTTP_HOST'] = self.my_site.domain
+        force_authenticate(request, user=self.caller)
+
+        view = resolve(url).func
+        response = view(request)
+        response.render()
+        results = response.data['results']
+
+        assert len(results) == expected_count, msg
+        assert results[0]['date_joined'] == expected_date_joined, msg
 
     @unittest.expectedFailure
     def test_get_all_enrolled_learners_for_site(self):

--- a/openedx/core/djangoapps/appsembler/api/tests/test_user_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_user_api.py
@@ -81,6 +81,7 @@ class UserIndexViewSetTest(TestCase):
         assert data['username'] == user.username
         assert data['fullname'] == user.profile.name
         assert data['email'] == user.email
+        assert data['date_joined'] == user.date_joined.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     def test_get_all_users_for_site(self):
         url = reverse('tahoe-api:v1:users-list')

--- a/openedx/core/djangoapps/appsembler/api/v1/filters.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/filters.py
@@ -71,12 +71,12 @@ class CourseEnrollmentFilter(django_filters.FilterSet):
 
 
 class UserIndexFilter(django_filters.FilterSet):
-    '''Provides filtering for the User model objects in the UserIndexViewSet.
-
-    '''
+    """Provides filtering for the User model objects in the UserIndexViewSet.
+    """
 
     email_exact = django_filters.CharFilter(field_name='email', lookup_expr='iexact')
+    date_joined = django_filters.DateFilter(field_name='date_joined__date')
 
     class Meta:
         model = get_user_model()
-        fields = ['email_exact']
+        fields = ['email_exact', 'date_joined', ]

--- a/openedx/core/djangoapps/appsembler/api/v1/serializers.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/serializers.py
@@ -68,9 +68,10 @@ class UserIndexSerializer(serializers.ModelSerializer):
     username = serializers.CharField(read_only=True)
     fullname = serializers.CharField(
         source='profile.name', default=None, read_only=True)
+    date_joined = serializers.DateTimeField(read_only=True)
 
     class Meta:
         model = get_user_model()
         fields = (
-            'id', 'username', 'fullname', 'email',
+            'id', 'username', 'fullname', 'email', 'date_joined',
         )


### PR DESCRIPTION
https://appsembler.atlassian.net/browse/BLACK-2409

This is a backward compatible update to enable a customer request to include `date_joined` to the User API

* Added filter on the date joined with the `date_joined` query parameter which expects a date in the format `YYY-MM-DD`
* Added test coverage
* Did not include date range filtering for date_joined. We can add that later if requested
