### PR TITLE
bump site-configuration-client==0.2.4 to set Studio Tahoe 2.0 caching to 300sec

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -26,5 +26,5 @@ google-cloud-storage==1.32.0
 tahoe-idp==2.0.0
 tahoe-sites==1.3.2
 tahoe-lti==0.3.0
-site-configuration-client==0.2.3
+site-configuration-client==0.2.4
 analytics-python==1.4.0  # RED-2969: To enable sync_mode for workers server


### PR DESCRIPTION
limit caching timeout when unset RED-3420

### TODO
 - [ ] Test on devstack