### PR TITLE
refactor: simplify caching for SiteConfiguration.api_adapter

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
@@ -182,7 +182,6 @@ def test_get_current_configuration_adapter_with_site_config():
     with with_site_configuration_context() as site:
         mock_api_adapter = Mock()
         site.configuration._api_adapter = mock_api_adapter
-        site.configuration._api_adapter_initialization_attempted = True
         assert get_current_configuration_adapter() == mock_api_adapter, "Return current site\'s api adapter"
 
 
@@ -206,7 +205,6 @@ def test_get_current_site_config_tier_info():
     }
     with with_site_configuration_context() as site:
         site.configuration._api_adapter = mock_api_adapter
-        site.configuration._api_adapter_initialization_attempted = True
         tier_info = get_current_site_config_tier_info()
 
     assert not tier_info.has_subscription_ended(), 'Should return valid TierInfo object'

--- a/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_tahoe_changes.py
@@ -299,7 +299,6 @@ class SiteConfigAPIClientTests(TestCase):
             site_values={},
         )
         site_configuration._api_adapter = self.api_adapter
-        site_configuration._api_adapter_initialization_attempted = True
         site_configuration.save()
         assert site_configuration.get_value('platform_name') == 'API Adapter Platform'
 
@@ -347,7 +346,6 @@ class SiteConfigAPIClientTests(TestCase):
             sass_variables={},
         )
         site_configuration._api_adapter = self.api_adapter
-        site_configuration._api_adapter_initialization_attempted = True
         assert site_configuration._get_theme_v2_variables_overrides()
 
     def test_page_content_without_adapter(self):
@@ -379,7 +377,6 @@ class SiteConfigAPIClientTests(TestCase):
             },
         )
         site_configuration._api_adapter = self.api_adapter
-        site_configuration._api_adapter_initialization_attempted = True
         assert site_configuration.get_page_content('about') == {
             'title': 'About page from site configuration service',
         }
@@ -404,7 +401,6 @@ class SiteConfigAPIClientTests(TestCase):
             site=self.site,
         )
         site_configuration._api_adapter = self.api_adapter
-        site_configuration._api_adapter_initialization_attempted = True
         assert site_configuration.get_secret_value('SEGMENT_KEY') == 'test-secret-from-service'
 
     def test_admin_config_without_adapter(self):
@@ -427,5 +423,4 @@ class SiteConfigAPIClientTests(TestCase):
             site=self.site,
         )
         site_configuration._api_adapter = self.api_adapter
-        site_configuration._api_adapter_initialization_attempted = True
         assert site_configuration.get_admin_setting('IDP_TENANT_ID') == 'dummy-tenant-id'


### PR DESCRIPTION
The previous method used too many variables and had no tests. This refactoring should be already tested with existing `test_tahoe_changes.py` tests.

Fixes for RED-3200.