### PR TITLE
welcome course import fixes for Tahoe 2.0 sites

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -84,6 +84,9 @@ def plugin_settings(settings):
     settings.TAHOE_DEFAULT_COURSE_GITHUB_ORG = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_GITHUB_ORG', '')
     settings.TAHOE_DEFAULT_COURSE_GITHUB_NAME = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_GITHUB_NAME', '')
     settings.TAHOE_DEFAULT_COURSE_VERSION = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_VERSION', '')
+    settings.TAHOE_DEFAULT_COURSE_CMS_TASK_DELAY = int(settings.ENV_TOKENS.get(
+        'TAHOE_DEFAULT_COURSE_CMS_TASK_DELAY', 0
+    ))
     settings.CMS_UPDATE_SEARCH_INDEX_JOB_QUEUE = settings.ENV_TOKENS.get(
         'CMS_UPDATE_SEARCH_INDEX_JOB_QUEUE', 'edx.cms.core.default'
     )

--- a/openedx/core/djangoapps/appsembler/sites/tasks.py
+++ b/openedx/core/djangoapps/appsembler/sites/tasks.py
@@ -2,7 +2,6 @@
 This file contains celery tasks for contentstore views
 """
 import beeline
-import logging
 import requests
 import os
 import tarfile
@@ -16,20 +15,16 @@ from celery.utils.log import get_task_logger
 from django.db import transaction
 from django.conf import settings
 
-from student.models import CourseEnrollment
-from student.roles import CourseAccessRole
-
 from opaque_keys.edx.keys import CourseKey
 
 from organizations.models import Organization, OrganizationCourse
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore, SignalHandler
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.xml_importer import import_course_from_xml
 
-LOGGER = get_task_logger(__name__)
+log = get_task_logger(__name__)
 
 
 def current_year():
@@ -84,8 +79,10 @@ def import_course_on_site_creation(organization_id):
 
     :param organization_id: The integer ID for the organization object in database.
     """
+    log.info('Starting importing course for organization_id %s', organization_id)
     try:
         organization = Organization.objects.get(pk=organization_id)
+        log.info('Importing course for organization %s', organization)
 
         course_name = settings.TAHOE_DEFAULT_COURSE_NAME
         course_github_org = settings.TAHOE_DEFAULT_COURSE_GITHUB_ORG
@@ -101,6 +98,8 @@ def import_course_on_site_creation(organization_id):
                 current_year(),
             )
         )
+        log.info('Importing course for organization %s with course_id %s',
+                 organization, course_target_id)
 
         # Build the GitHub download URL from settings to download the course in tar.gz format
         # from the GitHub releases
@@ -110,13 +109,15 @@ def import_course_on_site_creation(organization_id):
             course_version,
         )
     except Exception as exc:  # pylint: disable=broad-except
-        logging.exception('Course Clone Error')
+        log.exception('Course Clone Error')
         return 'exception: ' + str(exc)
 
     try:
         # Download the course in tar.gz format from github in a temp. file using a random file name
         with TemporaryDirectory() as dir_name, NamedTemporaryFile() as temp_file:
+            log.info('Importing course for organization %s with url %s', organization, course_download_url)
             response = requests.get(course_download_url)
+            log.info('Downloaded course for organization %s with url %s', organization, course_download_url)
             file_path = temp_file.name
             with open(file_path, 'wb') as fd:
                 for chunk in response.iter_content(chunk_size=128):
@@ -138,16 +139,7 @@ def import_course_on_site_creation(organization_id):
                 target_id=course_target_id,
                 create_if_not_present=True,
             )
-
-            # TODO: Remove this once we roll out Tahoe 2.0 sites, because OrgStaffRole is implemented there.
-            # Add the new registered user as admin in the course
-            CourseAccessRole.objects.get_or_create(
-                # TODO: Ensure only an admin get this course (`is_amc_admin`).
-                user=organization.users.first(),
-                role='instructor',  # This is called "Course Admin" in Studio.
-                course_id=course_target_id,
-                org=organization.short_name
-            )
+            log.info('Imported course for organization %s')
 
             OrganizationCourse.objects.create(
                 organization=organization,
@@ -159,47 +151,39 @@ def import_course_on_site_creation(organization_id):
                 sender=__name__,
                 course_key=course_target_id,
             )
-            emit_course_published_signal_in_cms.delay(
-                str(course_target_id),
+            emit_course_published_signal_in_cms.apply_async(
+                kwargs={'course_key': str(course_target_id)},
+                countdown=settings.TAHOE_DEFAULT_COURSE_CMS_TASK_DELAY,  # Delay the "course_published" signal
+                routing_key=settings.CMS_UPDATE_SEARCH_INDEX_JOB_QUEUE,  # Schedule in CMS
             )
+            log.info('course_published import signal emitted for course %s', course_target_id)
 
     # catch all exceptions so we can update the state and properly cleanup the course.
     except Exception as exc:  # pylint: disable=broad-except
         # update state: Failed
-        logging.exception('Course Clone Error')
+        log.exception('Course Clone Error')
 
         try:
             # cleanup any remnants of the course
+            log.info('Deleting tahoe welcome course %s', course_target_id)
             modulestore().delete_course(course_target_id, ModuleStoreEnum.UserID.system)
+            log.info('Deleted tahoe welcome course %s', course_target_id)
         except ItemNotFoundError:
             # it's possible there was an error even before the course module was created
             pass
 
         return 'exception: ' + str(exc)
 
-    try:
-        # enroll the user in the course
-        # we use a separate try/except because we want to keep the course even
-        # if the user cannot be enrolled, because it will find the course anyway
-        CourseEnrollment.enroll(
-            organization.users.first(),
-            course_target_id,
-            'honor'
-        )
-        # Regenerate course overview to properly display it in the home page.
-        CourseOverview.update_select_courses([course_target_id], force_update=True)
-    except Exception as exc:
-        logging.exception('Error enrolling the user in default course')
-        return 'exception: ' + str(exc)
 
-
-@task(routing_key=settings.CMS_UPDATE_SEARCH_INDEX_JOB_QUEUE)
+@task()
 def emit_course_published_signal_in_cms(course_key):
     """
     An LMS-scheduled task to update CMS course search index and other tasks.
 
     This is a "routing" task to schedule the `update_search_index` task from _LMS_ and run it in the _CMS_ queue among
-    other tasks. This is to work around the `cms.djangoapps.contentstore` module cannot be imported from LMS code.
+    other tasks.
+
+    This is to work around the `cms.djangoapps.contentstore` module cannot be imported from LMS code.
     """
     from cms.djangoapps.contentstore.signals import handlers  # Local import that run only in CMS.
 


### PR DESCRIPTION
### Changes

 - Remove the enroll becasue Tahoe 2.0 sites has no users until
   the user authenticate via `tahoe-idp`. Enrollment should happen by
   the Tahoe Enrollment API via Dashboard.

 - Use `apply_async` in emit_course_published_signal_in_cms to fix
   `ItemNotFoundError` errors

 - Removed `CourseAccessRole.objects.get_or_create` in favor of
   `OrgStaffRole`

 - Added `TAHOE_DEFAULT_COURSE_CMS_TASK_DELAY` settings

 - More detailed and improved logging for the import task

 - Removed any User-related code from the task

 - Added more testing for failure scenarios


### Breaking change
This will slightly degrade tahoe welcome course for Tahoe 1.0 (AMC) sites like the removal of auto-enrollment. But we're not making new AMC sites anymore.

### TODO
 - [x] Test on devstack
 - [ ] Test on staging