### PR TITLE
build and push devstack docker images after merges to `main`

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: 'Build the Docker images'
+      - name: 'Build the Tutor Docker images'
         shell: bash
         run: |
           # Build both images at once corresponding to `edx-platform` branch names
@@ -32,7 +32,17 @@ jobs:
           password: ${{ secrets.DOCKERPASSWORD }}
         if: ${{ env.BRANCH == 'main' || env.BRANCH == 'prod' }}
 
-      - name: 'Push the docker images after merge to `main` and `prod`'
+      - name: 'build devstack image (push after merge to `main`)'
+        shell: bash
+        run: |
+          # This overrides same-day merges on `main` but it's devstack so it doesn't matter much
+          DATE=$(date --iso-8601)
+          make DATE="$DATE" devstack-docker-build
+          if [ "$BRANCH" == "main" ]; then
+            make DATE="$DATE" devstack-docker-push
+          fi
+
+      - name: 'Push the Tutor docker images after merge to `main` and `prod`'
         shell: bash
         run: |
           IMAGE_NAME="appsembler/edxapp-juniper"

--- a/Dockerfile.devstack
+++ b/Dockerfile.devstack
@@ -20,18 +20,15 @@ FROM edxops/edxapp:juniper.master
 #
 
 RUN rm -rf /edx/app/edxapp/edx-platform
-
 COPY . /edx/app/edxapp/edx-platform
 
 RUN cd /edx/app/edxapp/edx-platform \
     && . ../edxapp_env \
     && paver install_prereqs \
-    && pip install -r requirements/edx/appsembler.txt
-
-RUN rm -rf /edx/app/edxapp/edx-platform
-
-RUN rm -f /edx/etc/lms.yml /edx/etc/studio.yml
-RUN ln -s /edx/src/edxapp-envs/lms.yml /edx/etc/
-RUN ln -s /edx/src/edxapp-envs/studio.yml /edx/etc/
+    && pip install -r requirements/edx/appsembler.txt \
+    && rm -rf /edx/app/edxapp/edx-platform \
+    && rm -f /edx/etc/lms.yml /edx/etc/studio.yml \
+    && ln -s /edx/src/edxapp-envs/lms.yml /edx/etc/ \
+    && ln -s /edx/src/edxapp-envs/studio.yml /edx/etc/
 
 WORKDIR /edx/app/edxapp/edx-platform

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ shell: ## launch a bash shell in a Docker container with all edx-platform depend
 
 DATE := $(shell date --iso-8601)
 devstack-docker-build:
-	docker build --no-cache --squash -f Dockerfile.devstack \
+	docker build --no-cache -f Dockerfile.devstack \
           -t appsembler/edxapp:juniper.master \
           -t appsembler/edxapp:juniper.manual-$(DATE) .
 


### PR DESCRIPTION
This overrides same-day merges on `main` but it's devstack so it doesn't matter much