### PR TITLE
tahoe-idp: disable Tahoe User Registration API

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/v1/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v1/views.py
@@ -63,6 +63,8 @@ from openedx.core.djangoapps.appsembler.api.v1.serializers import (
 )
 from openedx.core.djangoapps.appsembler.api.v1.waffle import FIX_ENROLLMENT_RESULTS_BUG
 
+from openedx.core.djangoapps.appsembler.tahoe_idp import helpers as tahoe_idp_helpers
+
 # TODO: Just move into v1 directory
 from openedx.core.djangoapps.appsembler.api.permissions import (
     TahoeAPIUserThrottle
@@ -152,6 +154,12 @@ class RegistrationViewSet(TahoeAuthMixin, viewsets.ViewSet):
         The code here is adapted from the LMS ``appsembler_api`` bulk registration
         code. See the ``appsembler/ginkgo/master`` branch
         """
+        if tahoe_idp_helpers.is_tahoe_idp_enabled():
+            return Response(
+                dict(user_message='This API is not available for this site. Please use the Identity Provider API.'),
+                status=status.HTTP_406_NOT_ACCEPTABLE,
+            )
+
         # Using .copy() to make the POST data mutable
         # see: https://stackoverflow.com/a/49794425/161278
         data = request.data.copy()

--- a/openedx/core/djangoapps/appsembler/api/v2/views.py
+++ b/openedx/core/djangoapps/appsembler/api/v2/views.py
@@ -27,6 +27,8 @@ from openedx.core.djangoapps.appsembler.api.v2.api import (
     username_exists
 )
 
+from openedx.core.djangoapps.appsembler.tahoe_idp import helpers as tahoe_idp_helpers
+
 # TODO: Just move into v1 directory
 from openedx.core.djangoapps.appsembler.api.permissions import (
     TahoeAPIUserThrottle
@@ -78,6 +80,12 @@ class RegistrationViewSet(RegistrationViewSetV1):
         The code here is adapted from the LMS ``appsembler_api`` bulk registration
         code. See the ``appsembler/ginkgo/master`` branch
         """
+        if tahoe_idp_helpers.is_tahoe_idp_enabled():
+            return Response(
+                dict(user_message='This API is not available for this site. Please use the Identity Provider API.'),
+                status=status.HTTP_406_NOT_ACCEPTABLE,
+            )
+
         # Using .copy() to make the POST data mutable
         # see: https://stackoverflow.com/a/49794425/161278
         data = request.data.copy()

--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_registration_api.py
@@ -1,0 +1,68 @@
+"""
+Tests to ensure the Tahoe Registration API is disabled if `tahoe-idp` is in use.
+"""
+import ddt
+from mock import patch
+
+from django.urls import reverse_lazy
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+from ...multi_tenant_emails.tests.test_utils import with_organization_context
+
+APPSEMBLER_API_VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.api.v1.views'
+
+
+@skip_unless_lms
+@ddt.ddt
+@patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.authentication_classes', [])
+@patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.permission_classes', [])
+@patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.throttle_classes', [])
+class TahoeIdPDisablesRegisrationAPITest(APITestCase):
+    """
+    Tests to ensure the Tahoe Registration API end-point allow multi-tenant emails.
+    """
+
+    EMAIL = 'learner@example.com'
+    PASSWORD = 'test'
+
+    def register_user(self, url, username):
+        return self.client.post(url, {
+            'username': username,
+            'password': self.PASSWORD,
+            'email': self.EMAIL,
+            'name': 'Learner',
+        })
+
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_TAHOE_IDP': False})
+    @ddt.data(
+        reverse_lazy('tahoe-api:v1:registrations-list'),
+        reverse_lazy('tahoe-api:v2:registrations-list'),
+    )
+    def test_api_without_tahoe_idp(self, url):
+        """
+        Both v1 and v2 API should work with Tahoe IdP.
+        """
+        color1 = 'red1'
+        with with_organization_context(site_color=color1):
+            response = self.register_user(url, 'red_learner')
+            content = response.content.decode('utf-8')
+            assert response.status_code == status.HTTP_200_OK, '{} {}'.format(color1, content)
+
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_TAHOE_IDP': True})
+    @ddt.data(
+        reverse_lazy('tahoe-api:v1:registrations-list'),
+        reverse_lazy('tahoe-api:v2:registrations-list'),
+    )
+    def test_api_wit_tahoe_idp(self, url):
+        """
+        Both v1 and v2 API shouldn't work with Tahoe IdP.
+        """
+        color1 = 'red1'
+        with with_organization_context(site_color=color1):
+            response = self.register_user(url, 'red_learner')
+            content = response.content.decode('utf-8')
+            assert response.status_code == status.HTTP_406_NOT_ACCEPTABLE, '{} {}'.format(color1, content)
+            assert 'This API is not available for this site. Please use the Identity Provider API.' in content


### PR DESCRIPTION
**Breaking change:** Site with the IdP enabled should prepare to use the [Identity Provider API](https://appsembler.atlassian.net/l/cp/9eD3StnL) instead. This affects all new sites as well as sites that will be migrated.

### TODO

 - [x] Test on devstack when IdP is enabled
 - [x] Test on devstack when IdP is disabled