### PR TITLE
remove_stray_courses: remove course references without organization linked

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/api.py
+++ b/openedx/core/djangoapps/appsembler/sites/api.py
@@ -30,11 +30,11 @@ from openedx.core.djangoapps.appsembler.sites.serializers import (
     RegistrationSerializer,
     AlternativeDomainSerializer,
 )
-from openedx.core.djangoapps.appsembler.sites.utils import (
-    delete_site,
+from .utils import (
     get_customer_files_storage,
     to_safe_file_name,
 )
+from .deletion_utils import delete_site
 
 log = logging.Logger(__name__)
 

--- a/openedx/core/djangoapps/appsembler/sites/deletion_utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/deletion_utils.py
@@ -1,0 +1,157 @@
+"""
+Site and courses deletion utils.
+"""
+from django.db import transaction
+
+import tahoe_sites.api
+from django.apps import apps
+
+import beeline
+from opaque_keys.edx.django.models import CourseKeyField, LearningContextKeyField
+
+from common.djangoapps.util.organizations_helpers import get_organization_courses
+
+from organizations.models import OrganizationCourse
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+
+def remove_course_creator_role(users):
+    """
+    Remove course creator role to fix `delete_site` issue.
+
+    This will fail in when running tests from within the LMS because the CMS migrations
+    don't run during tests. Patch this function to avoid such errors.
+    TODO: RED-2853 Remove this helper when AMC is removed
+          This helper is being replaced by `update_course_creator_role_for_cms` which has unit tests.
+    """
+    from cms.djangoapps.course_creators.models import CourseCreator  # Fix LMS->CMS imports.
+    from student.roles import CourseAccessRole  # Avoid circular import.
+    CourseCreator.objects.filter(user__in=users).delete()
+    CourseAccessRole.objects.filter(user__in=users).delete()
+
+
+@beeline.traced(name="delete_site")
+def delete_site(site):
+    from third_party_auth.models import SAMLConfiguration  # local import to avoid import-time errors
+
+    print('Deleting SiteConfiguration of', site)
+    site.configuration.delete()
+
+    print('Deleting theme of', site)
+    site.themes.all().delete()
+
+    organization = tahoe_sites.api.get_organization_by_site(site)
+
+    print('Deleting users of', site)
+    users = tahoe_sites.api.get_users_of_organization(organization, without_inactive_users=False)
+    remove_course_creator_role(users)
+
+    # Prepare removing users by avoiding on_delete=models.PROTECT error
+    # SAMLConfiguration will be deleted with `site.delete()`
+    SAMLConfiguration.objects.filter(changed_by__in=users).update(changed_by=None)
+
+    users.delete()
+
+    print('Deleting courses of', site)
+    delete_organization_courses(organization)
+
+    print('Deleting organization', organization)
+    organization.delete()
+
+    print('Deleting site', site)
+    site.delete()
+
+
+def get_models_using_course_key():
+    """
+    Get all course related model classes.
+    """
+    course_key_field_names = {
+        'course_key',
+        'course_id',
+    }
+
+    models_with_course_key = {
+        (CourseOverview, 'id'),  # The CourseKeyField with a `id` name. Hard-coding it for simplicity.
+        (OrganizationCourse, 'course_id'),  # course_id is CharField
+    }
+
+    model_classes = apps.get_models()
+    for model_class in model_classes:
+        for field_name in course_key_field_names:
+            field_object = getattr(model_class, field_name, None)
+            if field_object:
+                field_definition = getattr(field_object, 'field', None)
+                if field_definition and isinstance(field_definition, (CourseKeyField, LearningContextKeyField)):
+                    models_with_course_key.add(
+                        (model_class, field_name,)
+                    )
+
+    return models_with_course_key
+
+
+def delete_organization_courses(organization):
+    """
+    Delete all course related model instances.
+    """
+    course_keys = []
+
+    for course in get_organization_courses({'id': organization.id}):
+        course_keys.append(course['course_id'])
+
+    delete_related_models_of_courses(course_keys)
+
+
+def delete_related_models_of_courses(course_keys):
+    model_classes = get_models_using_course_key()
+
+    print('Deleting course related models:', ', '.join([
+        '{model}.{field}'.format(model=model_class.__name__, field=field_name)
+        for model_class, field_name in model_classes
+    ]))
+
+    for model_class, field_name in model_classes:
+        objects_to_delete = model_class.objects.filter(**{
+            '{field_name}__in'.format(field_name=field_name): course_keys,
+        })
+        objects_to_delete.delete()
+
+
+def get_courses_keys_without_organization_linked(limit=None, only_active_links=True):
+    """
+    Get keys of stray courses.
+    """
+    course_links = OrganizationCourse.objects.all()
+    if only_active_links:
+        course_links = course_links.filter(active=True)
+
+    queryset = CourseOverview.objects.exclude(
+        id__in=course_links.values_list('course_id', flat=True),
+    )
+
+    course_keys = queryset.values_list(
+        'id', flat=True
+    )
+
+    course_keys_list = [str(course_key) for course_key in course_keys]
+    if limit:
+        course_keys_list = course_keys_list[:limit]
+
+    return course_keys_list
+
+
+def remove_stray_courses_from_mysql(limit, commit):
+    """
+    Removes courses without linked organization from LMS MySQL database.
+
+    The MongoDB courses won't be removed with this command.
+    """
+    course_keys = get_courses_keys_without_organization_linked(limit=limit)
+    print('Deleting [commit={}] courses: \n {}'.format(commit, '\n '.join(course_keys)))
+
+    with transaction.atomic():
+        delete_related_models_of_courses(course_keys)
+        print('Finished [commit={}] courses.'.format(commit))
+
+        if not commit:
+            transaction.set_rollback(True)

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/remove_site.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/remove_site.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 from django.contrib.sites.models import Site
 from django.db import transaction
 
-from openedx.core.djangoapps.appsembler.sites.utils import delete_site
+from ...deletion_utils import delete_site
 
 
 class Command(BaseCommand):

--- a/openedx/core/djangoapps/appsembler/sites/management/commands/remove_stray_courses_from_mysql.py
+++ b/openedx/core/djangoapps/appsembler/sites/management/commands/remove_stray_courses_from_mysql.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand
+
+from ...deletion_utils import remove_stray_courses_from_mysql
+
+
+class Command(BaseCommand):
+    """
+    Bulk removal of courses without an organization linked (aka stray courses).
+
+    This only works for MySQL database.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--limit',
+            help='Maximum number of courses to delete',
+            default=1,
+            type=int,
+        )
+
+        parser.add_argument(
+            '--commit',
+            help='Otherwise, the transaction would be rolled back.',
+            default=False,
+            action='store_true',
+            dest='commit',
+        )
+
+    def handle(self, *args, **options):
+        remove_stray_courses_from_mysql(limit=options['limit'], commit=options['commit'])


### PR DESCRIPTION
It happens that we have courses without a specific organization linked, either due to errors or old data.


### TODO
 - [ ] Test on staging
 - [ ] Add unit tests