### PR TITLE
Support Tahoe 2.0 sites for get_all_orgs/get_value_for_org

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -78,3 +78,6 @@ def plugin_settings(settings):
 
     # Appsembler allows generating honor certs
     settings.FEATURES['TAHOE_AUTO_GENERATE_HONOR_CERTS'] = True
+
+    # Off by default. See the `site_configuration.tahoe_organization_helpers.py` module.
+    settings.FEATURES['TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT'] = False

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -80,6 +80,11 @@ def plugin_settings(settings):
             'openedx.core.djangoapps.appsembler.multi_tenant_emails',
         ]
 
+    # On by default on production. See the `site_configuration.tahoe_organization_helpers.py` module.
+    settings.FEATURES['TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT'] = settings.ENV_TOKENS['FEATURES'].get(
+        'TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT', True
+    )
+
     settings.TAHOE_DEFAULT_COURSE_NAME = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_NAME', '')
     settings.TAHOE_DEFAULT_COURSE_GITHUB_ORG = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_GITHUB_ORG', '')
     settings.TAHOE_DEFAULT_COURSE_GITHUB_NAME = settings.ENV_TOKENS.get('TAHOE_DEFAULT_COURSE_GITHUB_NAME', '')

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
@@ -23,6 +23,7 @@ def fake_production_settings(settings):
     settings.AUTH_TOKENS = {}
     settings.CELERY_QUEUES = {}
     settings.ALTERNATE_QUEUE_ENVS = []
+    settings.FEATURES = settings.FEATURES.copy()  # Prevent polluting other tests.
     settings.ENV_TOKENS = {
         'LMS_BASE': 'fake-lms-base',
         'LMS_ROOT_URL': 'fake-lms-root-url',
@@ -57,6 +58,8 @@ def test_production_lms(fake_production_settings, retval, additional_count):
             expected_dir_len = len(settings.STATICFILES_DIRS) + additional_count
             production_lms.plugin_settings(settings)
             assert len(settings.STATICFILES_DIRS) == expected_dir_len
+
+    assert settings.FEATURES['TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT'], 'Should be on by default on prod.'
 
 
 @pytest.fixture(scope='function')

--- a/openedx/core/djangoapps/site_configuration/tahoe_organization_helpers.py
+++ b/openedx/core/djangoapps/site_configuration/tahoe_organization_helpers.py
@@ -1,0 +1,43 @@
+"""
+Helpers to support TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT feature.
+
+TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT is an on by-default feature in production.
+It uses `short_name` lookup instead of looking up by `course_org_filter`.
+
+Although organization.short_name is more reliable and faster than `course_org_filter`, the best way to identify
+an organization is via its Site UUID.
+
+This module is a patch to the SiteConfiguration organization helpers across Open edX e.g. `get_value_for_org()`.
+
+Purpose:
+ - Provide compatibility with the Site Configuration Client.
+ - Filter by organizations with active subscription.
+"""
+
+from organizations.models import Organization
+import tahoe_sites.api
+
+
+def get_all_orgs():
+    """
+    This returns active of the orgs that are considered in site configurations, This can be used,
+        for example, to do filtering.
+
+        Returns:
+            A set of active organizations present in site configuration.
+
+    Unlike the upstream method, this is compatible with the Site Configuration Client.
+    """
+    from openedx.core.djangoapps.appsembler.sites import utils as site_utils
+    return site_utils.get_active_organizations().values_list('short_name', flat=True)
+
+
+def get_configuration_for_org(org):
+    """
+    Get the SiteConfiguration for a specific organization by its short_name.
+
+    Unlike the upstream method, this is compatible with the Site Configuration Client.
+    """
+    organization = Organization.objects.get(short_name=org)
+    site = tahoe_sites.api.get_site_by_organization(organization)
+    return site.configuration

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -11,6 +11,9 @@ from unittest.mock import patch, Mock
 import ddt
 from urllib.parse import urlsplit
 
+from organizations.models import Organization
+from organizations.tests.factories import OrganizationFactory
+
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.test import TestCase
@@ -18,8 +21,10 @@ from django.test.utils import override_settings
 
 from site_config_client.openedx.adapter import SiteConfigAdapter
 
+from openedx.core.djangoapps.appsembler.multi_tenant_emails.tests.test_utils import with_organization_context
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 @pytest.fixture
@@ -424,3 +429,69 @@ class SiteConfigAPIClientTests(TestCase):
         )
         site_configuration._api_adapter = self.api_adapter
         assert site_configuration.get_admin_setting('IDP_TENANT_ID') == 'dummy-tenant-id'
+
+
+@pytest.mark.django_db
+@patch.dict('django.conf.settings.FEATURES', {'TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT': True})
+@patch('openedx.core.djangoapps.appsembler.sites.utils.get_active_organizations')
+def test_get_all_orgs_filters_by_active(mock_active_orgs):
+    """
+    Test `get_all_orgs()` while using TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT.
+    """
+    OrganizationFactory.create(short_name='red')
+    OrganizationFactory.create(short_name='blue')
+    inactive_org = OrganizationFactory.create(short_name='inactive')
+
+    fake_active_orgs = Organization.objects.exclude(pk=inactive_org.pk)
+    mock_active_orgs.return_value = fake_active_orgs
+
+    all_orgs = configuration_helpers.get_all_orgs()
+    assert set(all_orgs) == {'red', 'blue'}, 'Should rely on get_active_organizations'
+
+
+@pytest.mark.django_db
+@patch.dict('django.conf.settings.FEATURES', {'TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT': True})
+@patch('openedx.core.djangoapps.appsembler.sites.utils.get_active_organizations')
+def test_get_configuration_for_org_via_short_name(mock_active_orgs, settings):
+    """
+    Test `get_configuration_for_org()` while using TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT.
+
+    This method tests get_configuration_for_org indirectly.
+    """
+    assert settings.FEATURES['TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT'], 'Patched as True in tests'
+
+    mock_active_orgs.return_value = Organization.objects.all()
+
+    unconfigured_url = configuration_helpers.get_value_for_org('blue1', 'blog_url', default='default_url')
+    assert unconfigured_url == 'default_url', 'Should return default value'
+
+    with with_organization_context(site_color='blue1', configs={'blog_url': 'http://blog.com'}):
+        # Configure the organization
+        configured_blog_url = configuration_helpers.get_value_for_org('blue1', 'blog_url', default='default_url')
+
+    assert configured_blog_url == 'http://blog.com', 'should read from site configs properly'
+
+
+@pytest.mark.django_db
+@patch.dict('django.conf.settings.FEATURES', {'TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT': True})
+@patch('openedx.core.djangoapps.appsembler.sites.utils.get_active_organizations')
+def test_get_configuration_for_org_via_short_name_inactive_org(mock_active_orgs, settings):
+    """
+    Test `get_configuration_for_org()` with expired subscription while using
+
+    This method tests get_configuration_for_org with TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT indirectly.
+    """
+    assert settings.FEATURES['TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT'], 'Patched as True in tests'
+
+    mock_active_orgs.return_value = Organization.objects.none()
+    inactive_org_url = configuration_helpers.get_value_for_org('blue1', 'blog_url', default='default_url')
+    assert inactive_org_url == 'default_url', 'If the organization is not active, ignore its configurations'
+
+
+def test_site_config_client_organizations_support_feature_disabled_by_default(settings):
+    """
+    Ensure TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT is disabled in testing by default.
+
+    This ensures that upstream Open edX won't fail.
+    """
+    assert not settings.FEATURES['TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT'], 'Disabled by default'


### PR DESCRIPTION
In Tahoe 2.0 sites SiteConfiguration is empty, therefore don't have `course_org_filter`. As a result, `get_all_orgs` and `get_value_for_org` won't work.

The the `TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT` feature looks for organizations by `short_name`.

This PR also cleans up performance hacks for organizations that are now not needed.

Fixes for RED-3200.