### PR TITLE
install python-jose always for jwt verification

### DIFF
--- a/Dockerfile.tutor
+++ b/Dockerfile.tutor
@@ -45,7 +45,6 @@ FROM edxapp-build as edxapp-build-experimental
 # Sync with `edx-configs` `appsembler/tahoe/us/juniper/staging/files/server-vars.yml`
 RUN echo "Installing pip packages:" \
     && pip install gestore==0.1.0-dev3 \
-    && pip install python-jose==3.2.0 \
     && pip install xblock-grade-fetcher==0.2 \
     && pip install -e 'git+https://github.com/appsembler/tahoe-idp.git@main#egg=tahoe_idp' \
     && echo "Finished installing pip packages."

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -12,6 +12,7 @@ psycopg2-binary==2.8.3
 django-hijack==2.1.10
 django-hijack-admin==2.1.10
 honeycomb-beeline==2.12.1
+python-jose==3.2.0  # JWT verification
 
 
 # Patched upstream packages
@@ -25,4 +26,3 @@ django-tiers==0.2.4
 tahoe-sites==0.1.5
 tahoe-lti==0.3.0
 site-configuration-client==0.1.5
-


### PR DESCRIPTION
this is needed for `tahoe-idp` which would be added later on

graduating `python-jose` to become a permanent package.