### PR TITLE
Reduce CERTIFICATE_DELAY_SECONDS from 2 seconds to half a second

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -31,7 +31,7 @@ from openedx.core.djangoapps.signals.signals import (
 from student.models import CourseEnrollment
 
 log = logging.getLogger(__name__)
-CERTIFICATE_DELAY_SECONDS = 0.5
+CERTIFICATE_DELAY_SECONDS = getattr(settings, 'CERTIFICATE_DELAY_SECONDS', 2)
 
 
 @receiver(COURSE_PACING_CHANGED, dispatch_uid="update_cert_settings_on_pacing_change")

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -31,7 +31,7 @@ from openedx.core.djangoapps.signals.signals import (
 from student.models import CourseEnrollment
 
 log = logging.getLogger(__name__)
-CERTIFICATE_DELAY_SECONDS = 2
+CERTIFICATE_DELAY_SECONDS = 0.5
 
 
 @receiver(COURSE_PACING_CHANGED, dispatch_uid="update_cert_settings_on_pacing_change")


### PR DESCRIPTION
## Change description

This was introduced by edX to deal with a race condition with
PhotoSecureVerification (https://github.com/openedx/edx-platform/pull/15996)
but the delay is actually too long for customers using auto-generated
certs on passing grade  (standalone customers on Tahoe codebase are using this feature), leading to visits to the Progress
page with no certificate yet available.
We do not use PhotoSecureVerification so why don't we just make this
shorter?  It's unfortunately not configurable.
Upstream, the constant has moved and there's been refactoring of
related code, so at this point I just want to override like this.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/BLACK-2505

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass - _there are no timing/integration tests_

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
