### PR TITLE
feat: add year_of_birth to the field_mapping for sso profile sync

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -842,6 +842,7 @@ def user_details_force_sync(auth_entry, strategy, details, user=None, *args, **k
         field_mapping.update({
             'fullname': (user.profile, 'name'),
             'country': (user.profile, 'country'),
+            'year_of_birth': (user.profile, 'year_of_birth'),
         })
 
         # Remove username from list of fields for update

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -402,6 +402,7 @@ class UserDetailsForceSyncTestCase(testutil.TestCase, test.TestCase):
             'fullname': u'Grown Up {}'.format(self.user.profile.name),
             'country': 'PK',
             'non_existing_field': 'value',
+            'year_of_birth': 1999,
         }
 
         # Mocks
@@ -430,6 +431,7 @@ class UserDetailsForceSyncTestCase(testutil.TestCase, test.TestCase):
         assert user.email == 'new+{}'.format(self.old_email)
         assert user.profile.name == u'Grown Up {}'.format(self.old_fullname)
         assert user.profile.country == 'PK'
+        assert user.profile.year_of_birth == 1999
 
         # Now verify that username field is not updated
         assert user.username == self.old_username
@@ -456,6 +458,7 @@ class UserDetailsForceSyncTestCase(testutil.TestCase, test.TestCase):
         assert user.email == self.old_email
         assert user.profile.name == u'Grown Up {}'.format(self.old_fullname)
         assert user.profile.country == 'PK'
+        assert user.profile.year_of_birth == 1999
 
         # Now verify that username field is not updated
         assert user.username == self.old_username
@@ -486,6 +489,7 @@ class UserDetailsForceSyncTestCase(testutil.TestCase, test.TestCase):
         assert user.username == self.old_username
         assert user.profile.name == u'Grown Up {}'.format(self.old_fullname)
         assert user.profile.country == 'PK'
+        assert user.profile.year_of_birth == 1999
 
         # An email should still be sent because the email changed.
         assert len(mail.outbox) == 1


### PR DESCRIPTION
## Description

This change enabled `year_of_birth` syncing in `tpa_pipeline`. For more info check [this JIRA ticket](https://appsembler.atlassian.net/browse/BLACK-2081)

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
