### PR TITLE
migrate_transcripts: --all-courses now means "active courses"

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_migrate_transcripts.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_migrate_transcripts.py
@@ -2,7 +2,7 @@
 """
 Tests for course transcript migration management command.
 """
-
+from unittest.mock import Mock
 
 import itertools
 import logging
@@ -80,7 +80,18 @@ class TestArgParsing(TestCase):
             call_command('migrate_transcripts', '--course-id', 'invalid-course')
 
 
+def get_all_courses():
+    """
+    Mock get_active_courses()
+    """
+    return [course.id for course in modulestore().get_course_summaries()]
+
+
 @ddt.ddt
+@patch(
+    'contentstore.management.commands.migrate_transcripts.get_active_courses_keys',
+    Mock(side_effect=get_all_courses),
+)
 class TestMigrateTranscripts(ModuleStoreTestCase):
     """
     Tests migrating video transcripts in courses from contentstore to django storage


### PR DESCRIPTION
Fixes for the following playbook: https://appsembler.atlassian.net/l/cp/d2Nim7gF