### PR TITLE
Studio configs 3rd take: Studio support for site configurations

### DIFF
--- a/cms/djangoapps/appsembler/certificates_helpers.py
+++ b/cms/djangoapps/appsembler/certificates_helpers.py
@@ -1,0 +1,20 @@
+"""
+Helpers for Certificates in CMS.
+"""
+from tahoe_sites.api import get_organization_by_course, get_site_by_organization
+from site_config_client.openedx.api import get_setting_value
+
+
+def is_certificates_enabled_for_course_site(course_id):
+    """
+    Check the CERTIFICATES_HTML_VIEW setting for the course site.
+    """
+    course_organization = get_organization_by_course(course_id)
+    course_site = get_site_by_organization(course_organization)
+
+    course_site_config = course_site.configuration
+
+    is_cert_enabled = get_setting_value(
+        'CERTIFICATES_HTML_VIEW', default=False, site_configuration=course_site_config,
+    )
+    return is_cert_enabled

--- a/cms/djangoapps/appsembler/tests/test_site_configuration_adapter.py
+++ b/cms/djangoapps/appsembler/tests/test_site_configuration_adapter.py
@@ -1,0 +1,39 @@
+"""
+Test the initialization of SiteConfig API adapter in CMS in SiteConfiguration.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tahoe_sites.api import create_tahoe_site_by_link
+from organizations.tests.factories import OrganizationFactory
+
+from openedx.core.djangoapps.appsembler.sites.site_config_client_helpers import enable_for_site
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory, SiteConfigurationFactory
+
+
+@pytest.mark.django_db
+def test_api_adapter_not_enabled(settings):
+    settings.DEFAULT_SITE_THEME = 'edx-theme-codebase'
+
+    organization = OrganizationFactory.create()
+    site = SiteFactory.create()
+
+    config = SiteConfigurationFactory.create(site=site, sass_variables={}, page_elements={})
+    assert config.api_adapter is None, 'Should _not_ have site api adapter because it is disabled.'
+
+
+@pytest.mark.django_db
+def test_api_adapter_enabled(settings):
+    settings.DEFAULT_SITE_THEME = 'edx-theme-codebase'
+
+    organization = OrganizationFactory.create()
+    site = SiteFactory.create()
+    create_tahoe_site_by_link(site=site, organization=organization)
+
+    enable_for_site(site)
+
+    with patch('site_config_client.openedx.adapter.SiteConfigAdapter.get_backend_configs') as mock_get:
+        mock_get.return_value = {'configuration': {'setting': {}}}
+        config = SiteConfigurationFactory.create(site=site, sass_variables={}, page_elements={})
+        assert config.api_adapter, 'Should have site api adapter'

--- a/cms/djangoapps/contentstore/api/views/course_validation.py
+++ b/cms/djangoapps/contentstore/api/views/course_validation.py
@@ -89,7 +89,7 @@ class CourseValidationView(DeveloperErrorViewMixin, GenericAPIView):
                 )
             if get_bool_param(request, 'certificates', all_requested):
                 response.update(
-                    certificates=self._certificates_validation(course, request)
+                    certificates=self._certificates_validation(course)
                 )
             if get_bool_param(request, 'updates', all_requested):
                 response.update(
@@ -202,8 +202,8 @@ class CourseValidationView(DeveloperErrorViewMixin, GenericAPIView):
             sum_of_weights=sum_of_weights,
         )
 
-    def _certificates_validation(self, course, request):
-        is_activated, certificates = CertificateManager.is_activated(request=request, course=course)
+    def _certificates_validation(self, course):
+        is_activated, certificates = CertificateManager.is_activated(course)
         certificates_enabled = certificates is not None
         return dict(
             is_activated=is_activated,

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -7,7 +7,6 @@
   from django.urls import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
-  from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <div class="wrapper-header wrapper" id="view-top">
   <header class="primary" role="banner">
@@ -23,7 +22,6 @@
       <%
             course_key = context_course.id
             url_encoded_course_key = quote(six.text_type(course_key).encode('utf-8'), safe='')
-            current_organization = request.user.organizations.first()
             index_url = reverse('course_handler', kwargs={'course_key_string': six.text_type(course_key)})
             course_team_url = reverse('course_team_handler', kwargs={'course_key_string': six.text_type(course_key)})
             assets_url = reverse('assets_handler', kwargs={'course_key_string': six.text_type(course_key)})
@@ -37,9 +35,10 @@
             advanced_settings_url = reverse('advanced_settings_handler', kwargs={'course_key_string': six.text_type(course_key)})
             tabs_url = reverse('tabs_handler', kwargs={'course_key_string': six.text_type(course_key)})
             certificates_url = ''
-            if current_organization and configuration_helpers.get_value_for_org(current_organization.name, "CERTIFICATES_HTML_VIEW", False) and context_course.cert_html_view_enabled:
+            if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
+
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>

--- a/openedx/core/djangoapps/appsembler/api/tests/factories.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/factories.py
@@ -52,7 +52,7 @@ class SiteConfigurationFactory(factory.DjangoModelFactory):
 
     site = factory.SubFactory(SiteFactory)
     enabled = True
-    values = {
+    site_values = {
         'PLATFORM_NAME': factory.SelfAttribute('site.name'),
         'SITE_NAME': factory.SelfAttribute('site.domain'),
     }

--- a/openedx/core/djangoapps/appsembler/sites/api_v2.py
+++ b/openedx/core/djangoapps/appsembler/sites/api_v2.py
@@ -47,7 +47,6 @@ class CompileSassView(views.APIView):
             }, status=status.HTTP_404_NOT_FOUND)
 
         configuration = SiteConfiguration.objects.get(site=site)
-        configuration.init_api_client_adapter(site)
         sass_status = configuration.compile_microsite_sass()
 
         if sass_status['successful_sass_compile']:

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
@@ -181,7 +181,8 @@ def test_get_current_configuration_adapter_with_site_config():
     """
     with with_site_configuration_context() as site:
         mock_api_adapter = Mock()
-        site.configuration.api_adapter = mock_api_adapter
+        site.configuration._api_adapter = mock_api_adapter
+        site.configuration._api_adapter_initialization_attempted = True
         assert get_current_configuration_adapter() == mock_api_adapter, "Return current site\'s api adapter"
 
 
@@ -204,7 +205,8 @@ def test_get_current_site_config_tier_info():
         'tier': 'trial',
     }
     with with_site_configuration_context() as site:
-        site.configuration.api_adapter = mock_api_adapter
+        site.configuration._api_adapter = mock_api_adapter
+        site.configuration._api_adapter_initialization_attempted = True
         tier_info = get_current_site_config_tier_info()
 
     assert not tier_info.has_subscription_ended(), 'Should return valid TierInfo object'

--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -24,15 +24,7 @@ def get_current_site_configuration():
     # Import is placed here to avoid model import at project startup.
     from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
     try:
-        configuration = getattr(site, "configuration", None)
-
-        if configuration:
-            # Tahoe: This might be the worst place to put the initialization logic, but it works for
-            #        Open edX so we're keeping it here to reduce performance impact
-            #        of `is_enabled_for_site()`
-            configuration.init_api_client_adapter(site)
-
-        return configuration
+        return getattr(site, "configuration", None)
     except SiteConfiguration.DoesNotExist:
         return None
 

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -298,7 +298,8 @@ class SiteConfigAPIClientTests(TestCase):
             site=self.site,
             site_values={},
         )
-        site_configuration.api_adapter = self.api_adapter
+        site_configuration._api_adapter = self.api_adapter
+        site_configuration._api_adapter_initialization_attempted = True
         site_configuration.save()
         assert site_configuration.get_value('platform_name') == 'API Adapter Platform'
 
@@ -345,7 +346,8 @@ class SiteConfigAPIClientTests(TestCase):
             site_values={},
             sass_variables={},
         )
-        site_configuration.api_adapter = self.api_adapter
+        site_configuration._api_adapter = self.api_adapter
+        site_configuration._api_adapter_initialization_attempted = True
         assert site_configuration._get_theme_v2_variables_overrides()
 
     def test_page_content_without_adapter(self):
@@ -376,7 +378,8 @@ class SiteConfigAPIClientTests(TestCase):
                 },
             },
         )
-        site_configuration.api_adapter = self.api_adapter
+        site_configuration._api_adapter = self.api_adapter
+        site_configuration._api_adapter_initialization_attempted = True
         assert site_configuration.get_page_content('about') == {
             'title': 'About page from site configuration service',
         }
@@ -400,7 +403,8 @@ class SiteConfigAPIClientTests(TestCase):
         site_configuration = SiteConfigurationFactory.create(
             site=self.site,
         )
-        site_configuration.api_adapter = self.api_adapter
+        site_configuration._api_adapter = self.api_adapter
+        site_configuration._api_adapter_initialization_attempted = True
         assert site_configuration.get_secret_value('SEGMENT_KEY') == 'test-secret-from-service'
 
     def test_admin_config_without_adapter(self):
@@ -422,5 +426,6 @@ class SiteConfigAPIClientTests(TestCase):
         site_configuration = SiteConfigurationFactory.create(
             site=self.site,
         )
-        site_configuration.api_adapter = self.api_adapter
+        site_configuration._api_adapter = self.api_adapter
+        site_configuration._api_adapter_initialization_attempted = True
         assert site_configuration.get_admin_setting('IDP_TENANT_ID') == 'dummy-tenant-id'

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -25,5 +25,5 @@ google-cloud-storage==1.32.0
 tahoe-idp==2.0.0
 tahoe-sites==1.3.1
 tahoe-lti==0.3.0
-site-configuration-client==0.1.12
+site-configuration-client==0.2.1
 analytics-python==1.4.0  # RED-2969: To enable sync_mode for workers server


### PR DESCRIPTION
### Changes
 - Getting back #1196 after fixing production data by removing duplicate sites.
 - Depends on #1218 for clean organization data.
 - This should fix bugs when SiteConfiguration is used outside a request context adding support for Studio Fix RED-3200.
 
### Follow ups
 - Still needs further refactoring and fixes for `get_value_for_org, which will be done via #1222 


