### PR TITLE
Disable docker image build in actions for temp branches

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -6,6 +6,9 @@ on:
       - main
       - prod
   pull_request:
+    branches:
+      - main
+      - prod
 
 jobs:
   build:


### PR DESCRIPTION
Only run the action for PRs on (main) and (prod) branches

## Change description

Disable docker image-build in actions for temp branches. Allow it only if the PR is against `main` or `prod` branches

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
