### PR TITLE
Fix requirements

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -89,7 +89,7 @@ edx-organizations
 edx-proctoring>=2.0.1
 edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed
 edx-rest-api-client
-https://github.com/appsembler/edx-search/archive/1.3.4-appsembler3.tar.gz  # edx-search
+edx-search
 edx-sga
 edx-submissions
 edx-toggles                         # Feature toggles management
@@ -164,7 +164,7 @@ super-csv                           # Generic CSV processor
 unicodecsv                          # Easier support for CSV files with unicode text
 user-util                           # Functionality for retiring users (GDPR compliance)
 web-fragments                       # Provides the ability to render fragments of web pages
-XBlock==1.2.2                              # Courseware component architecture
+XBlock                              # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.


### PR DESCRIPTION
## Change description

Fix requirements

Nutmeg upstream vs ours
----

```
git diff edx/open-release/nutmeg.master shadinaif/upgrade-to-nutmeg -- requirements
```

result: `appsembler.tx`t file. Plus:
```
b/requirements/edx/base.in
-edx-search
+https://github.com/appsembler/edx-search/archive/1.3.4-appsembler3.tar.gz  # edx-search
-XBlock                              # Courseware component architecture
+XBlock==1.2.2                              # Courseware component architecture
```

Safe to accept thiers (we already did that in the txt files)

appsembler.txt main vs our Nutmeg
----

```
git diff shadinaif/upgrade-to-nutmeg main requirements/edx/appsembler.txt
```

result:
```
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt

+# Patched upstream packages
+https://github.com/edx-solutions/xblock-google-drive/archive/589d9f51f9b.tar.gz  # v0.2.0 but the repo has no tags
+https://github.com/appsembler/edx-ora2/archive/2.7.6-appsembler.1.tar.gz
+https://github.com/appsembler/edx-sga/archive/v0.11.0.appsembler2.tar.gz
+https://github.com/appsembler/edx-proctoring/archive/v2.4.0-appsembler1.tar.gz
```

* edx-proctoring not needed when we use dockers
* edx-sga not needed when we use dockers
* edx-ora2 : we need to merge [this PR](https://github.com/openedx/edx-ora2/pull/1823) then upgrade the version
* xblock-google-drive not needed

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Related to: https://appsembler.atlassian.net/browse/RED-3364

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
