### PR TITLE
Site Configuration Client package updates

### DIFF
--- a/Dockerfile.tutor
+++ b/Dockerfile.tutor
@@ -63,6 +63,7 @@ RUN echo "Installing pip packages:" \
     && pip install gestore==0.1.0-dev3 \
     && pip install xblock-grade-fetcher==0.2 \
     && pip install -e 'git+https://github.com/appsembler/tahoe-idp.git@main#egg=tahoe-idp' \
+    && pip install "google-cloud-storage==1.32.0" \
     && echo "Finished installing pip packages."
 
 RUN mkdir -p /openedx/themes/ \

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -23,5 +23,5 @@ django-tiers==0.2.4
 fusionauth-client==1.36.0
 tahoe-sites==0.1.6
 tahoe-lti==0.3.0
-site-configuration-client==0.1.10
+site-configuration-client==0.1.11
 


### PR DESCRIPTION
 - bump site-configuration-client==0.1.11
 - docker: install gcp storage for site-configuration-client
