### PR TITLE
Add legacy /user_api/ prefix to MAIN_SITE_REDIRECT_ALLOWLIST

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
@@ -45,6 +45,7 @@ def plugin_settings(settings):
         # from the redirect mechanics.
         settings.MAIN_SITE_REDIRECT_ALLOWLIST = [
             '/api/',
+            '/user_api/',  # still used by EdxRestAPIClient in integrations
             '/admin',
             'oauth',  # TODO: Add slashes during Nutmeg upgrade since this requires a lot of QA
             'status',  # TODO: Add slashes during Nutmeg upgrade since this requires a lot of QA


### PR DESCRIPTION
## Change description

The change in #1257 broke the Open Badges PS integration in use by Kong, since it uses EdxRestAPIClient whose version compatible with Juniper relies on the legacy /user_api URLs.  Don't redirect /user_api/ to the Tahoe marketing site.



## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/BLACK-2673

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
