### PR TITLE
Fix tests that override settings.FEATURES

### DIFF
--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_enroll_by_email.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_enroll_by_email.py
@@ -21,7 +21,7 @@ def test_enroll_by_email_single_tenant(settings):
     """
     Ensure `enroll_by_email` works as upstream intended if APPSEMBLER_MULTI_TENANT_EMAILS is disabled.
     """
-    settings.FEATURES = {'APPSEMBLER_MULTI_TENANT_EMAILS': False}
+    settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'] = False
     course = CourseOverviewFactory.create()
     course_key = course.id
 
@@ -43,7 +43,7 @@ def test_enroll_by_email_multi_tenant(settings):
     """
     Ensure `enroll_by_email` works with APPSEMBLER_MULTI_TENANT_EMAILS is enabled.
     """
-    settings.FEATURES = {'APPSEMBLER_MULTI_TENANT_EMAILS': True}
+    settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'] = True
     course = CourseOverviewFactory.create()
     course_key = course.id
 

--- a/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_get_user_by_username_or_email.py
+++ b/openedx/core/djangoapps/appsembler/multi_tenant_emails/tests/test_get_user_by_username_or_email.py
@@ -20,7 +20,7 @@ def test_get_user_by_username_or_email_single_tenant(settings):
     """
     Ensure `get_user_by_username_or_email` works as upstream intended if APPSEMBLER_MULTI_TENANT_EMAILS is disabled.
     """
-    settings.FEATURES = {'APPSEMBLER_MULTI_TENANT_EMAILS': False}
+    settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'] = False
 
     with with_organization_context(site_color='blue1') as blue_org:
         blue_user = create_org_user(blue_org)
@@ -44,7 +44,7 @@ def test_get_user_by_username_or_email_multi_tenant(settings):
     """
     Ensure `get_user_by_username_or_email` works with APPSEMBLER_MULTI_TENANT_EMAILS is enabled.
     """
-    settings.FEATURES = {'APPSEMBLER_MULTI_TENANT_EMAILS': True}
+    settings.FEATURES['APPSEMBLER_MULTI_TENANT_EMAILS'] = True
 
     with with_organization_context(site_color='blue1') as blue_org:
         blue_user = create_org_user(blue_org)

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_site_config_client.py
@@ -105,9 +105,7 @@ def test_courseware_in_preview_mode(settings):
     """
     Support the Tahoe preview in `lms.djangoapps.courseware.access_utils.in_preview_mode`.
     """
-    settings.FEATURES = {
-        'PREVIEW_LMS_BASE': 'preview.example.com',
-    }
+    settings.FEATURES['PREVIEW_LMS_BASE'] = 'preview.example.com'
     with patch(
         'lms.djangoapps.courseware.access_utils.get_current_request_hostname'
     ) as mock_get_hostname:

--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_helpers.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_helpers.py
@@ -44,7 +44,7 @@ def user_with_org():
     ({}, {}, False, 'When no flag is enabled, the feature should be disabled'),
 ])
 def test_is_tahoe_idp_enabled(settings, global_flags, site_flags, should_be_enabled, message):
-    settings.FEATURES = global_flags
+    settings.FEATURES.update(global_flags)
     with override_site_config('admin', **site_flags):
         assert helpers.is_tahoe_idp_enabled() == should_be_enabled, message
 
@@ -75,13 +75,13 @@ def test_get_idp_register_url_with_next():
 
 
 def test_get_idp_form_url_with_tahoe_idp_disabled(settings):
-    settings.FEATURES = {'ENABLE_THIRD_PARTY_AUTH': True}
+    settings.FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
     with override_site_config('admin', ENABLE_TAHOE_IDP=False):
         assert not helpers.get_idp_form_url(Mock(), Mock(), Mock()), 'Only get a redirect URL when `tahoe-idp` is used'
 
 
 def test_get_idp_form_url_with_tahoe_tpa_disabled(settings):
-    settings.FEATURES = {'ENABLE_THIRD_PARTY_AUTH': False}
+    settings.FEATURES['ENABLE_THIRD_PARTY_AUTH'] = False
     with override_site_config('admin', ENABLE_TAHOE_IDP=True):
         url = helpers.get_idp_form_url(Mock(), Mock(), Mock())
 
@@ -89,7 +89,7 @@ def test_get_idp_form_url_with_tahoe_tpa_disabled(settings):
 
 
 def test_get_idp_form_url_for_login(settings):
-    settings.FEATURES = {'ENABLE_THIRD_PARTY_AUTH': True}
+    settings.FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
     with override_site_config('admin', ENABLE_TAHOE_IDP=True):
         url = helpers.get_idp_form_url(Mock(), 'login', '/home')
 
@@ -98,7 +98,7 @@ def test_get_idp_form_url_for_login(settings):
 
 @patch('openedx.core.djangoapps.appsembler.tahoe_idp.helpers.pipeline_running', Mock(return_value=False))
 def test_get_idp_form_url_for_register_without_pipeline(settings):
-    settings.FEATURES = {'ENABLE_THIRD_PARTY_AUTH': True}
+    settings.FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
 
     with override_site_config('admin', ENABLE_TAHOE_IDP=True):
         url = helpers.get_idp_form_url(None, 'register', '/home')
@@ -116,7 +116,7 @@ def test_get_idp_form_url_for_register_with_pipeline(settings):
     Upon registration, Open edX  auto-submits the frontend hidden registration form.
     Returning, None to avoid breaking an otherwise needed form submit.
     """
-    settings.FEATURES = {'ENABLE_THIRD_PARTY_AUTH': True}
+    settings.FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
     with override_site_config('admin', ENABLE_TAHOE_IDP=True):
         url = helpers.get_idp_form_url(None, 'register', '/home')
     assert not url, 'Return no URL when there is a running pipeline'

--- a/openedx/core/djangoapps/credentials/tests/test_tahoe_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_tahoe_utils.py
@@ -14,5 +14,5 @@ def test_tahoe_credentials_records_url(settings):
     """
     assert get_credentials_records_url(), 'By default a URL should be returned, otherwise upstream tests will break'
 
-    settings.FEATURES = {'TAHOE_ENABLE_CREDENTIALS': False}
+    settings.FEATURES['TAHOE_ENABLE_CREDENTIALS'] = False
     assert not get_credentials_records_url(), 'In Tahoe production credentials can be disabled'


### PR DESCRIPTION


## Change description

Fix tests that override `settings.FEATURES`. We should update `settings.FEATURES` in tests rather than override the whole object. Because sometimes, we make a change on another feature that affects tests indirectly. For example, disabling `edx-organization` fork will not be recognized by these tests because they loose the value of `TAHOE_SITES_USE_ORGS_MODELS`

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Related to https://appsembler.atlassian.net/browse/RED-3358

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
