### PR TITLE
chore: requirements update for FusionAuth

### DIFF
--- a/Dockerfile.tutor
+++ b/Dockerfile.tutor
@@ -46,7 +46,7 @@ FROM edxapp-build as edxapp-build-experimental
 RUN echo "Installing pip packages:" \
     && pip install gestore==0.1.0-dev3 \
     && pip install xblock-grade-fetcher==0.2 \
-    && pip install -e 'git+https://github.com/appsembler/tahoe-idp.git@1.0.0#egg=tahoe-idp' \
+    && pip install -e 'git+https://github.com/appsembler/tahoe-idp.git@v1.0.0#egg=tahoe-idp' \
     && echo "Finished installing pip packages."
 
 

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -21,6 +21,6 @@ https://github.com/edx-solutions/xblock-google-drive/archive/589d9f51f9b.tar.gz 
 # Tahoe plugins and customizations
 django-tiers==0.2.4
 fusionauth-client==1.36.0
-tahoe-sites==0.1.5
+tahoe-sites==0.1.6
 tahoe-lti==0.3.0
 site-configuration-client==0.1.5

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -12,14 +12,11 @@ psycopg2-binary==2.8.3
 django-hijack==2.1.10
 django-hijack-admin==2.1.10
 honeycomb-beeline==2.12.1
-python-jose==3.2.0  # JWT verification
-
 
 # Patched upstream packages
 https://github.com/edx-solutions/xblock-google-drive/archive/589d9f51f9b.tar.gz  # v0.2.0 but the repo has no tags
 -e git+https://github.com/appsembler/edx-ora2.git@2.7.6-appsembler.1#egg=2.7.6
 -e git+https://github.com/appsembler/edx-sga.git@821cf8c563c86d92630e57e2cae06ab1dfaeff09#egg=v0.11.0-appsembler2
-
 
 # Tahoe plugins and customizations
 django-tiers==0.2.4


### PR DESCRIPTION
Deprecating tahoe-idp tag `1.0.0` and using `v1.0.0` to be consistent with other projects we have.

PyPi shouldn't be affected.