### PR TITLE
Fix get_or_create_enrollment to save the correct key

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1302,6 +1302,15 @@ class CourseEnrollment(models.Model):
         if user.id is None:
             user.save()
 
+        try:
+            # To avoid running into MongoDB vs. MySQL case sensitivity issues, and to avoid having
+            # CourseEnrollment.course_id returning the ID with the wrong letters case; we convert the key to
+            # the correct letter case one
+            course_key = CourseOverview.get_from_id(course_key).id
+        except CourseOverview.DoesNotExist:
+            # We allow enrollments to non-existence courses!
+            pass
+
         enrollment, __ = cls.objects.get_or_create(
             user=user,
             course_id=course_key,


### PR DESCRIPTION
## Change description

Fix `get_or_create_enrollment` to save the correct key

The last assertion in the added test will fail without the fix
```python
self.assertEqual(enrollment.course_id, course.id)
```

**Note:** the test is a little bit complicated because SQLite does not support case-insensitive search with unicode. See comments in the test

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Related issue: https://appsembler.atlassian.net/browse/RED-3435

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
