### PR TITLE
Increase page limit from 20 to 100 in course discovery view

### DIFF
--- a/lms/static/js/discovery/models/search_state.js
+++ b/lms/static/js/discovery/models/search_state.js
@@ -11,7 +11,7 @@
         return Backbone.Model.extend({
 
             page: 0,
-            pageSize: 20,
+            pageSize: 100,  // Tahoe: fix a bug related to Course Access Groups - RED-3598
             searchTerm: '',
             terms: {},
             jqhxr: null,


### PR DESCRIPTION
## Change description

Refix an old bug by applying the same workaround but in the correct line of code. The bug is related to **Course Access Groups** making the course discovery view showing the wrong number of courses

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Related to: https://github.com/appsembler/edx-platform/pull/1041
Related to: https://appsembler.atlassian.net/browse/RED-3598

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
