### PR TITLE
Skip broken test_auto_auth.py flaky upstream tests

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_auto_auth.py
@@ -1,5 +1,5 @@
 """ Tests for auto auth. """
-
+import unittest
 
 import json
 
@@ -23,6 +23,7 @@ from student.models import CourseAccessRole, CourseEnrollment, UserProfile, anon
 from util.testing import UrlResetMixin
 
 
+@unittest.skipIf(settings.TAHOE_ALWAYS_SKIP_TEST, 'Broken upstream test, fixed in d7dc8de0537 commit of Lilac')
 class AutoAuthTestCase(UrlResetMixin, TestCase):
     """
     Base class for AutoAuth Tests that properly resets the urls.py


### PR DESCRIPTION
The fix is available in upstream's https://github.com/openedx/edx-platform/commit/d7dc8de053787a2ee0f8d1a9223a2bcce9246ba7 which is part of Lilac but the commit can't be cherry-picked cleanly.

Skipping the test file makes most sense in such cases.
