### PR TITLE
SiteViewSet to use tahoe-sites

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/api.py
+++ b/openedx/core/djangoapps/appsembler/sites/api.py
@@ -13,7 +13,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from organizations.models import Organization
-from tahoe_sites.api import get_organization_user_by_email
+from tahoe_sites.api import get_organization_user_by_email, get_organization_for_user, get_site_by_organization
 from branding.api import get_base_url
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from rest_framework.views import APIView
@@ -49,7 +49,8 @@ class SiteViewSet(viewsets.ReadOnlyModelViewSet):
         queryset = Site.objects.exclude(id=settings.SITE_ID)
         user = self.request.user
         if not user.is_superuser:
-            queryset = queryset.filter(organizations__in=user.organizations.all())
+            organization = get_organization_for_user(user=user)
+            queryset = queryset.filter(id=get_site_by_organization(organization=organization).id)
         return queryset
 
 


### PR DESCRIPTION
## Change description

SiteViewSet to use `tahoe-sites`. This is needed when we de-fork `edx-organizations`

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues



## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
