### PR TITLE
de-fork edx-organizations in favor of tahoe-sites

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
@@ -30,3 +30,5 @@ def plugin_settings(settings):
         settings.INSTALLED_APPS += [
             'openedx.core.djangoapps.appsembler.multi_tenant_emails',
         ]
+
+    settings.FEATURES['TAHOE_SITES_USE_ORGS_MODELS'] = False

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -78,7 +78,7 @@ edx-django-utils
 edx-drf-extensions
 edx-enterprise
 edx-milestones
-https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler14.tar.gz  # edx-organizations
+edx-organizations
 edx-proctoring>=2.0.1
 edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed
 edx-rest-api-client

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -107,7 +107,7 @@ edx-enterprise==3.2.14    # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler14.tar.gz  # edx-organizations==5.2.0
+edx-organizations==5.2.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
 edx-proctoring==2.4.0     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.2.1           # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -120,7 +120,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
 edx-lint==1.4.1           # via -r requirements/edx/testing.txt
 edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler14.tar.gz  # edx-organizations==5.2.0
+edx-organizations==5.2.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
 edx-proctoring==2.4.0     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.2.1           # via -r requirements/edx/testing.txt, edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -117,7 +117,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/ed
 edx-lint==1.4.1           # via -r requirements/edx/testing.in
 edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler14.tar.gz  # edx-organizations==5.2.0
+edx-organizations==5.2.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
 edx-proctoring==2.4.0     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.2.1           # via -r requirements/edx/base.txt, edx-enterprise


### PR DESCRIPTION
The aim is to uncover test failures when switching to exclusively `tahoe-sites`.