### PR TITLE
Fix Multi-tenant bug with rescore_problem tasks

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2426,7 +2426,7 @@ def strip_if_string(value):
     return value
 
 
-def get_user_by_username_or_email(username_or_email):
+def get_user_by_username_or_email(username_or_email, organization=None):
     """
     Return a User object by looking up a user against username_or_email.
 
@@ -2445,7 +2445,7 @@ def get_user_by_username_or_email(username_or_email):
     if settings.FEATURES.get('APPSEMBLER_MULTI_TENANT_EMAILS', False):
         # Tahoe: Use custom `get_user_by_username_or_email_inside_organization` helper to only get user in the
         #        current organization.
-        user = get_user_by_username_or_email_inside_organization(username_or_email)
+        user = get_user_by_username_or_email_inside_organization(username_or_email, organization)
     else:
         user = User.objects.get(Q(email=username_or_email) | Q(username=username_or_email))
     if user.username == username_or_email:
@@ -2455,7 +2455,7 @@ def get_user_by_username_or_email(username_or_email):
     return user
 
 
-def get_user_by_username_or_email_inside_organization(username_or_email):
+def get_user_by_username_or_email_inside_organization(username_or_email, organization=None):
     """
     Return a User object by looking up a user against username_or_email but
     inside a certain organization.
@@ -2470,12 +2470,14 @@ def get_user_by_username_or_email_inside_organization(username_or_email):
         MultipleObjectsReturned if more than one user has same email or
         username
     """
-    site = theming_helpers.get_current_site()
+    if not organization:
+        site = theming_helpers.get_current_site()
 
-    if not site:
-        raise User.DoesNotExist('Tahoe: Cannot get a current organization user without a site')
+        if not site:
+            raise User.DoesNotExist('Tahoe: Cannot get a current organization user without a site')
 
-    organization = get_organization_by_site(site)
+        organization = get_organization_by_site(site)
+
     return get_organization_user_by_username_or_email(
         username_or_email=username_or_email,
         organization=organization

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -12,6 +12,7 @@ from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from lms.djangoapps.instructor.enrollment import reset_student_attempts
 from lms.djangoapps.instructor_task.api import submit_rescore_problem_for_student
+from openedx.core.djangoapps.appsembler.api.tests.factories import OrganizationFactory, OrganizationCourseFactory
 from openedx.core.djangolib.testing.utils import get_mock_request
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
@@ -65,6 +66,8 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
                 data=problem_xml,
                 metadata={'weight': 2}
             )
+
+        OrganizationCourseFactory(organization=OrganizationFactory(), course_id=str(cls.course.id))
 
     def setUp(self):
         self.reset_course()

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -3,7 +3,6 @@
 Unit tests for instructor.api methods.
 """
 
-
 import datetime
 import functools
 import io
@@ -62,6 +61,7 @@ from lms.djangoapps.instructor_task.api_helper import (
     QueueConnectionError,
     generate_already_running_error_message
 )
+from openedx.core.djangoapps.appsembler.api.tests.factories import OrganizationFactory, OrganizationCourseFactory
 from openedx.core.djangoapps.course_date_signals.handlers import extract_dates
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_COMMUNITY_TA
@@ -3710,6 +3710,8 @@ class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginE
                 category="problem",
                 display_name="Exam Problem - Problem 2"
             )
+
+            OrganizationCourseFactory(organization=OrganizationFactory(), course_id=str(cls.course.id))
 
     def setUp(self):
         super(TestEntranceExamInstructorAPIRegradeTask, self).setUp()

--- a/lms/djangoapps/instructor_task/tasks_helper/module_state.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/module_state.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext_noop
 from opaque_keys.edx.keys import UsageKey
 from xblock.runtime import KvsFieldData
 from xblock.scorable import Score
+from tahoe_sites.api import get_organization_by_course
 
 from capa.responsetypes import LoncapaProblemError, ResponseError, StudentInputError
 from lms.djangoapps.courseware.courses import get_course_by_id, get_problems_in_section
@@ -410,7 +411,8 @@ def _get_modules_to_update(course_id, usage_keys, student_identifier, filter_fcn
     """
     def get_student():
         """ Fetches student instance if an identifier is provided, else return None """
-        return None if not student_identifier else get_user_by_username_or_email(student_identifier)
+        organization = get_organization_by_course(course_id)  # RED-3247 problem with multi-tenant and celery tasks
+        return None if not student_identifier else get_user_by_username_or_email(student_identifier, organization)
 
     module_query_params = {'course_id': course_id, 'module_state_keys': usage_keys}
 

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_get_modules_to_update_with_multi_tenant.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_get_modules_to_update_with_multi_tenant.py
@@ -1,0 +1,62 @@
+from unittest.mock import Mock, patch
+
+import ddt
+from django.contrib.auth.models import User
+from lms.djangoapps.course_blocks.transformers.tests.helpers import ModuleStoreTestCase
+from lms.djangoapps.instructor_task.tasks_helper.module_state import _get_modules_to_update
+from openedx.core.djangoapps.appsembler.api.tests.factories import OrganizationCourseFactory
+from openedx.core.djangoapps.appsembler.multi_tenant_emails.tests.test_utils import (
+    create_org_user,
+    with_organization_context,
+)
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+@ddt.ddt
+class TestGetModulesToUpdate(ModuleStoreTestCase):
+    """
+    _get_modules_to_update is called by perform_module_state_update which is called by instructor tasks to update
+    and/or override scores. We don't need to test the whole cycle, we just need to fix the bug where tasks are
+    failing because (get_student internal method of _get_modules_to_update) is failing with multi-tenant
+    """
+    def setUp(self):
+        """
+        Initialize tests data
+        """
+        super(TestGetModulesToUpdate, self).setUp()
+        with with_organization_context(site_color='purple') as purple_org:
+            self.user = create_org_user(purple_org)
+        self.course = CourseFactory.create()
+        OrganizationCourseFactory(organization=purple_org, course_id=str(self.course.id))
+
+    @patch(
+        'lms.djangoapps.courseware.models.StudentModule.get_state_by_params',
+        Mock(return_value='dummy_module')
+    )
+    @ddt.data(True, False)
+    def test_get_modules_to_update(self, option_value):
+        """
+        Verify that _get_modules_to_update works fine
+        """
+        with patch.dict('django.conf.settings.FEATURES', {'APPSEMBLER_MULTI_TENANT_EMAILS': option_value}):
+            self.assertEquals(
+                _get_modules_to_update(self.course.id, 'dummy_location', self.user.email, None),
+                'dummy_module'
+            )
+            self.assertEquals(
+                _get_modules_to_update(self.course.id, 'dummy_location', self.user.username, None),
+                'dummy_module'
+            )
+
+    @patch(
+        'lms.djangoapps.courseware.models.StudentModule.get_state_by_params',
+        Mock(return_value='dummy_module')
+    )
+    @ddt.data(True, False)
+    def test_get_modules_to_update_bad_user_identifier(self, option_value):
+        """
+        Verify that _get_modules_to_update will fail if a bad user identifier is sent to it
+        """
+        with patch.dict('django.conf.settings.FEATURES', {'APPSEMBLER_MULTI_TENANT_EMAILS': option_value}):
+            with self.assertRaises(User.DoesNotExist):
+                _get_modules_to_update(self.course.id, 'dummy_location', 'bad_user', None)


### PR DESCRIPTION
## Change description

Fix Multi-tenant bug with `rescore_problem` tasks

Instructors cannot rescore problems because our Multi-tenant `APPSEMBLER_MULTI_TENANT_EMAILS` option forces the use of `get_user_by_username_or_email` which requires a valid `request`. This fix is to add an option for passing the organization to `get_user_by_username_or_email_inside_organization` instead of fetching it from the current request. The optional argument will be used by `_get_modules_to_update`

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Related issue: https://appsembler.atlassian.net/browse/RED-3247

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
