### PR TITLE
Fix: cannot import tahoe-sites, not ready yet

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/helpers.py
+++ b/openedx/core/djangoapps/appsembler/settings/helpers.py
@@ -4,8 +4,6 @@ Helpers for the settings.
 
 from os import path
 
-from tahoe_sites.api import get_tahoe_sites_auth_backends
-
 
 def get_tahoe_theme_static_dirs(settings):
     """
@@ -76,10 +74,9 @@ def get_tahoe_multitenant_auth_backends(settings):
         upstream_backend_index = authentication_backends.index(upstream_user_model_backend)
 
         # Use multi-tenant Tahoe backends instead of the upstream EdxRateLimitedAllowAllUsersModelBackend backend.
-        authentication_backends = (
-            settings.AUTHENTICATION_BACKENDS[:upstream_backend_index] +
-            get_tahoe_sites_auth_backends() +
-            settings.AUTHENTICATION_BACKENDS[upstream_backend_index + 1:]
-        )
+        authentication_backends = settings.AUTHENTICATION_BACKENDS[:upstream_backend_index] + [
+            'tahoe_sites.backends.DefaultSiteBackend',
+            'tahoe_sites.backends.OrganizationMemberBackend',
+        ] + settings.AUTHENTICATION_BACKENDS[upstream_backend_index + 1:]
 
     return authentication_backends


### PR DESCRIPTION
## Change description

Fix: cannot import `tahoe-sites`, not ready yet. A bug I made while refactoring in favor of `tahoe-sites`

error message:
```
....
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py", line 8, in <module>
    from ..helpers import get_tahoe_theme_static_dirs, get_tahoe_multitenant_auth_backends
....
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/conf/__init__.py", line 171, in __init__
    raise ImproperlyConfigured("The %s setting must be a list or a tuple. " % setting)
django.core.exceptions.ImproperlyConfigured: The LOCALE_PATHS setting must be a list or a tuple.
```

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Related to https://github.com/appsembler/edx-platform/pull/1213

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
