### PR TITLE
Fix Delete My Account when using `tahoe-idp`

### DIFF
--- a/openedx/core/djangoapps/appsembler/tahoe_idp/constants.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/constants.py
@@ -1,1 +1,2 @@
 TAHOE_IDP_BACKEND_NAME = 'tahoe-idp'
+TAHOE_IDP_PROVIDER_NAME = 'oa2-{backend}'.format(backend=TAHOE_IDP_BACKEND_NAME)

--- a/openedx/core/djangoapps/appsembler/tahoe_idp/helpers.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/helpers.py
@@ -16,7 +16,11 @@ import third_party_auth
 from third_party_auth.pipeline import running as pipeline_running
 
 
-from .constants import TAHOE_IDP_BACKEND_NAME
+from .constants import (
+    TAHOE_IDP_BACKEND_NAME,
+    TAHOE_IDP_PROVIDER_NAME,
+)
+
 from student.roles import OrgInstructorRole, OrgStaffRole
 
 
@@ -83,6 +87,16 @@ def store_idp_metadata_in_user_profile(user, metadata):
     meta["tahoe_idp_metadata"] = metadata
     user.profile.set_meta(meta)
     user.profile.save()
+
+
+def remove_tahoe_idp_from_account_settings(providers):
+    """
+    Remove the `tahoe-idp` entry from account settings.
+    """
+    return [
+        provider for provider in providers
+        if provider['id'] != TAHOE_IDP_PROVIDER_NAME
+    ]
 
 
 def is_studio_allowed_for_user(user, organization=None):

--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_account_settings_views_with_tahoe_idp.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_account_settings_views_with_tahoe_idp.py
@@ -1,0 +1,62 @@
+""" Tests for views related to account settings and Tahoe IdP. """
+# -*- coding: utf-8 -*-
+
+
+from unittest import mock
+from django.http import HttpRequest
+from django.test import TestCase
+
+from openedx.core.djangoapps.programs.tests.mixins import ProgramsApiConfigMixin
+from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
+from openedx.core.djangoapps.user_api.accounts.settings_views import account_settings_context
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from student.tests.factories import UserFactory
+from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
+
+
+@skip_unless_lms
+class TahoeIdPAccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiConfigMixin, TestCase):
+    """ Tests for the account settings view. """
+
+    USERNAME = 'student'
+    PASSWORD = 'password'
+    FIELDS = [
+        'country',
+        'gender',
+        'language',
+        'level_of_education',
+        'password',
+        'year_of_birth',
+        'preferred_language',
+        'time_zone',
+    ]
+
+    @mock.patch("django.conf.settings.MESSAGE_STORAGE", 'django.contrib.messages.storage.cookie.CookieStorage')
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.user = UserFactory.create(username=self.USERNAME, password=self.PASSWORD)
+        self.client.login(username=self.USERNAME, password=self.PASSWORD)
+
+        self.request = HttpRequest()
+        self.request.user = self.user
+
+        # For these tests configure Tahoe IdP
+        self.configure_google_provider(enabled=True, visible=True, name='Tahoe IdP')
+
+        # Python-social saves auth failure notifcations in Django messages.
+        # See pipeline.get_duplicate_provider() for details.
+        self.request.COOKIES = {}
+
+    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
+    @mock.patch('openedx.core.djangoapps.appsembler.tahoe_idp.helpers.TAHOE_IDP_PROVIDER_NAME', 'oa2-google-oauth2')
+    def test_context_with_tahoe_idp(self, mock_enterprise_customer_for_request):
+        mock_enterprise_customer_for_request.return_value = {}
+
+        default_context = account_settings_context(self.request)
+
+        assert default_context['auth']['providers'], 'Should list providers'
+        assert default_context['auth']['providers'][0]['name'] == 'Tahoe IdP'
+
+        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_TAHOE_IDP': True}):
+            context_tahoe_idp = account_settings_context(self.request)
+            assert not context_tahoe_idp['auth']['providers'], 'Should remove the tahoe-idp provider'

--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_account_deletion.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_account_deletion.py
@@ -1,0 +1,82 @@
+"""
+Tests for the Account Deletion (Retirement) view.
+"""
+
+from mock import patch, Mock
+import pytest
+from social_django.models import UserSocialAuth
+
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from ...multi_tenant_emails.tests.test_utils import with_organization_context
+
+from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (
+    # Importing this module to allow using `usefixtures("setup_retirement_states")`
+    setup_retirement_states,  # pylint: disable=unused-import
+)
+
+
+@patch.dict('django.conf.settings.FEATURES', {'SKIP_EMAIL_VALIDATION': True})
+@pytest.mark.usefixtures("setup_retirement_states")
+@patch(
+    'openedx.core.djangoapps.ace_common.templatetags.ace._get_google_analytics_tracking_url',
+    Mock(return_value='http://url.com/')
+)
+class MultiTenantDeactivateLogoutViewTest(APITestCase):
+    """
+    Tests to ensure the DeactivateLogoutView deactivates the Tahoe IdP as well.
+    """
+
+    RED = 'red1'
+    EMAIL = 'ali@example.com'
+    PASSWORD = 'zzz'
+
+    def setUp(self):
+        super(MultiTenantDeactivateLogoutViewTest, self).setUp()
+        self.registration_url = reverse('user_api_registration')
+        self.deactivate_url = reverse('deactivate_logout')
+
+    def register_user(self, color, username=None):
+        """
+        Register a user.
+        """
+        response = self.client.post(self.registration_url, {
+            'email': self.EMAIL,
+            'name': 'Ali',
+            'username': username or 'ali_{}'.format(color),
+            'password': self.PASSWORD,
+            'honor_code': 'true',
+        })
+        return response
+
+    def deactivate_user(self, color, username=None):
+        """
+        Post a deactivate_logout request (a.k.a GDPR forget me).
+        """
+        client = self.client_class()
+        username = username or 'ali_{}'.format(color)
+        assert client.login(username=username, password=self.PASSWORD)
+        response = client.post(self.deactivate_url, {
+            'password': self.PASSWORD,
+        })
+        return response
+
+    @patch('openedx.core.djangoapps.user_api.accounts.views.tahoe_idp_api', create=True)
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_TAHOE_IDP': True})
+    def test_disallow_email_reuse_after_deactivate(self, mock_tahoe_idp_api):
+        """
+        Test the account deletion with Tahoe IdP support.
+        """
+        social_auth_uid = 'e1ede4d8-f6f6-11ec-9eb7-f778f1c67e22'
+        mock_tahoe_idp_api.get_tahoe_idp_id_by_user.return_value = social_auth_uid
+
+        with with_organization_context(site_color=self.RED):
+            register_res = self.register_user(self.RED)
+            assert register_res.status_code == status.HTTP_200_OK, register_res.content.decode('utf-8')
+            deactivate_res = self.deactivate_user(self.RED)
+            assert deactivate_res.status_code == status.HTTP_204_NO_CONTENT, deactivate_res.content.decode('utf-8')
+
+        mock_tahoe_idp_api.deactivate_user.assert_called_once_with(social_auth_uid)

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -36,6 +36,8 @@ from student.models import UserProfile
 from third_party_auth import pipeline
 from util.date_utils import strftime_localized
 
+from openedx.core.djangoapps.appsembler.tahoe_idp import helpers as tahoe_idp_helpers
+
 log = logging.getLogger(__name__)
 
 
@@ -175,6 +177,12 @@ def account_settings_context(request):
             # We only want to include providers if they are either currently available to be logged
             # in with, or if the user is already authenticated with them.
         } for state in auth_states if state.provider.display_for_login or state.has_account]
+
+        if tahoe_idp_helpers.is_tahoe_idp_enabled():
+            # Allow account deletion while using `tahoe-idp` backend.
+            context['auth']['providers'] = tahoe_idp_helpers.remove_tahoe_idp_from_account_settings(
+                providers=context['auth']['providers'],
+            )
 
     return context
 


### PR DESCRIPTION
RED-3086.

Delete user accounts of Tahoe IdP accounts without needing to verify the password.

### TODO
 - [x] test in devstack
 - [x] tests for openedx/core/djangoapps/user_api/accounts/settings_views.py