### PR TITLE
 Use tahoe-sites.api - Patch 04b: Remove UserOrganizationMapping from openedx

### DIFF
--- a/common/djangoapps/student/signals/receivers.py
+++ b/common/djangoapps/student/signals/receivers.py
@@ -61,8 +61,8 @@ def on_user_updated(sender, instance, **kwargs):
                     #
                     # Chicken-and-egg:
                     #   It's impossible to get the organization for a user that we didn't save yet
-                    #   to the database because we don't have `UserOrganizationMapping` yet.
-                    #   We cannot have `UserOrganizationMapping` until we save the user,
+                    #   to the database because we don't have a link between the user and the organization yet.
+                    #   We cannot have that link until we save the user,
                     #   therefore it's not possible to get the organization from the user.
                     check_within_organization=bool(organization),
                     organization=organization,

--- a/openedx/core/djangoapps/appsembler/analytics/helpers.py
+++ b/openedx/core/djangoapps/appsembler/analytics/helpers.py
@@ -2,7 +2,7 @@
 Helpers for the Appsembler Analytics app.
 """
 
-from organizations.models import UserOrganizationMapping
+from tahoe_sites.api import deprecated_get_admin_users_queryset_by_email
 
 
 def should_show_hubspot(user):
@@ -15,8 +15,6 @@ def should_show_hubspot(user):
     if user.is_superuser or user.is_staff:
         return False
 
-    mapping = UserOrganizationMapping.objects.get(user=user)
-    if not (mapping.is_amc_admin and mapping.is_active):
-        return False
+    is_active_admin = user in deprecated_get_admin_users_queryset_by_email(email=user.email)
 
-    return True
+    return is_active_admin

--- a/openedx/core/djangoapps/appsembler/api/sites.py
+++ b/openedx/core/djangoapps/appsembler/api/sites.py
@@ -2,8 +2,13 @@ import beeline
 import logging
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
-from organizations.models import Organization, OrganizationCourse
+
 from tahoe_sites.api import get_organization_by_site, get_users_of_organization
+
+from organizations.models import (
+    Organization,
+    OrganizationCourse,
+)
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 

--- a/openedx/core/djangoapps/appsembler/api/tests/test_enrollment_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_enrollment_api.py
@@ -30,8 +30,8 @@ from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from organizations.models import UserOrganizationMapping
 from tahoe_sites.tests.utils import create_organization_mapping
+from tahoe_sites.api import get_users_of_organization
 
 from openedx.core.djangoapps.appsembler.api.sites import (
     get_enrollments_for_site,
@@ -227,12 +227,10 @@ class EnrollmentApiPostTest(BaseEnrollmentApiTestCase):
             assert not CourseEnrollmentAllowed.objects.filter(email=new_user_email).exists()
 
         before_my_site_ce_count = get_enrollments_for_site(self.my_site).count()
-        before_my_site_user_count = UserOrganizationMapping.objects.filter(
-            organization=self.my_site_org).count()
+        before_my_site_user_count = get_users_of_organization(organization=self.my_site_org).count()
 
         before_other_site_ce_count = get_enrollments_for_site(self.other_site).count()
-        before_other_site_user_count = UserOrganizationMapping.objects.filter(
-            organization=self.other_site_org).count()
+        before_other_site_user_count = get_users_of_organization(organization=self.other_site_org).count()
 
         payload = {
             'action': 'enroll',
@@ -249,12 +247,10 @@ class EnrollmentApiPostTest(BaseEnrollmentApiTestCase):
         })
         results = response.data['results']
         after_my_site_ce_count = get_enrollments_for_site(self.my_site).count()
-        after_my_site_user_count = UserOrganizationMapping.objects.filter(
-            organization=self.my_site_org).count()
+        after_my_site_user_count = get_users_of_organization(organization=self.my_site_org).count()
 
         after_other_site_ce_count = get_enrollments_for_site(self.other_site).count()
-        after_other_site_user_count = UserOrganizationMapping.objects.filter(
-            organization=self.other_site_org).count()
+        after_other_site_user_count = get_users_of_organization(organization=self.other_site_org).count()
 
         assert after_other_site_ce_count == before_other_site_ce_count
         assert after_other_site_user_count == before_other_site_user_count

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_utils.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_utils.py
@@ -9,8 +9,11 @@ from django.conf import settings
 from unittest import skipUnless
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
-from organizations.models import Organization, UserOrganizationMapping
 from tahoe_sites.api import create_tahoe_site_by_link
+
+from organizations.models import Organization
+from tahoe_sites.tests.utils import create_organization_mapping
+
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
 
 from student.tests.factories import UserFactory
@@ -54,7 +57,7 @@ def create_org_user(organization, is_amc_admin=False, **kwargs):
     Create one user and save it to the database.
     """
     user = UserFactory.create(**kwargs)
-    UserOrganizationMapping.objects.create(user=user, organization=organization, is_amc_admin=is_amc_admin)
+    create_organization_mapping(user=user, organization=organization, is_admin=is_amc_admin)
     return user
 
 

--- a/openedx/core/djangoapps/appsembler/sites/admin.py
+++ b/openedx/core/djangoapps/appsembler/sites/admin.py
@@ -9,11 +9,11 @@ from django.utils.html import format_html
 from hijack_admin.admin import HijackUserAdminMixin
 from ratelimitbackend import admin
 from student.admin import UserAdmin
+from organizations.models import Organization
+from tahoe_sites.api import get_organization_for_user
 
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
-from organizations.models import UserOrganizationMapping
-from tahoe_sites.api import get_organization_for_user
 
 from openedx.core.djangoapps.appsembler.sites.forms import MakeAMCAdminForm
 from openedx.core.djangoapps.appsembler.sites.utils import (
@@ -49,7 +49,7 @@ class TahoeUserAdmin(UserAdmin, HijackUserAdminMixin):
         try:
             current_org = get_organization_for_user(user)
             current_org_name = current_org.name
-        except (UserOrganizationMapping.DoesNotExist, MultipleObjectsReturned):
+        except (Organization.DoesNotExist, MultipleObjectsReturned):
             current_org_name = ''
 
         form = MakeAMCAdminForm({'organization_name': current_org_name})

--- a/openedx/core/djangoapps/appsembler/sites/api.py
+++ b/openedx/core/djangoapps/appsembler/sites/api.py
@@ -4,6 +4,7 @@ import requests
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import generics, views, viewsets
 from rest_framework import status
 from rest_framework.generics import CreateAPIView
@@ -11,7 +12,8 @@ from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from organizations.models import Organization, UserOrganizationMapping
+from organizations.models import Organization
+from tahoe_sites.api import get_organization_user_by_email
 from branding.api import get_base_url
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from rest_framework.views import APIView
@@ -233,9 +235,9 @@ class FindUsernameByEmailView(APIView):
         if user_email and organization_name:
             try:
                 organization = Organization.objects.get(name=organization_name)
-                mapping = UserOrganizationMapping.objects.get(user__email=user_email, organization=organization)
-                return Response({'username': mapping.user.username}, status=status.HTTP_200_OK)
-            except (Organization.DoesNotExist, UserOrganizationMapping.DoesNotExist):
+                user = get_organization_user_by_email(email=user_email, organization=organization)
+                return Response({'username': user.username}, status=status.HTTP_200_OK)
+            except ObjectDoesNotExist:
                 pass
 
         return Response({}, status=status.HTTP_404_NOT_FOUND)

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/offboard.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/offboard.py
@@ -30,6 +30,7 @@ from student.models import (
 )
 
 from organizations.models import Organization, OrganizationCourse
+from tahoe_sites.api import get_users_of_organization
 
 
 class Command(BaseCommand):
@@ -422,9 +423,9 @@ class Command(BaseCommand):
         """
         self.debug_message('Processing {} organization users...'.format(organization.name))
         return [{
-            'username': mapping.user.username,
-            'active': mapping.is_active,
-        } for mapping in organization.userorganizationmapping_set.all()]
+            'username': user.username,
+            'active': user.is_active,
+        } for user in get_users_of_organization(organization=organization).all()]
 
     def process_site_configurations(self, site):
         """

--- a/openedx/core/djangoapps/appsembler/sites/permissions.py
+++ b/openedx/core/djangoapps/appsembler/sites/permissions.py
@@ -1,12 +1,18 @@
 from rest_framework import permissions
 
+from tahoe_sites.models import UserOrganizationMapping
+
 
 class AMCAdminPermission(permissions.BasePermission):
     """
     Allow making changes only if you're designated as an admin in AMC.
     """
 
+    # TODO: RED-2845 Remove this class when AMC is removed.
     def has_permission(self, request, view):
-        is_organization_admin = request.user.userorganizationmapping_set.filter(is_amc_admin=True).exists()
+        is_organization_admin = UserOrganizationMapping.objects.filter(
+            user=request.user,
+            is_admin=True,
+        ).exists()
         is_superuser = request.user.is_superuser
-        return is_organization_admin or is_superuser
+        return request.user.is_active and (is_organization_admin or is_superuser)

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_permissions.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_permissions.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
-from organizations.models import UserOrganizationMapping
-from organizations.tests.factories import UserFactory, OrganizationFactory
+from organizations.tests.factories import OrganizationFactory
 from rest_framework.test import APIRequestFactory
+
+from tahoe_sites.tests.utils import create_organization_mapping
+from student.tests.factories import UserFactory
 
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.appsembler.sites.permissions import AMCAdminPermission
@@ -30,9 +32,9 @@ class AMCAdminPermissionsTestCase(TestCase):
         self.assertFalse(AMCAdminPermission().has_permission(self.request, None))
 
     def test_organization_nonadmin_user(self):
-        UserOrganizationMapping.objects.create(user=self.user, organization=self.organization, is_amc_admin=False)
+        create_organization_mapping(user=self.user, organization=self.organization, is_admin=False)
         self.assertFalse(AMCAdminPermission().has_permission(self.request, None))
 
     def test_organization_admin_user(self):
-        UserOrganizationMapping.objects.create(user=self.user, organization=self.organization, is_amc_admin=True)
+        create_organization_mapping(user=self.user, organization=self.organization, is_admin=True)
         self.assertTrue(AMCAdminPermission().has_permission(self.request, None))

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -32,8 +32,14 @@ from django.utils.text import slugify
 
 from organizations import api as org_api
 from organizations import models as org_models
-from organizations.models import UserOrganizationMapping, Organization, OrganizationCourse
-from tahoe_sites.api import create_tahoe_site_by_link
+from organizations.models import Organization, OrganizationCourse
+
+from organizations.models import Organization
+from tahoe_sites.api import (
+    add_user_to_organization,
+    create_tahoe_site_by_link,
+    get_organization_for_user,
+)
 
 from common.djangoapps.util.organizations_helpers import get_organization_courses
 from openedx.core.lib.api.api_key_permissions import is_request_has_valid_api_key
@@ -206,10 +212,12 @@ def make_amc_admin(user, org_name):
     """
     org = Organization.objects.get(Q(name=org_name) | Q(short_name=org_name))
 
-    uom, _ = UserOrganizationMapping.objects.get_or_create(user=user, organization=org)
-    uom.is_active = True
-    uom.is_amc_admin = True
-    uom.save()
+    try:
+        get_organization_for_user(user=user)
+    except Organization.DoesNotExist:
+        add_user_to_organization(user=user, organization=org, is_admin=True)
+    else:
+        raise Exception('make_amc_admin, user already member of another organization')
 
     return {
         'user_email': user.email,
@@ -478,7 +486,7 @@ def bootstrap_site(site, org_data=None, username=None):
         organization = {}
     if username:
         user = User.objects.get(username=username)
-        org_models.UserOrganizationMapping.objects.create(user=user, organization=organization, is_amc_admin=True)
+        add_user_to_organization(user=user, organization=organization, is_admin=True)
     else:
         user = {}
     return organization, site, user

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -27,7 +27,6 @@ from openedx.core.djangoapps.appsembler.sites.utils import (
     is_request_for_amc_admin,
     get_current_organization,
 )
-from organizations.models import UserOrganizationMapping
 
 from openedx.core.lib.api.view_utils import require_post_params
 from openedx.core.djangoapps.user_api.models import UserPreference

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -27,6 +27,7 @@ from edx_django_utils.monitoring import set_custom_metric
 from eventtracking import tracker
 from ratelimitbackend.exceptions import RateLimitException
 from rest_framework.views import APIView
+from tahoe_sites.api import get_organization_user_by_email
 
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
@@ -49,7 +50,6 @@ from util.json_request import JsonResponse
 from util.password_policy_validators import normalize_password
 
 from django.core.exceptions import MultipleObjectsReturned
-from organizations.models import UserOrganizationMapping
 from openedx.core.djangoapps.appsembler.sites.utils import get_current_organization
 
 
@@ -119,8 +119,8 @@ def _get_user_by_email(request):
         # level.
         try:
             current_org = get_current_organization()
-            return current_org.userorganizationmapping_set.get(user__email=email).user
-        except UserOrganizationMapping.DoesNotExist:
+            return get_organization_user_by_email(email=email, organization=current_org)
+        except User.DoesNotExist:
             _log_failed_get_user_by_email(email)
         except MultipleObjectsReturned:
             log.exception(


### PR DESCRIPTION
## Change description

Use tahoe-sites.api - Patch 04b: Remove UserOrganizationMapping from openedx

## TODO
 - [ ] Manual testing as noted by Omar: https://github.com/appsembler/edx-platform/pull/1194#pullrequestreview-1051225789

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
