### PR TITLE
get custom domains from own models instead of AMC db

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/management/commands/custom_domains_list.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/custom_domains_list.py
@@ -4,6 +4,7 @@ from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
 
 from django.core.management import BaseCommand
 
+
 class Command(BaseCommand):
     help = "Outputs the list of custom domains that will be used to generate let's encrypt certs"
 

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/custom_domains_list.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/custom_domains_list.py
@@ -1,15 +1,13 @@
 import json
 
-from django.core.management import BaseCommand
-from django.db import connections
+from openedx.core.djangoapps.appsembler.sites.models import AlternativeDomain
 
+from django.core.management import BaseCommand
 
 class Command(BaseCommand):
     help = "Outputs the list of custom domains that will be used to generate let's encrypt certs"
 
     def handle(self, *args, **options):
-        cursor = connections['tiers'].cursor()
-        cursor.execute("SELECT custom_domain FROM organizations_microsite WHERE custom_domain != '';")
-        rows = cursor.fetchall()
-        domains = [{'domains': row} for row in rows]
+        altertive_domains = AlternativeDomain.objects.values_list('site__domain', flat=True)
+        domains = [{'domains': [domain]} for domain in altertive_domains]
         self.stdout.write(json.dumps(domains))

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import os
 from mock import patch, mock_open
 from io import StringIO
@@ -715,3 +716,22 @@ class DisableCustomDomainCommandTestCase(TestCase):
         assert not AlternativeDomain.objects.filter(domain=disable_domain).exists()
         # and there shouldn't be a lingering/duplicate Site for the old one either
         assert not Site.objects.filter(domain=disable_domain).exists()
+
+
+class CustomDomainsListCommandTestCase(TestCase):
+    """
+    Test ./manage.py lms custom_domains_list
+    """
+    def test_disable_custom_domain(self):
+        test_domain = "test-custom-domain.example.com"
+        altdomain = "test-custom-domain.tahoe.appsembler.com"
+
+        s = SiteFactory.create(domain=test_domain)
+        AlternativeDomainFactory.create(domain=altdomain, site=s)
+
+        out = StringIO()
+        call_command('custom_domains_list', stdout=out)
+
+        results = json.loads(out.getvalue())
+
+        assert {"domains": [test_domain]} in results


### PR DESCRIPTION
## Change description

Soon we will deprecate AMC and the postgres database won't exist anymore, I realized setting up a custom domains, all the info this commands gets from the AMC database is the same as the alternative domains 

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

This PRs works together with:
https://github.com/appsembler/configuration/pull/410

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
