### PR TITLE
Allow requests to (staging-)tahoe.appsembler.com/completion-aggregator/

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
@@ -52,6 +52,7 @@ def plugin_settings(settings):
             '/courses/yt_video_metadata',
             '/accounts/manage_user_standing',
             '/accounts/disable_account_ajax',
+            '/completion-aggregator/',  # :(  no /api/ in that API path
         ]
 
     settings.LMS_BASE = settings.ENV_TOKENS.get('LMS_BASE')


### PR DESCRIPTION

## Change description

Add /completion-aggregator/ to path prefixes in MAIN_SITE_REDIRECT_WHITELIST
It's helpful for shared code for PS integrations to have access to this API, without having to use a customer domain.

This API isn't accessible with a Tahoe API token, and we only use OAuth2 client applications for trusted/Appsembler-controlled code.

PS will be using this with the Data Pipeline Integrations OAuth2 Application on [staging](https://staging-tahoe.appsembler.com/admin/oauth2_provider/application/5/) and [production](https://tahoe.appsembler.com/admin/oauth2_provider/application/7/), from a Cloud Function in the Tahoe Data Integrations GCP project.

Also, while we're in there we should update our naming to use _ALLOWLIST so [I'll make another PR](https://github.com/appsembler/edx-platform/pull/1257) for that. 




## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/BLACK-2659

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
