### PR TITLE
Fixes for Tahoe User Profile metadata caching

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -8,7 +8,6 @@ import copy
 
 import analytics
 from analytics.client import Client
-from django.conf import settings
 
 from openedx.core.djangoapps.site_configuration import helpers
 from openedx.core.djangoapps.appsembler.eventtracking import exceptions, utils
@@ -131,6 +130,7 @@ def is_celery_worker():
 
     :return: <True> if the execution is for Celery; and <False> otherwise
     """
+    from django.conf import settings
     return getattr(settings, 'IS_CELERY_WORKER', False) or False
 
 

--- a/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
@@ -11,14 +11,6 @@ import os
 import sys
 
 
-def is_celery_worker():
-    """Utility function: return False if not a Celery worker."""
-    # Use this instead of common.djangoapps.track.shim.is_celery_worker
-    # ... as that relies on settings which is only lazy-loaded when
-    # ... plugin apps are instantiated.
-    return os.getenv('CELERY_WORKER_RUNNING', False)
-
-
 def is_not_lms():
     """Utility function: return False if not running in the LMS."""
     return os.getenv("SERVICE_VARIANT") != 'lms'

--- a/openedx/core/djangoapps/appsembler/eventtracking/apps.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/apps.py
@@ -6,6 +6,7 @@ from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
 
 from openedx.core.djangoapps.plugins.constants import ProjectType, PluginSignals
+from track.shim import is_celery_worker
 
 from . import app_variant, tahoeusermetadata
 
@@ -63,7 +64,7 @@ class EventTrackingConfig(AppConfig):
         if (
             app_variant.is_not_runserver() or
             app_variant.is_not_lms() or
-            app_variant.is_celery_worker()
+            is_celery_worker()
         ):
             logger.debug("Not initializing metadatacache. This is Studio, Celery, other command.")
             return

--- a/openedx/core/djangoapps/appsembler/eventtracking/apps.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/apps.py
@@ -55,6 +55,10 @@ class EventTrackingConfig(AppConfig):
     }
 
     def ready(self):
+
+        metadatacache = tahoeusermetadata.userprofile_metadata_cache
+        metadatacache.ready()
+
         # only want to prefill the cache on lms runserver...
         if (
             app_variant.is_not_runserver() or
@@ -63,6 +67,5 @@ class EventTrackingConfig(AppConfig):
         ):
             logger.debug("Not initializing metadatacache. This is Studio, Celery, other command.")
             return
-
-        metadatacache = tahoeusermetadata.userprofile_metadata_cache
-        tahoeusermetadata.prefetch_tahoe_usermetadata_cache.delay(metadatacache)
+        else:
+            tahoeusermetadata.prefetch_tahoe_usermetadata_cache.delay(metadatacache)

--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -9,7 +9,7 @@ import logging
 
 from celery import task
 from crum import get_current_user
-from django.core.cache import cache
+from django.core.cache import caches
 
 from . import app_variant
 
@@ -26,53 +26,56 @@ class TahoeUserProfileMetadataCache(object):
 
     # TODO: rework as a singleton.
 
-    CACHE_KEY_PREFIX = "appsembler_eventtracking_user_metadata_by_user_id"
-    CACHE_PREFILLING_KEY = "TahoeUserProfileMetadataCache_PREFILLING"
+    CACHE_NAME = "tahoe_userprofile_metadata_cache"  # can't get from settings here
+    CACHE_PREFILLING_KEY = "PREFILLING"
     READY = False
+    cache = None
 
-    def _make_key_by_user_id(self, user_id):
-        return '{}-{}'.format(self.CACHE_KEY_PREFIX, user_id)
+    def ready(self):
+        """Finish initializing once cache is created via appsembler.settings plugin_settings."""
+        self.cache = caches[self.CACHE_NAME]
 
     def prefill(self):
         """Prefill if not already prefilling."""
-        if cache.get(self.CACHE_PREFILLING_KEY):
+        if self.cache.get(self.CACHE_PREFILLING_KEY):
             # don't allow more than one prefill!
             logger.info("TahoeUserProfileMetadataCache already prefilling")
             return
 
-        cache.set(self.CACHE_PREFILLING_KEY, True)
-        logger.info("START Prefilling Tahoe UserMetadata Cache...")
+        self.cache.set(self.CACHE_PREFILLING_KEY, True)
+        logger.info("START Prefilling Tahoe UserProfile Metadata Cache...")
 
         from student.models import UserProfile
 
         for up in UserProfile.objects.all().select_related('user'):
-            self.set_by_user_id(up.user.id, up.get_meta().get('tahoe_idp_metadata', {}), True)
+            self.cache.set(up.user.id, up.get_meta().get('tahoe_idp_metadata', {}), True)
 
-        cache.set(self.CACHE_PREFILLING_KEY, False)
+        self.cache.set(self.CACHE_PREFILLING_KEY, False)
         self.READY = True
-        logger.info("FINISH Prefilling Tahoe UserMetadata Cache")
+        logger.info("FINISH Prefilling Tahoe UserProfile Metadata Cache")
 
     def get_by_user_id(self, user_id):
         if not self.READY:
             return None
-        return cache.get(self._make_key_by_user_id(user_id))
+        return self.cache.get(user_id)
 
     def set_by_user_id(self, user_id, val, is_prefill=False):
         if not self.READY and not is_prefill:
             # we can set as part of the prefill before done, but not otherwise
             return
-        key = self._make_key_by_user_id(user_id)
-        cache.set(key, val)
-        logger.debug('Set and retrieved {} with value {}'.format(key, cache.get(key)))
+        self.cache.set(user_id, val)
+        logger.debug('Set and retrieved for user id {} with value {}'.format(
+            user_id, self.cache.get(user_id)
+        ))
 
     def invalidate(self, instance):
         # called by signal handler on post_save, post_delete of UserProfile
         # we can invalidate even while prefilling as long as key is found
-        key = self._make_key_by_user_id(instance.user_id)
-        cache.delete(key)
+        # TODO: if this is a save and not delete, we should set the new value
+        self.cache.delete(instance.user_id)
 
 
-# import of settings is a problem when setting this via plugin architecture
+# import of settings is a problem when creating this via plugin architecture
 @task(routing_key=PREFETCH_TAHOE_USERMETADATA_CACHE_QUEUE)
 def prefetch_tahoe_usermetadata_cache(cache_instance):
     """Celery task to prefill the TahoeUserProfileMetadataCache.

--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -57,7 +57,14 @@ class TahoeUserProfileMetadataCache(object):
     def get_by_user_id(self, user_id):
         if not self.READY:
             return None
-        return self.cache.get(user_id)
+        val = self.cache.get(user_id)
+        if val:
+            logger.debug(
+                'Retrieved UserProfile metadata from cache for user id {} with value {}'.format(
+                    user_id, val
+                )
+            )
+        return val
 
     def set_by_user_id(self, user_id, val, is_prefill=False):
         if not self.READY and not is_prefill:

--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -84,9 +84,6 @@ def plugin_settings(settings):
         }
     ]
 
-    # during prefetch at startup, worker queries all UserProfile meta so we might reassign
-    settings.PREFETCH_TAHOE_USERMETADATA_CACHE_QUEUE = settings.DEFAULT_PRIORITY_QUEUE
-
     # Appsembler allows generating honor certs
     settings.FEATURES['TAHOE_AUTO_GENERATE_HONOR_CERTS'] = True
 

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -127,3 +127,14 @@ def plugin_settings(settings):
             }
         }
     )
+
+    # add a cache for user profile metadata for use by the TahoeUserMetadataProcessor
+    # must be done here as lms/envs/production sets via ENV_TOKENS['CACHES']
+    settings.CACHES.update({
+        'tahoe_userprofile_metadata_cache': {
+            'KEY_PREFIX': 'tahoe_userprofile_metadata_',
+            'LOCATION': settings.ENV_TOKENS.get('MEMCACHE_LOCATION', ['localhost:11211']),
+            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+            'MAX_ENTRIES': 100000  # estimated at 30Mb. See BLACK-2636
+        }
+    })

--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -132,9 +132,9 @@ def plugin_settings(settings):
     # must be done here as lms/envs/production sets via ENV_TOKENS['CACHES']
     settings.CACHES.update({
         'tahoe_userprofile_metadata_cache': {
-            'KEY_PREFIX': 'tahoe_userprofile_metadata_',
+            'KEY_PREFIX': 'tahoe_userprofile_metadata',
             'LOCATION': settings.ENV_TOKENS.get('MEMCACHE_LOCATION', ['localhost:11211']),
             'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-            'MAX_ENTRIES': 100000  # estimated at 30Mb. See BLACK-2636
+            'MAX_ENTRIES': 100000  # estimated at <=30Mb. See BLACK-2636
         }
     })

--- a/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
@@ -33,8 +33,7 @@ def plugin_settings(settings):
 
     settings.CACHES.update({
         'tahoe_userprofile_metadata_cache': {
-            'KEY_PREFIX': 'tahoe_userprofile_metadata_',
-            # 'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+            'KEY_PREFIX': 'tahoe_userprofile_metadata',
             'LOCATION': 'edx_loc_mem_cache',
             'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
         }

--- a/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/test_common.py
@@ -30,3 +30,12 @@ def plugin_settings(settings):
         settings.INSTALLED_APPS += [
             'openedx.core.djangoapps.appsembler.multi_tenant_emails',
         ]
+
+    settings.CACHES.update({
+        'tahoe_userprofile_metadata_cache': {
+            'KEY_PREFIX': 'tahoe_userprofile_metadata_',
+            # 'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+            'LOCATION': 'edx_loc_mem_cache',
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        }
+    })


### PR DESCRIPTION
## Change description

Caching functionality was set up for use by TahoeUserMetadataProcessor eventtracking processor in the appsembler.eventtracking app.

This changes to use a new separate cache and makes fixes to the instantiation and prefilling of that cache.

**Before deployment to production or staging** needs merge of https://github.com/appsembler/edx-configs/pull/1464 to `master`

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/BLACK-2636

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
