### PR TITLE
use tahoe_sites inside legacy_amc_helpers

### DIFF
--- a/openedx/core/djangoapps/appsembler/tahoe_tiers/helpers.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_tiers/helpers.py
@@ -4,9 +4,11 @@ Tiers Tahoe helpers.
 
 import beeline
 
+from tahoe_sites.api import get_uuid_by_organization
+
 from ..sites.site_config_client_helpers import get_current_site_config_tier_info
 
-from .legacy_amc_helpers import get_amc_tier_info_from_organization
+from .legacy_amc_helpers import get_amc_tier_info
 
 
 TIER_INFO_REQUEST_FIELD_NAME = '_tahoe_tier_info'
@@ -22,7 +24,12 @@ def get_tier_info(request):
         # Try AMC tiers first, to ensure the least feature/performance impact on Tahoe 1.0 sites.
         organization = request.session.get('organization')
         beeline.add_context_field('organization', organization)
-        tier_info = get_amc_tier_info_from_organization(organization)
+        if organization:
+            site_uuid = get_uuid_by_organization(organization)
+            tier_info = get_amc_tier_info(site_uuid=site_uuid)
+        else:
+            beeline.add_context_field("tiers.no_organization", True)
+
         if tier_info:
             beeline.add_context_field('amc_tier_info_used', True)
 


### PR DESCRIPTION
RED-3129.

 - makes easier migration out for our `edx-organizations` fork
 - reduce false log exceptions in Tiers for Tahoe 2.0 sites
