### PR TITLE
Port TierMiddleware and add SiteConfig support

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/devstack_common.py
@@ -35,6 +35,10 @@ def plugin_settings(settings):
 
     settings.CUSTOMER_THEMES_BACKEND_OPTIONS = {}
 
+    if settings.FEATURES.get('ENABLE_TIERS_APP'):
+        # Database in devstack has no SSL
+        settings.DATABASES['tiers']['OPTIONS']['sslmode'] = 'allow'
+
     # Those are usually hardcoded in devstack.py for some reason
     settings.LMS_BASE = settings.ENV_TOKENS.get('LMS_BASE')
     settings.LMS_ROOT_URL = settings.ENV_TOKENS.get('LMS_ROOT_URL')

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -63,14 +63,13 @@ def plugin_settings(settings):
     if settings.FEATURES.get('ENABLE_TIERS_APP', False):
         settings.TIERS_ORGANIZATION_MODEL = 'organizations.Organization'
         settings.TIERS_EXPIRED_REDIRECT_URL = settings.ENV_TOKENS.get('TIERS_EXPIRED_REDIRECT_URL', None)
-        settings.TIERS_ORGANIZATION_TIER_GETTER_NAME = 'get_tier_for_org'
 
         settings.TIERS_DATABASE_URL = settings.AUTH_TOKENS.get('TIERS_DATABASE_URL')
         settings.DATABASES['tiers'] = dj_database_url.parse(settings.TIERS_DATABASE_URL, ssl_require=True)
         settings.DATABASE_ROUTERS.insert(0, 'openedx.core.djangoapps.appsembler.tahoe_tiers.db_routers.TiersDbRouter')
 
         settings.MIDDLEWARE += [
-            'tiers.middleware.TierMiddleware',
+            'openedx.core.djangoapps.appsembler.tahoe_tiers.middleware.TahoeTierMiddleware',
         ]
         settings.INSTALLED_APPS += [
             'tiers',

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
@@ -208,4 +208,3 @@ def test_get_current_site_config_tier_info():
         tier_info = get_current_site_config_tier_info()
 
     assert not tier_info.has_subscription_ended(), 'Should return valid TierInfo object'
-

--- a/openedx/core/djangoapps/appsembler/tahoe_tiers/helpers.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_tiers/helpers.py
@@ -1,7 +1,39 @@
 """
-API helpers.
+Tiers Tahoe helpers.
 """
 
+import beeline
 
-def get_tier_info_for_organization(organization):
-    from tiers.tier_info import TierInfo
+from ..sites.site_config_client_helpers import get_current_site_config_tier_info
+
+from .legacy_amc_helpers import get_amc_tier_info_from_organization
+
+
+TIER_INFO_REQUEST_FIELD_NAME = '_tahoe_tier_info'
+
+
+@beeline.traced('tahoe_tiers.helpers.get_tier_info')
+def get_tier_info(request):
+    """
+    Get TierInfo either for both Tahoe 1.0 (AMC Postgres Tiers) and Tahoe 2.0 (SiteConfig service).
+    """
+    tier_info = getattr(request, TIER_INFO_REQUEST_FIELD_NAME, None)  # Get request-cached tier-info
+    if not tier_info:
+        # Try AMC tiers first, to ensure the least feature/performance impact on Tahoe 1.0 sites.
+        organization = request.session.get('organization')
+        beeline.add_context_field('organization', organization)
+        tier_info = get_amc_tier_info_from_organization(organization)
+        if tier_info:
+            beeline.add_context_field('amc_tier_info_used', True)
+
+    if not tier_info:
+        # If no tier info exists, try with the Site Configuration service tier info
+        tier_info = get_current_site_config_tier_info()
+        if tier_info:
+            beeline.add_context_field('site_config_tier_info_used', True)
+
+    if not tier_info:
+        beeline.add_context_field('no_tier_info', True)
+
+    setattr(request, TIER_INFO_REQUEST_FIELD_NAME, tier_info)
+    return tier_info

--- a/openedx/core/djangoapps/appsembler/tahoe_tiers/legacy_amc_helpers.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_tiers/legacy_amc_helpers.py
@@ -4,45 +4,60 @@ A module for deprecated AMC tier utilities.
 TODO: Remove this module once AMC is shut down.
 """
 
+import logging
+import beeline
+
 from django.utils import timezone
 from django.db.models import Q, F
 
+from tiers.models import Tier
 
-def get_amc_tier_info_for_org(organization):
+log = logging.getLogger(__name__)
+
+
+@beeline.traced('legacy_amc_helpers.get_amc_tier_info_from_organization')
+def get_amc_tier_info_from_organization(organization):  # pragma: no cover
     """
-    Get the Tier for the organization.
+    Get TierInfo for an AMC-enabled (Tahoe 1.0) site.
 
     Hack: This queries the django-tier database in a rather hacky way.
+
+    WARNING: !! This function is _not_ covered with tests. Please edit with caution and test manually. !!
     """
-    from tiers.models import Tier  # pylint: disable=import-error
-    tier = Tier.objects.defer('organization').get(organization__edx_uuid=organization.edx_uuid)
-    tier_object = Tier(
-        name=tier.name,
-        tier_enforcement_exempt=tier.tier_enforcement_exempt,
-        tier_expires_at=tier.tier_expires_at,
-        organization=organization,
-    )
-    return tier_object.get_tier_info()
+    if not organization:
+        beeline.add_context_field("tiers.no_organization", True)
+        return None
+
+    beeline.add_context_field("tiers.organization", "{}".format(organization))
+    try:
+        # Query the AMC Postgres database directly
+        tier = Tier.objects.defer('organization').get(organization__edx_uuid=organization.edx_uuid)
+        tier_info = tier.get_tier_info()
+    except Exception:
+        # If the organization for some reason does not have a tier assigned
+        # fail silently. This should not happen. We should always automatically create
+        # a tier for each organization.
+        beeline.add_context_field("tiers.organization_without_tier", True)
+        log.exception("Organization has a problem with its Tier: {0}".format(organization))
+        return None
+
+    return tier_info
 
 
-def get_active_tiers_uuids_from_amc_postgres(now=None):
+def get_active_tiers_uuids_from_amc_postgres():  # pragma: no cover
     """
     Get active Tier organization UUIDs from the Tiers (AMC Postgres) database.
 
-    Note: This mostly a hack that's needed for improving the performance of
-          batch operations by excluding dead sites.
+    Hack: This queries the django-tier database in a rather hacky way.
 
     Return a list of UUID objects.
+
+    WARNING: !! This function is _not_ covered with tests. Please edit with caution and test manually. !!
     """
-    from tiers.models import Tier
-
-    if not now:
-        now = timezone.now()
-
     # This queries the AMC Postgres database
     active_tiers_uuids = Tier.objects.filter(
         Q(tier_enforcement_exempt=True) |
-        Q(tier_expires_at__gte=now)
+        Q(tier_expires_at__gte=timezone.now())
     ).annotate(
         organization_edx_uuid=F('organization__edx_uuid')
     ).values_list('organization_edx_uuid', flat=True)

--- a/openedx/core/djangoapps/appsembler/tahoe_tiers/middleware.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_tiers/middleware.py
@@ -1,0 +1,71 @@
+import logging
+import beeline
+
+from django.shortcuts import redirect, reverse
+from django.utils.deprecation import MiddlewareMixin
+from django.urls import NoReverseMatch
+
+from tiers.helpers import is_equal_or_sub_url, is_white_listed_url
+from tiers.app_settings import settings
+
+from .helpers import get_tier_info
+
+
+log = logging.getLogger(__name__)
+
+
+class TahoeTierMiddleware(MiddlewareMixin):
+    """
+    Django Tiers middleware.
+
+    This is a copy/pasta from `django-tiers` to prepare for AMC shut down.
+
+    # TODO: Clean up AMC-specific legacy.
+    """
+    @beeline.traced(name="TiersMiddleware.process_request")
+    def process_request(self, request):
+        """
+        Fetch organization from session and deny access to the system if the tier
+        is expired
+        """
+        # If we're already on the url where we have to be, do nothing
+        expired_redirect_url = settings.expired_redirect_url()
+        if expired_redirect_url and is_equal_or_sub_url(request_url=request.path, checked_url=expired_redirect_url):
+            beeline.add_context_field("tiers.no_action_required", True)
+            return
+
+        # try/catch needed because the URLs don't necessarily exist both in LMS and CMS
+        try:
+            # If we're trying to log out or release a hijacked user, don't redirect to expired page
+            if request.path == reverse("release_hijack") or request.path == reverse("account_logout"):
+                return
+        except NoReverseMatch:
+            pass
+
+        # If the user has superuser privileges don't do anything
+        if request.user.is_authenticated and request.user.is_superuser:
+            return
+
+        tier_info = get_tier_info(request)
+
+        if not tier_info:
+            # Yes, errors in fetching the TierInfo are ignored completely, this is mostly to avoid having LMS go down
+            # if AMC database is down.
+            beeline.add_context_field("tiers.no_tier_info", True)
+            return
+
+        # Only display expiration warning for Trial tiers for now
+        request.session['DISPLAY_EXPIRATION_WARNING'] = tier_info.should_show_expiration_warning()
+        request.session['TIER_EXPIRES_IN'] = tier_info.time_til_expiration()
+        beeline.add_context_field("tiers.tier_expires_in", request.session['TIER_EXPIRES_IN'])
+        # TODO: I'm not sure if we have to refresh the session info at this point somehow.
+        request.session['TIER_EXPIRED'] = tier_info.has_subscription_ended()
+        beeline.add_context_field("tiers.tier_expired", request.session['TIER_EXPIRED'])
+        # TODO: We should use request.TIER_NAME instead of meddling the session, but being consistent for now
+        request.session['TIER_NAME'] = tier_info.tier
+        beeline.add_context_field("tiers.tier_name", tier_info.tier)
+
+        # TODO: I'm not sure if we have to refresh the session info at this point somehow.
+        if tier_info.has_subscription_ended():
+            if expired_redirect_url and not is_white_listed_url(request.path):
+                return redirect(expired_redirect_url)

--- a/openedx/core/djangoapps/appsembler/tahoe_tiers/tests/conftest.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_tiers/tests/conftest.py
@@ -1,0 +1,21 @@
+"""
+Factories and fixtures for pytest.
+"""
+
+import pytest
+
+from django.utils import timezone
+
+from tiers.tier_info import TierInfo
+
+
+@pytest.fixture
+def tier_info():
+    """
+    TierInfo fixture.
+    """
+    return TierInfo(
+        tier='trial',
+        always_active=False,
+        subscription_ends=timezone.now(),
+    )

--- a/openedx/core/djangoapps/appsembler/tahoe_tiers/tests/test_helpers.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_tiers/tests/test_helpers.py
@@ -1,0 +1,76 @@
+"""
+Tests for helper functions.
+"""
+import pytest
+from unittest.mock import patch
+
+from django.test import RequestFactory
+
+from organizations.tests.factories import OrganizationFactory
+
+from openedx.core.djangoapps.appsembler.tahoe_tiers.helpers import (
+    TIER_INFO_REQUEST_FIELD_NAME,
+    get_tier_info,
+)
+
+from .conftest import tier_info
+
+
+def test_get_tier_info_unavailable():
+    """
+    Test the `get_tier_info` helper for complete missing TierInfo.
+    """
+    request = RequestFactory().get('/dashboard')
+    request.session = {}
+
+    actual_tier_info = get_tier_info(request)
+
+    assert actual_tier_info is None, 'Because no organization is associated with the request'
+    assert hasattr(request, TIER_INFO_REQUEST_FIELD_NAME)
+    assert getattr(request, TIER_INFO_REQUEST_FIELD_NAME) is None
+
+
+def test_get_tier_info_from_request_cache(tier_info):
+    """
+    Test the `get_tier_info` helper for using the `_tahoe_tier_info`.
+    """
+    request = RequestFactory().get('/dashboard')
+    setattr(request, TIER_INFO_REQUEST_FIELD_NAME, tier_info)
+
+    actual_tier_info = get_tier_info(request)
+
+    assert actual_tier_info == tier_info, 'Should return from request `_tahoe_tier_info` property'
+    assert getattr(request, TIER_INFO_REQUEST_FIELD_NAME) == tier_info, 'should cache it'
+
+
+@pytest.mark.django_db
+@patch('openedx.core.djangoapps.appsembler.tahoe_tiers.helpers.get_amc_tier_info_from_organization')
+def test_get_tier_info_from_amc(mock_get_amc_tier_info, tier_info):
+    """
+    Test the `get_tier_info` helper for using the `_tahoe_tier_info`.
+    """
+    request = RequestFactory().get('/dashboard')
+    organization = OrganizationFactory.create()
+    request.session = {'organization': organization}
+    mock_get_amc_tier_info.return_value = tier_info
+
+    actual_tier_info = get_tier_info(request)
+
+    assert actual_tier_info == tier_info, 'Should return AMC tiers'
+    mock_get_amc_tier_info.assert_called_once_with(organization)
+    assert getattr(request, TIER_INFO_REQUEST_FIELD_NAME) == tier_info, 'should cache it'
+
+
+@patch('openedx.core.djangoapps.appsembler.tahoe_tiers.helpers.get_current_site_config_tier_info')
+def test_get_tier_info_from_site_config(mock_get_site_config_tier_info, tier_info):
+    """
+    Test the `get_tier_info` helper for using the `_tahoe_tier_info`.
+    """
+    request = RequestFactory().get('/dashboard')
+    request.session = {}
+    mock_get_site_config_tier_info.return_value = tier_info
+
+    actual_tier_info = get_tier_info(request)
+
+    assert actual_tier_info == tier_info, 'Should return from Site Config adapter'
+    assert getattr(request, TIER_INFO_REQUEST_FIELD_NAME) == tier_info, 'should cache it'

--- a/openedx/core/djangoapps/appsembler/tahoe_tiers/tests/test_middleware.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_tiers/tests/test_middleware.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timedelta
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from django.test.client import RequestFactory
+from mock import patch, PropertyMock
+
+from tiers.tier_info import TierInfo
+
+from openedx.core.djangoapps.appsembler.tahoe_tiers.middleware import TahoeTierMiddleware
+from openedx.core.djangoapps.appsembler.tahoe_tiers.helpers import TIER_INFO_REQUEST_FIELD_NAME
+
+
+@patch.object(User, 'is_authenticated', PropertyMock(return_value=True))
+class TestMiddlewareTests(TestCase):
+    """
+    TiersMiddleware tests with a non-expired trial Tier.
+    """
+
+    def setUp(self):
+        super(TestMiddlewareTests, self).setUp()
+        self.middleware = TahoeTierMiddleware()
+        self.tier_info = TierInfo(
+            tier='trial',
+            subscription_ends=timezone.now() + timedelta(days=40),
+            always_active=False,
+        )
+        self.request = RequestFactory().get('/dashboard')
+        setattr(self.request, TIER_INFO_REQUEST_FIELD_NAME, self.tier_info)
+        self.request.session = {}
+        self.user = User()
+        self.request.user = self.user
+
+    def test_empty_by_default_attributes(self):
+        default = object()
+        for attrib in ['DISPLAY_EXPIRATION_WARNING', 'TIER_EXPIRES_IN', 'TIER_EXPIRED', 'TIER_NAME']:
+            assert self.request.session.get(attrib, default) is default
+
+    def test_added_session_attribs(self):
+        self.middleware.process_request(self.request)
+        assert not self.request.session['TIER_EXPIRED']
+        assert self.request.session['TIER_EXPIRES_IN'] == self.tier_info.time_til_expiration()
+        assert self.request.session['DISPLAY_EXPIRATION_WARNING']
+        assert self.request.session['TIER_NAME'] == 'trial'
+
+
+class TestExpiredTierMiddleware(TestCase):
+    """
+    TiersMiddleware tests with an expired trial Tier.
+    """
+
+    def setUp(self):
+        super(TestExpiredTierMiddleware, self).setUp()
+        self.middleware = TahoeTierMiddleware()
+        self.tier_info = TierInfo(
+            tier='trial',
+            subscription_ends=timezone.now() - timedelta(days=40),
+            always_active=False,
+        )
+        self.request = RequestFactory().get('/dashboard')
+        setattr(self.request, TIER_INFO_REQUEST_FIELD_NAME, self.tier_info)
+        self.request.session = {}
+        self.user = User()
+        self.request.user = self.user
+
+    @patch.object(User, 'is_authenticated', PropertyMock(return_value=True))
+    @override_settings(TIERS_EXPIRED_REDIRECT_URL='/expired')
+    def test_added_session_attribs(self):
+        self.middleware.process_request(self.request)
+        assert self.request.session['TIER_EXPIRED']
+        assert self.request.session['TIER_NAME'] == 'trial'
+
+    @patch.object(User, 'is_authenticated', PropertyMock(return_value=True))
+    @override_settings(TIERS_EXPIRED_REDIRECT_URL='/expired')
+    def test_redirect(self):
+        response = self.middleware.process_request(self.request)
+        assert response, 'should redirect'
+        assert response.status_code == 302 and response['Location'] == '/expired', 'should redirect'
+
+    @patch.object(User, 'is_authenticated', PropertyMock(return_value=True))
+    @override_settings(TIERS_EXPIRED_REDIRECT_URL='/expired')
+    def test_expired_url_should_not_redirect(self):
+        self.request.path = '/expired'
+        response = self.middleware.process_request(self.request)
+        assert not response, 'should NOT redirect if it is already on expred url'
+
+    @patch.object(User, 'is_authenticated', PropertyMock(return_value=True))
+    @override_settings(TIERS_EXPIRED_REDIRECT_URL='/expired')
+    def test_admin_url_should_not_redirect(self):
+        self.request.path = '/admin'
+        response = self.middleware.process_request(self.request)
+        assert not response, 'should NOT redirect if if on /admin'
+
+    @patch.object(User, 'is_authenticated', PropertyMock(return_value=True))
+    @override_settings(TIERS_EXPIRED_REDIRECT_URL='/expired')
+    def test_homepage_url_should_redirect(self):
+        self.request.path = '/'
+        response = self.middleware.process_request(self.request)
+        assert response, 'should redirect if if on homepage "/"'
+
+    @patch.object(User, 'is_authenticated', PropertyMock(return_value=False))
+    def test_redirect_non_authenticated(self):
+        self.middleware.process_request(self.request)
+        assert 'TIER_NAME' in self.request.session
+        assert self.request.session['TIER_EXPIRED']

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -101,7 +101,7 @@ class SiteConfiguration(models.Model):
             site_config_client_helpers as site_helpers,
         )
         if site_helpers.is_enabled_for_site(site):
-            self.api_adapter = site_helpers.get_configuration_adapter(site)
+            self.api_adapter = site_helpers.init_site_configuration_adapter(site)
 
     @beeline.traced('site_config.get_value')
     def get_value(self, name, default=None):

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -19,9 +19,8 @@ https://github.com/edx-solutions/xblock-google-drive/archive/589d9f51f9b.tar.gz 
 -e git+https://github.com/appsembler/edx-sga.git@821cf8c563c86d92630e57e2cae06ab1dfaeff09#egg=v0.11.0-appsembler2
 
 # Tahoe plugins and customizations
-django-tiers==0.2.4
+django-tiers==0.2.7
 fusionauth-client==1.36.0
 tahoe-sites==0.1.6
 tahoe-lti==0.3.0
 site-configuration-client==0.1.11
-

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -23,4 +23,4 @@ django-tiers==0.2.7
 fusionauth-client==1.36.0
 tahoe-sites==0.1.6
 tahoe-lti==0.3.0
-site-configuration-client==0.1.11
+site-configuration-client==0.1.12


### PR DESCRIPTION
### Summary

 - Copy TierMiddleware from https://github.com/appsembler/django-tiers/ while removing AMC related parts
 - Move the AMC-specific `tier.get_tier_info()` into `get_tier_info()` helper which uses `get_amc_tier_info_from_organization`
 - Add SiteConfig service helper to support Tahoe 2.0 sites via `get_current_site_config_tier_info`

### Tech-debt notes

In prep to ditch AMC and use Site Config service we're removing the `django-tiers` package in its current form.

Next step will probably mean we create a new `tahoe-tiers` package which isn't going to be used in AMC.

The would be costly abstractions and plugins to use `TierMiddleware` with AMC while supporting SiteConfig at the same time. Therefore we're making a clone into `edx-platform` until we move it back into a future `tahoe-tiers` package.

I know this is convluted, because I've had a hard time wrapping my head around the fact how `django-tiers` works.

So this essentially one more tech-debt that we'd invest into paying the `django-tiers` larger tech-debt.

### Related PRs

 - https://github.com/appsembler/site-configuration-client/pull/76 
 - #1168 

### TODO

 - [x] Test on devstack
 - [x] Fix tests after https://github.com/appsembler/site-configuration-client/pull/76 is merged