### PR TITLE
fix: empty signature added after every certificate saving (#30912)

### DIFF
--- a/cms/static/js/certificates/models/certificate.js
+++ b/cms/static/js/certificates/models/certificate.js
@@ -43,7 +43,7 @@ define([
             initialize: function(attributes, options) {
                 // Set up the initial state of the attributes set for this model instance
                 this.canBeEmpty = options && options.canBeEmpty;
-                if (options.add) {
+                if (options.add && !attributes.signatories) {
                     // Ensure at least one child Signatory model is defined for any new Certificate model
                     attributes.signatories = new SignatoryModel({certificate: this});
                 }


### PR DESCRIPTION
Cherrypicking from upstream

A new behaviour:

- Empty signature is still added when initially create a certificate;
- Empty signature isn't added when certificate has at least one signature.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
