### PR TITLE
MTE / tahoe-sites: allow sending password reset emails for inactive users

### DIFF
--- a/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_registration_api.py
@@ -24,9 +24,6 @@ APPSEMBLER_API_VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.api.v1.views'
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.authentication_classes', [])
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.permission_classes', [AllowAny])
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.throttle_classes', [])
-@override_settings(APPSEMBLER_FEATURES={
-    'SKIP_LOGIN_AFTER_REGISTRATION': False,
-})
 class RegistrationApiViewTests(TestCase):
     def setUp(self):
 

--- a/openedx/core/djangoapps/appsembler/api/tests/test_registration_api_v2.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_registration_api_v2.py
@@ -3,6 +3,7 @@ Tests for openedx.core.djangoapps.appsembler.api.v2.views.RegistrationViewSet
 
 """
 from django.contrib.auth.models import User
+from django.core import mail
 from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -26,7 +27,6 @@ APPSEMBLER_API_VIEWS_MODULE_V2 = 'openedx.core.djangoapps.appsembler.api.v2.view
 })
 class RegistrationApiViewTestsV2(TestCase):
     def setUp(self):
-
         self.site = SiteFactory()
         # The DRF Router appends '-list' to the base 'registrations' name when
         # registering the endpoint
@@ -45,23 +45,20 @@ class RegistrationApiViewTestsV2(TestCase):
 
     @ddt.unpack
     @ddt.data(
-        {'send_activation_email': True, 'should_send': True},
-        {'send_activation_email': False, 'should_send': False},
-        {'send_activation_email': 'True', 'should_send': True},
-        {'send_activation_email': 'False', 'should_send': False},
-        {'send_activation_email': 'true', 'should_send': True},
-        {'send_activation_email': 'false', 'should_send': False},
+        {'send_activation_email': True, 'expected_subject': 'Activate your', 'email_count': 1},
+        {'send_activation_email': False, 'expected_subject': None, 'email_count': 0},
+        {'send_activation_email': 'True', 'expected_subject': 'Activate your', 'email_count': 1},
+        {'send_activation_email': 'False', 'expected_subject': None, 'email_count': 0},
+        {'send_activation_email': 'true', 'expected_subject': 'Activate your', 'email_count': 1},
+        {'send_activation_email': 'false', 'expected_subject': None, 'email_count': 0},
     )
-    def test_send_activation_email_with_password(self, send_activation_email, should_send):
+    def test_send_activation_email_with_password(self, send_activation_email, expected_subject, email_count):
         """
         This test makes sure when the API endpoint is called with a password,
         the send_activation_email parameter is being used properly. Also makes
         sure when the attribute is True the user remains inactive until the
         activation is performed through the activation email. It also makes
         sure the user is automatically activate when the parameter is False.
-
-        TODO: Reuse the tests of v1's RegistrationApiViewTests instead of duplicating code
-              as described in https://github.com/appsembler/edx-platform/issues/1047
         """
         params = {
             'username': 'mr_potato_head',
@@ -71,13 +68,15 @@ class RegistrationApiViewTestsV2(TestCase):
             'send_activation_email': send_activation_email,
         }
 
-        with patch('openedx.core.djangoapps.user_authn.views.register.compose_and_send_activation_email') as fake_send:
-            res = self.client.post(self.url, params)
-            self.assertContains(res, 'user_id', status_code=200)
-            new_user = User.objects.get(username=params['username'])
+        res = self.client.post(self.url, params)
 
-            assert fake_send.called == should_send, 'activation email should not be called'
-            assert new_user.is_active == (not should_send), 'xor, Either activate or send the email'
+        self.assertContains(res, 'user_id', status_code=200)
+        new_user = User.objects.get(username=params['username'])
+        assert new_user.is_active == (not email_count)
+        subject = mail.outbox[0].subject if mail.outbox else ''
+        assert len(mail.outbox) == email_count, 'Incorrect message count: Subject={}'.format(subject)
+        if expected_subject:
+            assert expected_subject in mail.outbox[0].subject
 
     def test_duplicate_identifiers(self):
         self.client.post(self.url, self.sample_user_data)
@@ -115,3 +114,90 @@ class RegistrationApiViewTestsV2(TestCase):
         }
         res = self.client.post(self.url, similar_user_data)
         self.assertContains(res, "The password is too similar to the username.", status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_happy_path(self):
+        assert not mail.outbox, 'Should not have any messages'
+        res = self.client.post(self.url, self.sample_user_data)
+        self.assertContains(res, 'user_id', status_code=200)
+        assert mail.outbox, 'Should send the activation email'
+        email = mail.outbox[0]
+        assert 'Activate' in email.subject, 'Should have the activation email subject'
+        assert '/activate/' in email.body, 'Should include the activation link in the body'
+
+    def test_without_password_field(self):
+        params = {
+            'username': 'mr_potato_head',
+            'email': 'mr_potato_head@example.com',
+            'name': 'Mr Potato Head',
+        }
+        with patch('openedx.core.djangoapps.user_authn.views.password_reset.get_current_site',
+                   return_value=self.site):
+            res = self.client.post(self.url, params)
+        self.assertContains(res, 'user_id', status_code=status.HTTP_200_OK)
+
+    @ddt.data(
+        {'send_activation_email': True},
+        {'send_activation_email': 'True'},
+        {'send_activation_email': 'true'},
+        {'send_activation_email': False},
+        {'send_activation_email': 'False'},
+        {'send_activation_email': 'false'},
+        {},
+    )
+    def test_send_activation_email_without_password(self, activation_email_params):
+        """
+        Should not send the activation email. Ignores the `send_activation_email` param. It
+        also makes sure the user remains inactive (is_active=False). The user
+        will be activated after the password is reseted.
+        """
+        params = {
+            'username': 'mr_potato_head',
+            'email': 'mr_potato_head@example.com',
+            'name': 'Mr Potato Head',
+        }
+        params.update(activation_email_params)
+
+        with patch('openedx.core.djangoapps.user_authn.views.password_reset.get_current_site',
+                   return_value=self.site):
+            res = self.client.post(self.url, params)
+
+        self.assertContains(res, 'user_id', status_code=200)
+        new_user = User.objects.get(username=params['username'])
+        assert not new_user.is_active
+        assert mail.outbox, 'Should send the password reset email'
+
+        assert len(mail.outbox) == 1, ('Send NOT password reset email but NOT activation.\n'
+                                       'Subjects={subjects}.\n'
+                                       'params]}').format(
+            subjects=[email.subject for email in mail.outbox],
+            params=params,
+        )
+
+        email = mail.outbox[0]
+        assert 'Password reset on' in email.subject
+
+    @ddt.unpack
+    @ddt.data(
+        {'missing_field': 'username', 'error_message': 'Username must be between'},
+        {'missing_field': 'name', 'error_message': 'Your legal name must be a minimum of one'},
+    )
+    def test_missing_field(self, missing_field, error_message):
+        params = self.sample_user_data.copy()
+        del params[missing_field]
+        res = self.client.post(self.url, params)
+        body = res.content.decode('utf-8')
+        assert res.status_code == 400, 'Should fail with 400 error: {}'.format(body)
+        assert error_message in body, 'Should fail with 400 error: {}'.format(body)
+
+    @ddt.unpack
+    @ddt.data(
+        {'invalid_field': 'username', 'error_message': 'Usernames can only contain letters'},
+        {'invalid_field': 'email', 'error_message': 'A properly formatted e-mail is required'},
+    )
+    def test_incorrect_field_format(self, invalid_field, error_message):
+        params = self.sample_user_data.copy()
+        params[invalid_field] = '%%%%%%%'
+        res = self.client.post(self.url, params)
+        body = res.content.decode('utf-8')
+        assert res.status_code == 400, 'Should fail with 400 error: {}'.format(body)
+        assert error_message in body, 'Should fail with 400 error: {}'.format(body)

--- a/openedx/core/djangoapps/appsembler/api/tests/test_throttling.py
+++ b/openedx/core/djangoapps/appsembler/api/tests/test_throttling.py
@@ -33,9 +33,6 @@ def make_post_data(val):
 @ddt.ddt
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.authentication_classes', [])
 @patch(APPSEMBLER_API_VIEWS_MODULE + '.RegistrationViewSet.permission_classes', [AllowAny])
-@override_settings(APPSEMBLER_FEATURES={
-    'SKIP_LOGIN_AFTER_REGISTRATION': False,
-})
 @override_settings(CACHES={
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -170,7 +170,8 @@ class PasswordResetFormNoActive(PasswordResetForm):
             current_org = get_current_organization()
             try:
                 # The following will raise an exception if many records found in the organization for this email
-                one_user = get_organization_user_by_email(email=email, organization=current_org, fail_if_inactive=True)
+                one_user = get_organization_user_by_email(email=email, organization=current_org,
+                                                          fail_if_inactive=False)
             except User.DoesNotExist:
                 self.users_cache = []
             else:


### PR DESCRIPTION
Fixes password email being withheld due to `user.is_active == False` against the desired use case.

### Root cause

 - This bug was introduced by the commit: 46619cce8102fa4ba25a0275de5a98cb9a07165f as part of the `tahoe-sites` migration efforts
 - We had no tests to catch the bug in the v2 API
 - The tests needed APPSEMBLER_MULTI_TENANT_EMAILS in the v1 API, but wasn't added to avoid breaking the deprecated v1 unintentionally


### Changes

 - added tests for password-reset email in registration api
 - ensured that tests fail properly and catch the error by enabling APPSEMBLER_MULTI_TENANT_EMAILS
 - set `fail_if_inactive=False` to fix the regression bug caused by 46619cce8102fa4ba25a0275de5a98cb9a07165f

### API breaking? changes
I'm adding few more JSON fields in the response. In general it shouldn't be a breaking change, but if needed I can revert those changes:

```diff
 {
   "user_id": 60,
+  "password_provided": false,
+  "password_reset_email_was_sent": true,
+  "password_reset_validation_errors":null
 }
```

```diff
 {
   "user_id": 60,
+  "password_provided": false,
+  "password_reset_email_was_sent": true,
+  "password_reset_validation_errors": {"email": ["That e-mail address doesn't have an associated user account. Are you sure you've registered?"]}
 }
```

### Related tasks
 - Fixes https://github.com/appsembler/edx-platform/issues/1047 
 - Related to RED-3356

### TODO

 - [ ] Get review on the breaking changes
 - [ ] Update the API doc if needed
 - [x] Test on devstack
 - [x] Unit/integration tests