### PR TITLE
remove_site: fix CMS role IntegrityError + refactoring

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/management/commands/remove_site.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/remove_site.py
@@ -30,10 +30,10 @@ class Command(BaseCommand):
         organization_domain = options['domain']
 
         self.stdout.write('Removing "%s" in progress...' % organization_domain)
-        organization = self._get_site(organization_domain)
+        site = self._get_site(organization_domain)
 
         with transaction.atomic():
-            delete_site(organization)
+            delete_site(site)
 
             if not options['commit']:
                 transaction.set_rollback(True)

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -102,7 +102,8 @@ class CreateDevstackSiteCommandTestCase(TestCase):
         with patch.object(Command, 'congrats') as mock_congrats:
             call_command('create_devstack_site', self.name, 'localhost')
 
-        mock_congrats.assert_called_once()  # Ensure that congrats message is printed
+        assert mock_congrats.called  # Ensure that congrats message is printed
+        assert mock_congrats.call_count == 1  # Ensure that congrats message is printed once
 
         # Ensure objects are created correctly.
         assert Site.objects.get(domain=self.site_name)

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_commands.py
@@ -1,6 +1,6 @@
 import hashlib
 import os
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open, Mock
 from io import StringIO
 
 from django.conf import settings
@@ -9,11 +9,13 @@ from django.contrib.sites.models import Site
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import override_settings, TestCase
+
 from tahoe_sites.api import (
     create_tahoe_site_by_link,
     get_organization_for_user,
     get_users_of_organization,
     get_uuid_by_organization,
+    get_organization_by_site,
 )
 from tahoe_sites.tests.utils import create_organization_mapping
 
@@ -160,6 +162,10 @@ class TestCandidateSitesCleanupCommand(TestCase):
     'DISABLE_COURSE_CREATION': False,
     'ENABLE_CREATOR_GROUP': True,
 })
+@patch(  # Avoid CMS-related import issues in tests
+    'openedx.core.djangoapps.appsembler.sites.utils.remove_course_creator_role',
+    Mock()
+)
 class RemoveSiteCommandTestCase(TestCase):
     """
     Test ./manage.py lms remove_site mysite
@@ -182,17 +188,23 @@ class RemoveSiteCommandTestCase(TestCase):
         """
         deleted_domain = '{}.localhost:18000'.format(self.to_be_deleted)
         remained_domain = '{}.localhost:18000'.format(self.shall_remain)
+        assert SiteConfiguration.objects.count() == 2, 'there are two sites'
+        remained_site = Site.objects.get(domain=remained_domain)
 
+        # TODO: Re-produce the error we face in staging
+        to_delete_site = Site.objects.get(domain=deleted_domain)
+        to_delete_organization = get_organization_by_site(to_delete_site)
+        users = get_users_of_organization(to_delete_organization)
+        assert len(users), 'Ensure the site has users'
         call_command('remove_site', deleted_domain, commit=True)
 
         # Ensure objects are removed correctly.
         assert not Site.objects.filter(domain=deleted_domain).exists()
-        site = Site.objects.get(domain=remained_domain)
 
-        assert SiteConfiguration.objects.count() == 1
-        assert SiteConfiguration.objects.get(site=site)
+        assert SiteConfiguration.objects.count() == 1, 'One site is deleted'
+        assert SiteConfiguration.objects.get(site=remained_site), 'remained_domain site config is kept'
 
-        assert SiteTheme.objects.filter(site=site).count() == site.themes.count()
+        assert SiteTheme.objects.filter(site=remained_site).count() == remained_site.themes.count()
 
     def test_remove_devstack_site_rollback(self):
         """

--- a/openedx/core/djangoapps/appsembler/sites/tests/test_site_delete_utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/tests/test_site_delete_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 import tahoe_sites.api
 from django.contrib.auth import get_user_model
@@ -22,6 +24,14 @@ from openedx.core.djangoapps.appsembler.sites.utils import (
     get_models_using_course_key,
     delete_organization_courses,
 )
+
+
+def delete_site_with_patched_cms_imports(red_site):
+    """
+    Delete a site without running the CMS-related code.
+    """
+    with patch('openedx.core.djangoapps.appsembler.sites.utils.remove_course_creator_role'):
+        delete_site(red_site)
 
 
 @pytest.fixture
@@ -49,7 +59,7 @@ def test_delete_site(make_site):
     Test `delete_site` happy path.
     """
     red_site = make_site('red')
-    delete_site(red_site)
+    delete_site_with_patched_cms_imports(red_site)
 
     with pytest.raises(User.DoesNotExist):
         User.objects.get(username='red')
@@ -63,7 +73,7 @@ def test_delete_one_site_keeps_another(make_site):
     red_site = make_site('red')
     make_site('blue')
 
-    delete_site(red_site)
+    delete_site_with_patched_cms_imports(red_site)
 
     with pytest.raises(User.DoesNotExist):
         User.objects.get(username='red')


### PR DESCRIPTION
Fixes https://appsembler.atlassian.net/l/cp/fPgy6ZWi by manually deleting stray tables: https://github.com/appsembler/scripts/pull/167

### Error

```
django.db.utils.IntegrityError: (1451, 'Cannot delete or update a parent row: 
a foreign key constraint fails (`edxapp`.`course_creators_coursecreator`, 
CONSTRAINT `course_creators_coursec_user_id_46ea06ad28f0be3b_fk_auth_user_id` 
FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`))')
```