### PR TITLE
update site-configuration-client release

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -26,4 +26,4 @@ django-tiers==0.2.4
 fusionauth-client==1.36.0
 tahoe-sites==0.1.5
 tahoe-lti==0.3.0
-site-configuration-client==0.1.6
+site-configuration-client==0.1.7

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -26,4 +26,4 @@ django-tiers==0.2.4
 fusionauth-client==1.36.0
 tahoe-sites==0.1.5
 tahoe-lti==0.3.0
-site-configuration-client==0.1.5
+site-configuration-client==0.1.6


### PR DESCRIPTION
Update `site-configuration-client` release from `0.1.5` ➡️  `0.1.6`
- Depends on [PR-68](https://github.com/appsembler/site-configuration-client/pull/68)

🛑 Do not merge until version 0.1.6 has been released to [pypi](https://pypi.org/project/site-configuration-client/#history)