### PR TITLE
fix User.save() in commandline due to MTE bug

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -55,8 +55,8 @@ from six.moves import range
 from six.moves.urllib.parse import urlencode
 from slumber.exceptions import HttpClientError, HttpServerError
 from user_util import user_util
-from organizations.models import UserOrganizationMapping, OrganizationCourse
-from tahoe_sites.api import get_organization_by_site
+from organizations.models import UserOrganizationMapping, OrganizationCourse, Organization
+from tahoe_sites.api import get_organization_by_site, get_organization_for_user
 from openedx.core.djangoapps.theming.helpers import (
     get_current_request,
     get_current_site,
@@ -2358,9 +2358,12 @@ class CourseEnrollmentAllowed(DeletableByUserValue, models.Model):
 
         if settings.FEATURES.get('APPSEMBLER_MULTI_TENANT_EMAILS', False):
             if not is_request_for_new_amc_site(get_current_request()):
-                current_organization = get_current_organization()
+                try:
+                    user_organization = get_organization_for_user(user)
+                except Organization.DoesNotExist:
+                    user_organization = get_current_organization()
                 return queryset.filter(course_id__in=OrganizationCourse.objects.filter(
-                    organization=current_organization,
+                    organization=user_organization,
                     active=True,
                 ).values('course_id'))
 

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_course_enrollment_allowed.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_course_enrollment_allowed.py
@@ -101,6 +101,24 @@ class TestCourseEnrollmentAllowedMultitenant(ModuleStoreTestCase):
         assert list(CourseEnrollment.objects.all()), 'Should be enrolled'
         assert CourseEnrollment.is_enrolled(john_b, course.id), 'Should be enrolled'
 
+    def test_enrollment_allowed_no_current_request(self):
+        """
+        Test CourseEnrollmentAllowed without `request` when the APPSEMBLER_MULTI_TENANT_EMAILS feature is enabled.
+        """
+        with with_organization_context(site_color=self.RED) as org:
+            course = self.create_org_course(org)
+            assert not CourseEnrollmentAllowed.objects.count(), 'No enrollment allowed yet.'
+            self.invite(org, course.id, self.JOHN_EMAIL)
+            john_b = self.register_user(org.name, email='another.email@exmple.com', password=self.PASSWORD)
+
+        assert not CourseEnrollment.is_enrolled(john_b, course.id), 'Should not be enrolled yet'
+
+        john_b.email = self.JOHN_EMAIL  # Change email
+        john_b.save()  # Simulate a command-line save.
+
+        assert list(CourseEnrollment.objects.all()), 'Should be enrolled'
+        assert CourseEnrollment.is_enrolled(john_b, course.id), 'Should be enrolled'
+
     def test_enrollment_allowed_two_sites(self):
         """
         Test CourseEnrollmentAllowed when the APPSEMBLER_MULTI_TENANT_EMAILS feature is enabled.


### PR DESCRIPTION
fixes an old mutl-tenant emails bug: RED-1179

Multi-tenant emails broke command-line User.save() in which get_current_organization fails, the fix uses get_organization_for_user() to fix the issue.

The original bug was introduced via https://github.com/appsembler/edx-platform/pull/609