### PR TITLE
Add is_studio_allowed_for_user helper

### DIFF
--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_helpers.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_helpers.py
@@ -5,11 +5,27 @@ from unittest.mock import patch, Mock
 
 import pytest
 
+from organizations.tests.factories import OrganizationFactory
 from site_config_client.openedx.test_helpers import override_site_config
-
-from student.tests.factories import UserFactory
+from tahoe_sites import api as tahoe_sites_apis
 
 from openedx.core.djangoapps.appsembler.tahoe_idp import helpers
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
+from student.roles import OrgInstructorRole, OrgStaffRole
+from student.tests.factories import UserFactory
+
+
+@pytest.fixture
+def user_with_org():
+    """
+    :return: user, organization
+    """
+    site = SiteFactory.create()
+    organization = OrganizationFactory.create()
+    tahoe_sites_apis.create_tahoe_site_by_link(organization, site)
+    learner = UserFactory.create()
+    tahoe_sites_apis.add_user_to_organization(learner, organization, is_admin=False)
+    return learner, organization
 
 
 @pytest.mark.parametrize('global_flags,site_flags,should_be_enabled,message', [
@@ -102,3 +118,71 @@ def test_store_idp_metadata_in_user_profile():
     learner = UserFactory()
     helpers.store_idp_metadata_in_user_profile(learner, {'custom_field': 'some value'})
     assert learner.profile.get_meta() == {'tahoe_idp_metadata': {'custom_field': 'some value'}}
+
+
+@pytest.mark.django_db
+def test_is_studio_allowed_for_user_superuser():
+    """
+    Verify that is_studio_allowed_for_user returns <True> for superusers
+    """
+    # We're not using user_with_org fixture to test users with no linked organization
+    user = UserFactory.create(is_superuser=True)
+    assert helpers.is_studio_allowed_for_user(user)
+
+
+@pytest.mark.django_db
+def test_is_studio_allowed_for_user_staff():
+    """
+    Verify that is_studio_allowed_for_user returns <True> for staff users
+    """
+    # We're not using user_with_org fixture to test users with no linked organization
+    user = UserFactory.create(is_staff=True)
+    assert helpers.is_studio_allowed_for_user(user)
+
+
+@pytest.mark.django_db
+def test_is_studio_allowed_for_user_organization_admin(user_with_org):
+    """
+    Verify that is_studio_allowed_for_user returns <True> for organization admins
+    """
+    user, organization = user_with_org
+    tahoe_sites_apis.update_admin_role_in_organization(user, organization, set_as_admin=True)
+    assert helpers.is_studio_allowed_for_user(user, organization)
+
+
+@pytest.mark.django_db
+def test_is_studio_allowed_for_user_staff_role(user_with_org):
+    """
+    Verify that is_studio_allowed_for_user returns <True> for users having <OrgStaffRole>
+    """
+    user, organization = user_with_org
+    OrgStaffRole(organization.short_name).add_users(user)
+    assert helpers.is_studio_allowed_for_user(user, organization)
+
+
+@pytest.mark.django_db
+def test_is_studio_allowed_for_user_instructor_role(user_with_org, client):
+    """
+    Verify that is_studio_allowed_for_user returns <True> for users having <OrgInstructorRole>
+    """
+    user, organization = user_with_org
+    OrgInstructorRole(organization.short_name).add_users(user)
+    assert helpers.is_studio_allowed_for_user(user, organization)
+
+
+@pytest.mark.django_db
+def test_is_studio_allowed_for_user_learner(user_with_org):
+    """
+    Verify that is_studio_allowed_for_user returns <False> for normal users
+    """
+    learner, organization = user_with_org
+    assert not helpers.is_studio_allowed_for_user(learner, organization)
+
+
+@pytest.mark.django_db
+def test_is_studio_allowed_for_user_learner_no_organization(user_with_org):
+    """
+    Verify that is_studio_allowed_for_user will fetch the organization if not provided
+    """
+    learner, _ = user_with_org
+    assert not helpers.is_studio_allowed_for_user(learner)


### PR DESCRIPTION
## Change description

Add `is_studio_allowed_for_user` helper to check whether a user is permitted to log into Studio or not

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/RED-3034

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
