### PR TITLE
install fusionauth-client==1.36.0 on all tahoe instances

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -23,6 +23,7 @@ https://github.com/edx-solutions/xblock-google-drive/archive/589d9f51f9b.tar.gz 
 
 # Tahoe plugins and customizations
 django-tiers==0.2.4
+fusionauth-client==1.36.0
 tahoe-sites==0.1.5
 tahoe-lti==0.3.0
 site-configuration-client==0.1.5


### PR DESCRIPTION
We need this for devstack to work correctly. The library will do nothing unless explicitly imported via `tahoe-idp`.