### PR TITLE
bump site-configuration-client==0.2.3

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -25,5 +25,5 @@ google-cloud-storage==1.32.0
 tahoe-idp==2.0.0
 tahoe-sites==1.3.1
 tahoe-lti==0.3.0
-site-configuration-client==0.2.2
+site-configuration-client==0.2.3
 analytics-python==1.4.0  # RED-2969: To enable sync_mode for workers server


### PR DESCRIPTION
support for `integration` value in site config
