### PR TITLE
site config fixes: clear cache, support preview

### DIFF
--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -28,6 +28,8 @@ from student.roles import CourseBetaTesterRole
 from xmodule.util.xmodule_django import get_current_request_hostname
 from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
 
+from openedx.core.djangoapps.appsembler.preview import helpers as preview_helpers
+
 DEBUG_ACCESS = False
 log = getLogger(__name__)
 
@@ -98,6 +100,11 @@ def in_preview_mode():
     """
     Returns whether the user is in preview mode or not.
     """
+    if preview_helpers.is_preview_mode():
+        # Tahoe: Support `?preview=true` parameter in URL to avoid needing
+        #        a specific domain for course content preview
+        return True
+
     hostname = get_current_request_hostname()
     preview_lms_base = settings.FEATURES.get('PREVIEW_LMS_BASE', None)
     return bool(preview_lms_base and hostname and hostname.split(':')[0] == preview_lms_base.split(':')[0])

--- a/openedx/core/djangoapps/appsembler/preview/__init__.py
+++ b/openedx/core/djangoapps/appsembler/preview/__init__.py
@@ -1,0 +1,3 @@
+"""
+A module for checking if a request is being made in preview mode.
+"""

--- a/openedx/core/djangoapps/appsembler/preview/helpers.py
+++ b/openedx/core/djangoapps/appsembler/preview/helpers.py
@@ -1,0 +1,23 @@
+"""
+Tahoe's custom preview mode helpers.
+"""
+
+import crum
+
+
+PREVIEW_GET_PARAM = 'preview'
+PREVIEW_PARAM_TRUE = 'true'
+
+
+def is_preview_mode(current_request=None):
+    """
+    Check if the request should be shown as preview.
+    """
+    if not current_request:
+        current_request = crum.get_current_request()
+
+    if not current_request:
+        return False
+
+    preview_param = current_request.GET.get(PREVIEW_GET_PARAM, 'false')
+    return str(preview_param).lower() == PREVIEW_PARAM_TRUE

--- a/openedx/core/djangoapps/appsembler/preview/tests/test_helpers.py
+++ b/openedx/core/djangoapps/appsembler/preview/tests/test_helpers.py
@@ -1,0 +1,41 @@
+"""
+Tests for helpers.
+"""
+import pytest
+from unittest.mock import patch
+from django.test.client import RequestFactory
+
+from ..helpers import is_preview_mode, PREVIEW_GET_PARAM
+
+
+def test_no_request():
+    assert not is_preview_mode(), 'default to non-preview if no request is provided'
+
+
+def test_request_non_preview_mode():
+    request = RequestFactory().get('/test')
+    assert not is_preview_mode(current_request=request), 'default to non-preview'
+
+
+@pytest.mark.parametrize('preview_param', [True, 'true', 'True'])
+def test_request_preview_mode_case_insensitive(preview_param):
+    request = RequestFactory().get('/test', data={'preview': preview_param})
+    is_preview_result = is_preview_mode(current_request=request)
+    assert is_preview_result, 'Should respect case-insensitive `preview=true` param'
+
+
+def test_request_preview_mode_crum():
+    """
+    Ensure `crum.get_current_request` is used when no request is provided via parameters.
+    """
+    request = RequestFactory().get('/test', data={PREVIEW_GET_PARAM: 'true'})
+    with patch('crum.get_current_request', return_value=request):
+        assert is_preview_mode(), 'Should default to `crum` request'
+
+
+def test_request_preview_mode_test_yes():
+    """
+    Ensure `crum.get_current_request` should be `live` if provided anything other than yes.
+    """
+    request = RequestFactory().get('/test', data={PREVIEW_GET_PARAM: 'yes'})
+    assert not is_preview_mode(current_request=request), 'Anything is falsy, except for `true`'

--- a/openedx/core/djangoapps/appsembler/sites/config_values_modifier.py
+++ b/openedx/core/djangoapps/appsembler/sites/config_values_modifier.py
@@ -59,8 +59,7 @@ class TahoeConfigurationValueModifier:
         return self.get_domain()
 
     def get_css_overrides_file(self):
-        domain_without_port_number = self.get_domain().split(':')[0]
-        return '{}.css'.format(domain_without_port_number)
+        return self.site_config_instance.get_css_overrides_file()
 
     def get_lms_root_url(self):
         """

--- a/openedx/core/djangoapps/appsembler/sites/site_config_client_helpers.py
+++ b/openedx/core/djangoapps/appsembler/sites/site_config_client_helpers.py
@@ -3,14 +3,15 @@ Integration helpers for SiteConfig Client adapter.
 """
 
 from django.core.exceptions import ObjectDoesNotExist
-
 import tahoe_sites.api
-
 from site_config_client.openedx.features import (
     is_feature_enabled_for_site,
     enable_feature_for_site,
 )
 from site_config_client.openedx.adapter import SiteConfigAdapter
+
+from ..preview.helpers import is_preview_mode
+
 
 # TODO: Move these helpers into the `site_config_client.openedx.api` module
 
@@ -38,6 +39,21 @@ def enable_for_site(site):
     enable_feature_for_site(uuid)
 
 
-def get_configuration_adapter(site):
+def get_configuration_adapter_status(current_request=None):
+    """
+    Get the live/draft status for the site configuration adapter.
+    """
+    if is_preview_mode(current_request):
+        return 'draft'
+    else:
+        return 'live'
+
+
+def get_configuration_adapter(site, status=None):
+    """
+    Get the configuration adapter with the current
+    """
+    if not status:
+        status = get_configuration_adapter_status()
     uuid = tahoe_sites.api.get_uuid_by_site(site)
-    return SiteConfigAdapter(uuid)
+    return SiteConfigAdapter(site_uuid=uuid, status=status)

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_api_v2_views.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_api_v2_views.py
@@ -73,7 +73,7 @@ def test_compile_sass_view(client, site_with_uuid, superuser_with_token):
     site, site_uuid = site_with_uuid
     site_configuration = SiteConfigurationFactory.build(
         site=site,
-        site_values={'css_overrides_file': 'site.css'}
+        site_values={},
     )
     site_configuration.save()
 
@@ -164,8 +164,7 @@ def test_compile_sass_file(caplog, site_with_uuid):
     site, _ = site_with_uuid
     site_config = SiteConfigurationFactory.build(
         site=site,
-        site_values={'css_overrides_file': 'site.css',
-                     'THEME_VERSION': 'tahoe-v2'},
+        site_values={'THEME_VERSION': 'tahoe-v2'},
     )
     site_config.save()
 
@@ -174,5 +173,7 @@ def test_compile_sass_file(caplog, site_with_uuid):
     sass_status = site_config.compile_microsite_sass()
     assert sass_status['successful_sass_compile']
     assert 'Sass compile finished successfully' in sass_status['sass_compile_message']
-    assert '_main-v2.scss' in sass_status['scss_file_used'], 'Use `_main-v2.scss` due to THEME_VERSION`'
-    assert 'main.scss' not in sass_status['scss_file_used']
+    assert sass_status['scss_file_used'] == '_main-v2.scss', 'Use `_main-v2.scss` due to THEME_VERSION`'
+    assert sass_status['site_css_file'] == 'fake-site.css'
+    assert sass_status['theme_version'] == 'tahoe-v2'
+    assert sass_status['configuration_source'] == 'openedx_site_configuration_model'

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_config_values_modifier.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_config_values_modifier.py
@@ -2,7 +2,7 @@
 Tests for TahoeConfigurationValueModifier.
 """
 import pytest
-
+from django.contrib.sites.models import Site
 from unittest.mock import Mock
 
 from openedx.core.djangoapps.appsembler.sites.config_values_modifier import TahoeConfigurationValueModifier
@@ -61,7 +61,6 @@ def test_domain_name():
     ['ACTIVATION_EMAIL_SUPPORT_LINK', 'https://mysite.com/help', 'Should fix RED-2385.'],
     ['PASSWORD_RESET_SUPPORT_LINK', 'https://mysite.com/help', 'Should fix RED-2471.'],
     ['PASSWORD_RESET_SUPPORT_LINK', 'https://mysite.com/help', 'Should fix RED-2471.'],
-    ['css_overrides_file', 'mysite.com.css', 'Should configure the path for css_override_file'],
 ])
 def test_modifier_urls(settings, config_name, expected_value, message):
     settings.LMS_ROOT_URL = 'https://hello-world.com'
@@ -73,9 +72,12 @@ def test_modifier_urls(settings, config_name, expected_value, message):
     assert overriding_value == expected_value, message
 
 
+@pytest.mark.django_db
 def test_css_override_file_with_port_number():
-    modifier = TahoeConfigurationValueModifier(site_config_instance=Mock())
-    modifier.site_config_instance.site.domain = 'test.localhost:18000'
+    with ENABLE_CONFIG_VALUES_MODIFIER.override(True):
+        site_config = SiteConfiguration()
+        site_config.site = Site(domain='test.localhost:18000')
+    modifier = site_config.tahoe_config_modifier
     assert modifier.get_css_overrides_file() == 'test.localhost.css', 'Should not include port number in css file name'
 
 

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
@@ -1,12 +1,14 @@
 """
 Tests for site_config_client_helpers and SiteConfigAdapter.
 """
-
+from unittest.mock import patch
 import pytest
 from django.contrib.sites.models import Site
+from django.test import RequestFactory
 from mock import Mock
 from organizations.tests.factories import OrganizationFactory
 
+from lms.djangoapps.courseware.access_utils import in_preview_mode
 from openedx.core.djangoapps.appsembler.sites import (
     site_config_client_helpers as client_helpers,
 )
@@ -56,10 +58,12 @@ def test_is_disabled_for_main_site(settings, site_with_org):
 @pytest.mark.django_db
 def test_get_configuration_adapter(site_with_org):
     site, org = site_with_org
-
-    adapter = client_helpers.get_configuration_adapter(site)
+    request = RequestFactory().get('/', data={'preview': 'true'})
+    with patch('crum.get_current_request', return_value=request):
+        adapter = client_helpers.get_configuration_adapter(site)
     assert adapter, 'Should return if client package is installed'
     assert adapter.site_uuid == org.edx_uuid, 'Should set the correct ID'
+    assert adapter.status == 'draft', 'can be set to draft based on current request parameters'
 
 
 @pytest.mark.django_db
@@ -69,3 +73,40 @@ def test_get_configuration_adapter(site_with_org):
     adapter = client_helpers.get_configuration_adapter(site)
     assert adapter, 'Should return if client package is installed'
     assert adapter.site_uuid == org.edx_uuid, 'Should set the correct ID'
+    assert adapter.status == 'live', 'by default should be live status'
+
+
+def test_get_configuration_adapter_status_default():
+    """Ensure status is `live` by default."""
+    status = client_helpers.get_configuration_adapter_status(current_request=None)
+    assert status == 'live'
+
+
+def test_get_configuration_adapter_status_draft():
+    """Ensure status can be set to `draft`."""
+    request = RequestFactory().get('/', data={'preview': 'true'})
+    status = client_helpers.get_configuration_adapter_status(request)
+    assert status == 'draft'
+
+
+def test_courseware_in_preview_mode(settings):
+    """
+    Support the Tahoe preview in `lms.djangoapps.courseware.access_utils.in_preview_mode`.
+    """
+    settings.FEATURES = {
+        'PREVIEW_LMS_BASE': 'preview.example.com',
+    }
+    with patch(
+        'lms.djangoapps.courseware.access_utils.get_current_request_hostname'
+    ) as mock_get_hostname:
+        mock_get_hostname.return_value = 'preview.example.com'
+        assert in_preview_mode(), 'Sanity check: preview.example.com is the preview domain'
+
+        mock_get_hostname.return_value = 'example.com'
+        assert not in_preview_mode(), 'Sanity check: example.com is not the preview domain'
+
+        request = RequestFactory().get('/', data={'preview': 'true'})
+        with patch('crum.get_current_request', return_value=request):
+            assert in_preview_mode(), (
+                'New feature: example.com/?preview=true should be considered as a preview request'
+            )

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -20,6 +20,8 @@ from model_utils.models import TimeStampedModel
 
 from .exceptions import TahoeConfigurationException
 from ..appsembler.sites.waffle import ENABLE_CONFIG_VALUES_MODIFIER
+from ..appsembler.preview.helpers import is_preview_mode
+
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -42,6 +44,11 @@ def get_initial_page_elements():
     """
     from openedx.core.djangoapps.appsembler.sites import utils
     return utils.get_initial_page_elements()
+
+
+def get_customer_themes_storage():
+    storage_class = get_storage_class(settings.DEFAULT_FILE_STORAGE)
+    return storage_class(**settings.CUSTOMER_THEMES_BACKEND_OPTIONS)
 
 
 @python_2_unicode_compatible
@@ -280,6 +287,27 @@ class SiteConfiguration(models.Model):
         self.delete_css_override()
         super(SiteConfiguration, self).delete(using=using)
 
+    def get_css_overrides_file(self, preview=None):
+        """
+        Return the css override file base name.
+
+        Depending on the `preview` parameter, the file can be returned either for preview (`draft`) or live CSS file.
+        """
+        domain = self.site.domain
+        domain_without_port_number = domain.split(':')[0]
+
+        if preview is None:
+            preview = is_preview_mode()
+
+        if preview:
+            css_file_prefix = 'preview-'
+        else:
+            css_file_prefix = ''
+        return '{prefix}{domain}.css'.format(
+            prefix=css_file_prefix,
+            domain=domain_without_port_number,
+        )
+
     def compile_microsite_sass(self):
         """
         Compiles the microsite sass and save it into the storage bucket.
@@ -287,27 +315,25 @@ class SiteConfiguration(models.Model):
         :return dict {
           "successful_sass_compile": boolean: whether the CSS was compiled successfully
           "sass_compile_message": string: Status message that's safe to show for customers.
+          "scss_file_used": string: The source css file name.
+          "site_css_file": string: The stored file in the customer theme storage.
+          "theme_version": string: Theme version.
+          "configuration_source": string: "site_config_service_client" or "openedx_site_configuration_model".
         }
         """
         # Importing `sites.utils` locally to avoid test-time Django errors.
         # TODO: Fix Site Configuration and Organizations hacks. https://github.com/appsembler/edx-platform/issues/329
         from openedx.core.djangoapps.appsembler.sites import utils as sites_utils
 
-        storage = self.get_customer_themes_storage()
-        css_file_name = self.get_value('css_overrides_file')
-        if not css_file_name:
-            developer_message = 'Skipped compiling due to missing `css_overrides_file`'
-            exception_message = 'Tahoe: {developer_message} for `{site}` config_id=`{config_id}`'.format(
-                developer_message=developer_message,
-                site=self.site.domain,
-                config_id=self.id,
-            )
-            logger.exception(exception_message, exc_info=TahoeConfigurationException(exception_message))
-            return {
-                'successful_sass_compile': False,
-                'sass_compile_message': developer_message,
-            }
+        if self.api_adapter:
+            configuration_source = 'site_config_service_client'
+            # Clear cache to fetch fresh css and config variables
+            self.api_adapter.delete_backend_configs_cache()
+        else:
+            configuration_source = 'openedx_site_configuration_model'
 
+        storage = get_customer_themes_storage()
+        css_file_name = self.get_css_overrides_file()
         theme_version = self.get_value('THEME_VERSION', 'amc-v1')
         if theme_version == 'tahoe-v2':
             scss_file = '_main-v2.scss'
@@ -333,11 +359,31 @@ class SiteConfiguration(models.Model):
             'successful_sass_compile': successful_sass_compile,
             'sass_compile_message': sass_compile_message,
             'scss_file_used': scss_file,
+            'site_css_file': css_file_name,
+            'theme_version': theme_version,
+            'configuration_source': configuration_source,
         }
 
-    def get_css_url(self):
-        storage = self.get_customer_themes_storage()
-        return storage.url(self.get_value('css_overrides_file'))
+    def get_css_url(self, preview=None):
+        """
+        Return the fully qualified css override file with to be included in the theme.
+
+        Depending on the `preview` parameter, the file can be returned either for preview (`draft`) or live CSS file.
+
+        If the preview css file isn't compiled, the live CSS file will be returned.
+        """
+        storage = get_customer_themes_storage()
+
+        if preview is None:
+            preview = is_preview_mode()
+
+        css_override_file = self.get_css_overrides_file(preview=preview)
+
+        if preview and not storage.exists(css_override_file):
+            # If the CSS preview file is stale or missing use the regular one
+            css_override_file = self.get_css_overrides_file(preview=False)
+
+        return storage.url(css_override_file)
 
     def set_sass_variables(self, entries):
         """
@@ -349,16 +395,14 @@ class SiteConfiguration(models.Model):
                 new_value = (var_name, [entries[var_name], entries[var_name]])
                 self.sass_variables[index] = new_value
 
-    def get_customer_themes_storage(self):
-        storage_class = get_storage_class(settings.DEFAULT_FILE_STORAGE)
-        return storage_class(**settings.CUSTOMER_THEMES_BACKEND_OPTIONS)
-
     def delete_css_override(self):
-        css_file = self.get_value('css_overrides_file')
-        if css_file:
+        live_css_file = self.get_css_overrides_file()
+        draft_css_file = self.get_css_overrides_file()
+
+        for css_file in [live_css_file, draft_css_file]:
             try:
-                storage = self.get_customer_themes_storage()
-                storage.delete(self.get_value('css_overrides_file'))
+                storage = get_customer_themes_storage()
+                storage.delete(css_file)
             except Exception:  # pylint: disable=broad-except  # noqa
                 logger.warning("Can't delete CSS file {}".format(css_file))
 

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -1,6 +1,8 @@
 """
 Tests for site configuration's Tahoe customizations.
 """
+from io import StringIO
+
 import logging
 import pytest
 from sass import CompileError
@@ -186,6 +188,27 @@ class SiteConfigurationTests(TestCase):
             tahoex_org_name = self.test_config['course_org_filter']
             assert SiteConfiguration.get_value_for_org(tahoex_org_name, 'LMS_ROOT_URL') == self.expected_site_root_url
 
+    def test_get_css_url_in_live_mode(self):
+        site_config = SiteConfigurationFactory.create(site=self.site)
+        assert site_config.get_css_url() == '/static/uploads/example-site.tahoe.appsembler.com.css'
+
+    def test_get_css_url_in_preview_mode_missing_file(self):
+        """
+        Because the preview file isn't compiled, calling get_css_url(preview=True) should return the `live` file.
+        """
+        site_config = SiteConfigurationFactory.create(site=self.site)
+        assert site_config.get_css_url(preview=True) == '/static/uploads/example-site.tahoe.appsembler.com.css'
+
+    @patch('openedx.core.djangoapps.site_configuration.models.get_customer_themes_storage')
+    def test_get_css_url_in_preview_existing_file(self, mock_get_storage):
+        storage = Mock()
+        storage.exists.return_value = True  # Act as if the file exists.
+        storage.open.return_value = StringIO()
+        storage.url = lambda filename: '/path/to/{}'.format(filename)
+        mock_get_storage.return_value = storage
+        site_config = SiteConfigurationFactory.create(site=self.site)
+        assert site_config.get_css_url(preview=True) == '/path/to/preview-example-site.tahoe.appsembler.com.css'
+
 
 @pytest.mark.django_db
 @patch('openedx.core.djangoapps.appsembler.sites.utils.compile_sass', Mock(return_value='I am working CSS'))
@@ -195,7 +218,7 @@ def test_logs_of_site_configuration_compile_sass_successful_on_save(caplog):
     """
     caplog.set_level(logging.INFO)
     assert 'Sass compile' not in caplog.text
-    SiteConfigurationFactory.create(site_values={'css_overrides_file': 'omar.css'})
+    SiteConfigurationFactory.create(site_values={})
     assert 'tahoe sass compiled successfully' in caplog.text, 'Should compile sass on save'
 
 
@@ -209,25 +232,10 @@ def test_site_configuration_compile_sass_on_save_fail_gracefully(caplog, clean_s
     caplog.set_level(logging.INFO)
     site_config = clean_site_configuration_factory(
         site=Site.objects.create(domain='test.com'),
-        site_values={'css_overrides_file': 'omar.css'}
+        site_values={},
     )
     site_config.save()
     assert 'CSS is not working -- Omar' in caplog.text, 'Should log failures instead of throwing an exception'
-
-
-@pytest.mark.django_db
-def test_site_configuration_compile_sass_missing_override_file(caplog, clean_site_configuration_factory):
-    """
-    Ensure save() is successful on sass compile errors.
-    """
-    caplog.set_level(logging.INFO)
-    site_config = clean_site_configuration_factory(
-        site=Site.objects.create(domain='test.com'),
-    )
-    sass_status = site_config.compile_microsite_sass()
-    assert not sass_status['successful_sass_compile'], 'Should fail due to missing css_overrides_file'
-    assert 'Skipped compiling due to missing `css_overrides_file`' == sass_status['sass_compile_message']
-    assert 'missing `css_overrides_file`' in caplog.text, 'Should log failures instead of throwing an exception'
 
 
 @pytest.mark.django_db
@@ -238,9 +246,7 @@ def test_site_configuration_compile_sass_failure(caplog, clean_site_configuratio
     Test sass status returns on failure.
     """
     caplog.set_level(logging.INFO)
-    site_configuration = clean_site_configuration_factory(
-        site_values={'css_overrides_file': 'omar.css'}
-    )
+    site_configuration = clean_site_configuration_factory(site_values={})
     sass_status = site_configuration.compile_microsite_sass()
     assert not sass_status['successful_sass_compile']
     assert 'CSS is not working -- Omar' in sass_status['sass_compile_message']
@@ -253,9 +259,7 @@ def test_site_configuration_compile_sass_success(caplog, clean_site_configuratio
     Test sass status returns on success.
     """
     caplog.set_level(logging.INFO)
-    site_configuration = clean_site_configuration_factory(
-        site_values={'css_overrides_file': 'omar.css'}
-    )
+    site_configuration = clean_site_configuration_factory(site_values={})
     sass_status = site_configuration.compile_microsite_sass()
     assert sass_status['successful_sass_compile']
     assert 'Sass compile finished successfully' in sass_status['sass_compile_message']

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -23,4 +23,4 @@ django-tiers==0.2.4
 fusionauth-client==1.36.0
 tahoe-sites==0.1.6
 tahoe-lti==0.3.0
-site-configuration-client==0.1.7
+site-configuration-client==0.1.8


### PR DESCRIPTION
support preview via `?preview=true` parameter

support preview for:
 - page content such as `/about` others
 - css theme with `preveiw-site.com.css` variant of `site.com.css`
 - course content instead of needing a `preview.*` domain
 - clear cache before compiling css

### Reviewers

This pull request touches a pretty sensitive part of the platform -- configuration. If something breaks, don't hesitate to revert this pull request. Despite the extensive testing, things can and do go wrong.

### Testing

 - [x] Tests with pretty decent coverage
 - [x] Testing on devstack
 - [ ] Testing on staging