### PR TITLE
prevent live/preview cache mixup via TieredCacheMiddleware for unauthenticated users

### DIFF
--- a/openedx/core/djangoapps/appsembler/preview/helpers.py
+++ b/openedx/core/djangoapps/appsembler/preview/helpers.py
@@ -19,5 +19,11 @@ def is_preview_mode(current_request=None):
     if not current_request:
         return False
 
+    user = getattr(current_request, 'user', None)
+    if not (user and user.is_active):
+        # Require a logged-in user for preview otherwise preview/live would be mixed up in caching.
+        # This makes sure `preview` won't work with edx_django_utils's TieredCacheMiddleware.
+        return False
+
     preview_param = current_request.GET.get(PREVIEW_GET_PARAM, 'false')
     return str(preview_param).lower() == PREVIEW_PARAM_TRUE

--- a/openedx/core/djangoapps/appsembler/preview/tests/test_helpers.py
+++ b/openedx/core/djangoapps/appsembler/preview/tests/test_helpers.py
@@ -2,10 +2,14 @@
 Tests for helpers.
 """
 import pytest
+from django.contrib.auth import get_user_model
 from unittest.mock import patch
 from django.test.client import RequestFactory
 
 from ..helpers import is_preview_mode, PREVIEW_GET_PARAM
+
+
+User = get_user_model()
 
 
 def test_no_request():
@@ -14,14 +18,22 @@ def test_no_request():
 
 def test_request_non_preview_mode():
     request = RequestFactory().get('/test')
+    request.user = User()
     assert not is_preview_mode(current_request=request), 'default to non-preview'
 
 
 @pytest.mark.parametrize('preview_param', [True, 'true', 'True'])
 def test_request_preview_mode_case_insensitive(preview_param):
     request = RequestFactory().get('/test', data={'preview': preview_param})
+    request.user = User()
     is_preview_result = is_preview_mode(current_request=request)
     assert is_preview_result, 'Should respect case-insensitive `preview=true` param'
+
+
+def test_request_preview_mode_without_user():
+    request = RequestFactory().get('/test', data={'preview': 'true'})
+    is_preview_result = is_preview_mode(current_request=request)
+    assert not is_preview_result, 'Disable preview mode for unauthenticated users'
 
 
 def test_request_preview_mode_crum():
@@ -29,6 +41,7 @@ def test_request_preview_mode_crum():
     Ensure `crum.get_current_request` is used when no request is provided via parameters.
     """
     request = RequestFactory().get('/test', data={PREVIEW_GET_PARAM: 'true'})
+    request.user = User()
     with patch('crum.get_current_request', return_value=request):
         assert is_preview_mode(), 'Should default to `crum` request'
 
@@ -38,4 +51,5 @@ def test_request_preview_mode_test_yes():
     Ensure `crum.get_current_request` should be `live` if provided anything other than yes.
     """
     request = RequestFactory().get('/test', data={PREVIEW_GET_PARAM: 'yes'})
+    request.user = User()
     assert not is_preview_mode(current_request=request), 'Anything is falsy, except for `true`'

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
@@ -3,6 +3,7 @@ Tests for site_config_client_helpers and SiteConfigAdapter.
 """
 from unittest.mock import patch
 import pytest
+from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.test import RequestFactory
 from mock import Mock
@@ -12,6 +13,8 @@ from lms.djangoapps.courseware.access_utils import in_preview_mode
 from openedx.core.djangoapps.appsembler.sites import (
     site_config_client_helpers as client_helpers,
 )
+
+User = get_user_model()
 
 
 @pytest.fixture
@@ -85,6 +88,7 @@ def test_get_configuration_adapter_status_default():
 def test_get_configuration_adapter_status_draft():
     """Ensure status can be set to `draft`."""
     request = RequestFactory().get('/', data={'preview': 'true'})
+    request.user = User()
     status = client_helpers.get_configuration_adapter_status(request)
     assert status == 'draft'
 
@@ -106,6 +110,8 @@ def test_courseware_in_preview_mode(settings):
         assert not in_preview_mode(), 'Sanity check: example.com is not the preview domain'
 
         request = RequestFactory().get('/', data={'preview': 'true'})
+        request.user = User()
+
         with patch('crum.get_current_request', return_value=request):
             assert in_preview_mode(), (
                 'New feature: example.com/?preview=true should be considered as a preview request'

--- a/openedx/core/djangoapps/site_configuration/management/commands/tests/test_create_or_update_site_configuration.py
+++ b/openedx/core/djangoapps/site_configuration/management/commands/tests/test_create_or_update_site_configuration.py
@@ -3,6 +3,9 @@ Tests for the create_or_update_site_configuration management command.
 """
 from __future__ import absolute_import, unicode_literals
 
+import unittest
+from django.conf import settings
+
 import codecs
 import json
 
@@ -16,6 +19,10 @@ from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 
 
 @ddt.ddt
+@unittest.skipIf(
+    settings.TAHOE_ALWAYS_SKIP_TEST,
+    'skip low-priority broken upstream tests due to Tahoe changes on the SiteConfiguration model',
+)
 class CreateOrUpdateSiteConfigurationTest(TestCase):
     """
     Test for the create_or_update_site_configuration management command.

--- a/tox.ini
+++ b/tox.ini
@@ -126,7 +126,7 @@ commands =
         lms/djangoapps/instructor/ \
         lms/djangoapps/verify_student/tests/test_services.py  \
         openedx/core/djangoapps/appsembler \
-        openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+        openedx/core/djangoapps/site_configuration/
 
 [testenv:lms-2]
 commands =


### PR DESCRIPTION
enable `?preview=true` only for logged in users

### TODO
 - [x] Test on devstack/staging