### PR TITLE
delete multiple sites at once; fixes for CMS-modules

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_lms.py
@@ -64,6 +64,13 @@ def plugin_settings(settings):
             tpa_admin_app_name,
         ]
 
+    settings.INSTALLED_APPS += [
+        'user_tasks',  # Release upgrade note: This line can be removed if it causes errors,
+                       #                       but the `remove_site` must be tested afterwards
+                       # `user_tasks` is a CMS-only app, but adding it in LMS to fix an error with `remove_site` command
+                       # `user_tasks` helps to manage of user-triggered async tasks (course import/export, etc.)
+    ]
+
     settings.CORS_ORIGIN_ALLOW_ALL = True
 
     settings.CORS_ALLOW_HEADERS = (

--- a/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
+++ b/openedx/core/djangoapps/appsembler/settings/tests/test_settings.py
@@ -23,6 +23,7 @@ def fake_production_settings(settings):
     settings.AUTH_TOKENS = {}
     settings.CELERY_QUEUES = {}
     settings.ALTERNATE_QUEUE_ENVS = []
+    settings.INSTALLED_APPS = settings.INSTALLED_APPS.copy()  # Prevent polluting the original list
     settings.FEATURES = settings.FEATURES.copy()  # Prevent polluting other tests.
     settings.ENV_TOKENS = {
         'LMS_BASE': 'fake-lms-base',

--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -518,8 +518,14 @@ def delete_organization_courses(organization):
     for course in get_organization_courses({'id': organization.id}):
         course_keys.append(course['course_id'])
 
-    for model_class, field_name in get_models_using_course_key():
-        print('Deleting models of', model_class.__name__, 'with field', field_name)
+    model_classes = get_models_using_course_key()
+
+    print('Deleting course related models:', ', '.join([
+        '{model}.{field}'.format(model=model_class.__name__, field=field_name)
+        for model_class, field_name in model_classes
+    ]))
+
+    for model_class, field_name in model_classes:
         objects_to_delete = model_class.objects.filter(**{
             '{field_name}__in'.format(field_name=field_name): course_keys,
         })


### PR DESCRIPTION
### Changes

This should make a production-ready site deletion in LMS.

CMS course deletion is still not complete: https://github.com/appsembler/edx-platform/pull/1185

Other services such as FusionAuth, SiteConfig, etc will be handled separately.

### Tests
Not adding new tests due to excessive manual testing on staging. Single-domain remove_site is already covered.