### PR TITLE
explicitly set routing keys in settings

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -113,9 +113,12 @@ def plugin_settings(settings):
         'TAHOE_COURSE_OUTLINE_COMPLETABLE_BLOCK_TYPES', []
     )
 
-    settings.CELERY_ROUTES = (settings.CELERY_ROUTES,
-                                'lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3': {
-                                    'queue': settings.ENV_TOKENS.get('RECALCULATE_GRADES_ROUTING_KEY', settings.DEFAULT_PRIORITY_QUEUE),
-                                    'routing_key': settings.ENV_TOKENS.get('RECALCULATE_GRADES_ROUTING_KEY', settings.DEFAULT_PRIORITY_QUEUE),
-                                },
+    settings.CELERY_ROUTES = (
+        settings.CELERY_ROUTES,
+        {
+            'lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3': {
+                'queue': settings.ENV_TOKENS.get('RECALCULATE_GRADES_ROUTING_KEY', settings.DEFAULT_PRIORITY_QUEUE),
+                'routing_key': settings.ENV_TOKENS.get('RECALCULATE_GRADES_ROUTING_KEY', settings.DEFAULT_PRIORITY_QUEUE)
+            }
+        }
     )

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -112,3 +112,10 @@ def plugin_settings(settings):
     settings.TAHOE_COURSE_OUTLINE_COMPLETABLE_BLOCK_TYPES = settings.ENV_TOKENS.get(
         'TAHOE_COURSE_OUTLINE_COMPLETABLE_BLOCK_TYPES', []
     )
+
+    settings.CELERY_ROUTES = (settings.CELERY_ROUTES,
+                                'lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3': {
+                                    'queue': settings.ENV_TOKENS.get('RECALCULATE_GRADES_ROUTING_KEY', settings.DEFAULT_PRIORITY_QUEUE),
+                                    'routing_key': settings.ENV_TOKENS.get('RECALCULATE_GRADES_ROUTING_KEY', settings.DEFAULT_PRIORITY_QUEUE),
+                                },
+    )

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
@@ -30,6 +30,7 @@ def fake_production_settings(settings):
         'FEATURES': {}
     }
     settings.MAIN_SITE_REDIRECT_WHITELIST = []
+    settings.CELERY_ROUTES = ()
     return settings
 
 


### PR DESCRIPTION
## Change description

This is a follow up of https://github.com/appsembler/edx-configs/pull/1443 

The main grading task of the platform is routed in the `task` decorator, after merging the above PR I tested in staging and grading tasks are still getting into the default queue. Celery is really a mess, there are at least 4 or 5 different ways of routing tasks and they can be override... I'm not sure exactly why in our case sometimes grading tasks go to the default queue. 

Settings tasks and queues in settings in the Django Celery recommended way of doing this.

https://stackoverflow.com/questions/10707287/django-celery-routing-problems
https://stackoverflow.com/questions/29786019/why-do-celery-routes-have-both-a-queue-and-a-routing-key

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
