### PR TITLE
Final preperations to de-fork our edx-organizations

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/sites.py
+++ b/openedx/core/djangoapps/appsembler/api/sites.py
@@ -9,6 +9,7 @@ from organizations.models import (
     Organization,
     OrganizationCourse,
 )
+from tahoe_sites.api import get_site_by_organization
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
@@ -66,13 +67,7 @@ def get_site_for_course(course_id):
         # Keep until this assumption analyzed
         msg = 'Multiple orgs found for course: {}'
         assert org_courses.count() == 1, msg.format(course_id)
-        first_org = org_courses.first().organization
-        if hasattr(first_org, 'sites'):
-            msg = 'Must have one and only one site. Org is "{}"'
-            assert first_org.sites.count() == 1, msg.format(first_org.name)
-            site = first_org.sites.first()
-        else:
-            site = None
+        site = get_site_by_organization(organization=org_courses.get().organization)
     else:
         # We don't want to make assumptions of who our consumers are
         # TODO: handle no organizations found for the course

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_amc_signup.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_amc_signup.py
@@ -77,6 +77,7 @@ class MultiTenantAMCSignupTest(APITestCase):
                 'domain': color,
             },
             'organization': {
+                'edx_uuid': str(uuid.uuid4()),
                 'name': color,
                 'short_name': color,
             },

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_amc_signup.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_amc_signup.py
@@ -77,7 +77,6 @@ class MultiTenantAMCSignupTest(APITestCase):
                 'domain': color,
             },
             'organization': {
-                'edx_uuid': str(uuid.uuid4()),
                 'name': color,
                 'short_name': color,
             },

--- a/openedx/core/djangoapps/appsembler/settings/helpers.py
+++ b/openedx/core/djangoapps/appsembler/settings/helpers.py
@@ -4,6 +4,8 @@ Helpers for the settings.
 
 from os import path
 
+from tahoe_sites.api import get_tahoe_sites_auth_backends
+
 
 def get_tahoe_theme_static_dirs(settings):
     """
@@ -74,9 +76,10 @@ def get_tahoe_multitenant_auth_backends(settings):
         upstream_backend_index = authentication_backends.index(upstream_user_model_backend)
 
         # Use multi-tenant Tahoe backends instead of the upstream EdxRateLimitedAllowAllUsersModelBackend backend.
-        authentication_backends = settings.AUTHENTICATION_BACKENDS[:upstream_backend_index] + [
-            'organizations.backends.DefaultSiteBackend',
-            'organizations.backends.OrganizationMemberBackend',
-        ] + settings.AUTHENTICATION_BACKENDS[upstream_backend_index + 1:]
+        authentication_backends = (
+            settings.AUTHENTICATION_BACKENDS[:upstream_backend_index] +
+            get_tahoe_sites_auth_backends() +
+            settings.AUTHENTICATION_BACKENDS[upstream_backend_index + 1:]
+        )
 
     return authentication_backends

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_tahoe_auth_backends_bridgekeeper.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_tahoe_auth_backends_bridgekeeper.py
@@ -36,8 +36,8 @@ class TestInstructorAccessWithTahoeAuthBackends(ModuleStoreTestCase):
         """
         Ensure get_tahoe_multitenant_auth_backends adds Tahoe backends to AUTHENTICATION_BACKENDS.
         """
-        assert 'organizations.backends.DefaultSiteBackend' in settings.AUTHENTICATION_BACKENDS
-        assert 'organizations.backends.OrganizationMemberBackend' in settings.AUTHENTICATION_BACKENDS
+        assert 'tahoe_sites.backends.DefaultSiteBackend' in settings.AUTHENTICATION_BACKENDS
+        assert 'tahoe_sites.backends.OrganizationMemberBackend' in settings.AUTHENTICATION_BACKENDS
 
     def test_instructors_has_access(self):
         """

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/create_devstack_site.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/create_devstack_site.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
             'organization': {
                 'name': name,
                 'short_name': name,
-                'edx_uuid': uuid.uuid4(),
+                'edx_uuid': uuid.uuid4(),  # TODO: RED-2845 Remove this line when AMC is migrated
             },
             'initial_values': {
                 'SITE_NAME': site_name,

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/offboard.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/offboard.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand, CommandError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import ForeignKey
-from tahoe_sites.api import get_organization_by_site
+from tahoe_sites.api import get_organization_by_site, get_uuid_by_organization
 
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -119,7 +119,7 @@ class Command(BaseCommand):
         objects = {
             'site': self.process_site(site),
             'organizations': [
-                self.process_organization(org) for org in [organization]
+                self.process_organization(organization),
             ],
             'courses': self.process_courses(organization),
             'configurations': self.process_site_configurations(site),
@@ -412,7 +412,7 @@ class Command(BaseCommand):
             'description': organization.description,
             'logo': organization.logo.url if organization.logo else '',
             'active': organization.active,
-            'UUID': organization.edx_uuid,
+            'UUID': get_uuid_by_organization(organization=organization),
             'created': organization.created,
             'users': self.process_organization_users(organization)
         }

--- a/openedx/core/djangoapps/appsembler/sites/serializers.py
+++ b/openedx/core/djangoapps/appsembler/sites/serializers.py
@@ -3,6 +3,7 @@ from django.contrib.sites.models import Site
 from rest_framework import serializers
 from organizations import api as organizations_api
 from organizations.models import Organization
+from tahoe_sites.zd_helpers import should_site_use_org_models
 
 from openedx.core.djangoapps.user_authn.views.registration_form import validate_username
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
@@ -87,7 +88,7 @@ class SiteSerializer(serializers.ModelSerializer):
 class OrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organization
-        fields = ('id', 'name', 'short_name', 'edx_uuid')
+        fields = ('id', 'name', 'short_name') + ('edx_uuid',) if should_site_use_org_models() else ()
 
     @beeline.traced(name="OrganizationSerializer.create")
     def create(self, validated_data):

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -309,7 +309,9 @@ class TestOffboardSiteCommand(ModuleStoreTestCase):
 
     @patch('openedx.core.djangoapps.appsembler.sites.management.commands.offboard.Command.process_organization_users', return_value=['user1', 'user2'])
     def test_process_organization(self, mock_process_organization_users):
+        site = SiteFactory(domain='test')
         organization = OrganizationFactory.create(name='test')
+        create_tahoe_site_by_link(organization=organization, site=site)
         data = self.command.process_organization(organization)
         assert data == {
             'name': organization.name,

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -13,6 +13,7 @@ from tahoe_sites.api import (
     create_tahoe_site_by_link,
     get_organization_for_user,
     get_users_of_organization,
+    get_uuid_by_organization,
 )
 from tahoe_sites.tests.utils import create_organization_mapping
 
@@ -316,7 +317,7 @@ class TestOffboardSiteCommand(ModuleStoreTestCase):
             'description': organization.description,
             'logo': '',
             'active': organization.active,
-            'UUID': organization.edx_uuid,
+            'UUID': get_uuid_by_organization(organization=organization),
             'created': organization.created,
             'users': ['user1', 'user2']
         }

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -39,7 +39,8 @@ from tahoe_sites.api import (
     add_user_to_organization,
     create_tahoe_site_by_link,
     get_organization_for_user,
-    get_organizations_queryset_from_uuids,
+    get_organizations_from_uuids,
+    get_sites_from_organizations,
     update_admin_role_in_organization,
 )
 
@@ -94,7 +95,7 @@ def get_active_organizations():
     """
     active_tiers_uuids = get_active_organizations_uuids()
 
-    return get_organizations_queryset_from_uuids(uuids=active_tiers_uuids)
+    return get_organizations_from_uuids(uuids=active_tiers_uuids)
 
 
 def get_active_sites(order_by='domain'):
@@ -106,9 +107,7 @@ def get_active_sites(order_by='domain'):
 
     TODO: This helper should live in a future Tahoe Sites package.
     """
-    return Site.objects.filter(
-        organizations__in=get_active_organizations()
-    ).order_by(order_by)
+    return get_sites_from_organizations(organizations=get_active_organizations()).order_by(order_by)
 
 
 @beeline.traced(name="get_amc_oauth_app")

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -39,6 +39,7 @@ from tahoe_sites.api import (
     add_user_to_organization,
     create_tahoe_site_by_link,
     get_organization_for_user,
+    get_organizations_queryset_from_uuids,
     update_admin_role_in_organization,
 )
 
@@ -93,10 +94,7 @@ def get_active_organizations():
     """
     active_tiers_uuids = get_active_organizations_uuids()
 
-    # Now back to the LMS MySQL database
-    return Organization.objects.filter(
-        edx_uuid__in=[str(edx_uuid) for edx_uuid in active_tiers_uuids],
-    )
+    return get_organizations_queryset_from_uuids(uuids=active_tiers_uuids)
 
 
 def get_active_sites(order_by='domain'):
@@ -481,7 +479,7 @@ def bootstrap_site(site, org_data=None, username=None):
         organization_data = org_api.add_organization({
             'name': organization_slug,
             'short_name': organization_slug,
-            'edx_uuid': org_data.get('edx_uuid')
+            'edx_uuid': org_data.get('edx_uuid')  # TODO: RED-2845 Remove this line when AMC is migrated
         })
         organization = org_models.Organization.objects.get(id=organization_data.get('id'))
         create_tahoe_site_by_link(organization=organization, site=site)

--- a/openedx/core/djangoapps/appsembler/tahoe_tiers/legacy_amc_helpers.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_tiers/legacy_amc_helpers.py
@@ -1,7 +1,7 @@
 """
 A module for deprecated AMC tier utilities.
 
-TODO: Remove this module once AMC is shut down.
+TODO: Remove this module once AMC is shut down. Related to RED-2845 too
 """
 
 import logging


### PR DESCRIPTION
## Change description

This is considered part of refactoring `edx-organizations` into the new `tahoe-sites` package

* Remove edx_uuid from the code
* Remove direct use of organizations auth backends
* Fix fetching site by organization
* Remove `TAHOE_ENABLE_MULTI_ORGS_PER_SITE` feature flag

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Related to: https://appsembler.atlassian.net/browse/RED-3274

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
