### PR TITLE
Easier /admin search for SiteConfigClientEnabled

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/serializers_v2.py
+++ b/openedx/core/djangoapps/appsembler/sites/serializers_v2.py
@@ -68,7 +68,12 @@ class TahoeSiteCreationSerializer(serializers.Serializer):
 
         sass_status = site_config.compile_microsite_sass()
 
-        site_config_client_helpers.enable_for_site(site)
+        site_config_client_helpers.enable_for_site(
+            site=site,
+            note='domain = {domain} , organization name = {short_name} -- (system generated note).'.format(
+                **validated_data,
+            ),
+        )
         course_creation_task_scheduled = import_course_on_site_creation_after_transaction(organization)
 
         return {

--- a/openedx/core/djangoapps/appsembler/sites/site_config_client_helpers.py
+++ b/openedx/core/djangoapps/appsembler/sites/site_config_client_helpers.py
@@ -47,9 +47,9 @@ def is_enabled_for_site(site):
     return is_feature_enabled_for_site(uuid)
 
 
-def enable_for_site(site):
+def enable_for_site(site, note=''):
     uuid = tahoe_sites.api.get_uuid_by_site(site)
-    enable_feature_for_site(uuid)
+    enable_feature_for_site(uuid, note=note)
 
 
 def get_active_site_uuids_from_site_config_service():


### PR DESCRIPTION
add the domain name and organization.short_name in the `note` field


Fixes RED-3248

### TODO 

 - [x] Test the API in devstack

### Screenshot of `/admin`
<kbd>![image](https://user-images.githubusercontent.com/645156/182367546-be2620a2-6606-4afa-9b40-4e959c94a35e.png)</kbd>
