### PR TITLE
Fix addition of tahoe_user_metadata in events emitted by Celery workers

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
@@ -12,8 +12,11 @@ import sys
 
 
 def is_not_lms():
-    """Utility function: return False if not running in the LMS."""
-    return os.getenv("SERVICE_VARIANT") != 'lms'
+    """Utility function: return False if not running in the LMS unless testing."""
+    return (
+        os.getenv("SERVICE_VARIANT") != 'lms' and
+        'pytest ' not in ' '.join(sys.argv)
+    )
 
 
 def is_not_runserver():

--- a/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
@@ -11,11 +11,22 @@ import os
 import sys
 
 
-def is_not_lms():
-    """Utility function: return False if not running in the LMS unless testing."""
+def is_lms():
+    """Utility function: return True if running in the LMS."""
+    return os.getenv("SERVICE_VARIANT") == 'lms'
+
+
+def is_lms_test():
+    """
+    Utility function: return False if this is in a test.
+
+    It's ugly but needed to run in LMS tests and not in CMS tests,
+    to keep SQL query counts as expected.
+    """
+    argstr = ' '.join(sys.argv)
     return (
-        os.getenv("SERVICE_VARIANT") != 'lms' and
-        'pytest ' not in ' '.join(sys.argv)
+        'pytest ' in argstr and
+        'cms/' not in argstr
     )
 
 

--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -166,10 +166,10 @@ class TahoeUserMetadataProcessor(object):
         # WARNING:
         # We have to be careful to not add SQL queries that would require updating upstream tests
         # which count SQL queries; e.g., `cms.djangoapps.contentstore.views.tests.test_course_index)
-        # currently we can do this by only enabling the event processor for LMS
-        if app_variant.is_not_lms():  # we don't care about user metadata for Studio, at this point
+        # Currently we can do this by only enabling the event processor for LMS.
+        # We don't care about user metadata for Studio, at this point.
+        if not (app_variant.is_lms() or app_variant.is_lms_test()):
             return event
-
         # eventtracking Processors are loaded before apps are ready
         from django.contrib.auth.models import User
 

--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -168,7 +168,7 @@ class TahoeUserMetadataProcessor(object):
         # which count SQL queries; e.g., `cms.djangoapps.contentstore.views.tests.test_course_index)
         # Currently we can do this by only enabling the event processor for LMS.
         # We don't care about user metadata for Studio, at this point.
-        if not (app_variant.is_lms() or app_variant.is_lms_test()):
+        if not app_variant.is_lms() and not app_variant.is_lms_test():
             return event
         # eventtracking Processors are loaded before apps are ready
         from django.contrib.auth.models import User

--- a/openedx/core/djangoapps/appsembler/eventtracking/tests/test_tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tests/test_tahoeusermetadata.py
@@ -1,6 +1,8 @@
 """Test the appsembler.eventtracking.tahoeusermetadata module."""
 
+from copy import deepcopy
 import factory
+import json
 from mock import MagicMock, patch
 import pytest
 
@@ -20,17 +22,28 @@ BASE_EVENT_WITH_CONTEXT = {
     "data": {}
 }
 
+TAHOE_USER_METADATA_CONTEXT = {
+    "tahoe_user_metadata": {
+        "registration_extra": {"custom_reg_field": "value1"}
+    }
+}
+
 
 class UserProfileWithMetadataFactory(UserProfileFactory):
     """Factory for UserProfile sequence with some tahoe_user_metadata."""
-    # TODO: a Sequence is a bit of a silly way to set things up.
-    meta = factory.Sequence(lambda n: {
-        "tahoe_user_metadata": {
-            "some_other_key": "some_other_val",
-            "registration_extra": {"custom_reg_field": "value{n}"}
-        }
-    } if n == 1 else {"tahoe_user_metadata": {}}
-    )
+
+    def _meta_val(n):
+        """Return a JSON meta value for Sequence member"""
+        reg_field_value = "value{}".format(n % 2)
+        meta_dict = {
+            "tahoe_idp_metadata": {
+                "registration_additional": {"custom_reg_field": reg_field_value}
+            }
+        } if n % 2 == 1 else {"tahoe_idp_metadata": {}}
+
+        return json.dumps(meta_dict)
+
+    meta = factory.Sequence(_meta_val)
 
 
 class UserWithTahoeMetadataFactory(UserFactory):
@@ -55,22 +68,33 @@ def processor():
 @pytest.mark.django_db
 def test_for_metadata_no_cache(users, base_event, processor):
     """Test happy path, Processor returns the event with user metadata in `context`."""
+    event_with_metadata = deepcopy(base_event)
+    event_with_metadata.update(context=TAHOE_USER_METADATA_CONTEXT)
+
     with patch(EVENTTRACKING_MODULE + '.tahoeusermetadata.get_current_user', MagicMock()) as mocked:
-        mocked.return_value = users[0]
-        base_event.update(context={
-            "tahoe_user_metadata": {
-                "some_other_key": "some_other_val",
-                "registration_extra": {"custom_reg_field": "value0"}
-            }
-        })
+        mocked.return_value = users[1]
         event = processor(base_event)
-        assert event == base_event
+        assert event == event_with_metadata
 
 
 @pytest.mark.django_db
 def test_no_context_added_if_no_metadata_of_interest(users, base_event, processor):
     """Test happy path, Processor returns the event with user metadata in `context`."""
     with patch(EVENTTRACKING_MODULE + '.tahoeusermetadata.get_current_user', MagicMock()) as mocked:
-        mocked.return_value = users[1]
+        mocked.return_value = users[0]
         event = processor(base_event)
         assert event == base_event
+
+
+@pytest.mark.django_db
+def test_get_user_from_db_when_not_avail_from_request(users, base_event, processor):
+    event_with_metadata = deepcopy(base_event)
+    event_with_metadata.update(context=TAHOE_USER_METADATA_CONTEXT)
+
+    with patch(EVENTTRACKING_MODULE + '.tahoeusermetadata.get_current_user', MagicMock()) as mocked:
+        mocked.return_value = None
+        event_with_user_id = deepcopy(base_event)
+        event_with_user_id.update({'user_id': users[1].id})
+        event_with_metadata.update({'user_id': users[1].id})
+        event = processor(event_with_user_id)
+        assert event == event_with_metadata

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -76,3 +76,21 @@ def get_site_config_for_event(event_props):
             log.exception('get_site_config_for_event: Cannot get site config for event. props=`%s`', repr(event_props))
             raise EventProcessingError(e)
     return site_configuration
+
+
+def get_user_id_from_event(event_props):
+    """
+    Get a user id from event properties.
+
+    For events emitted without a request. This would generally be an event emitted
+    by a Celery worker, e.g., `edx.bi.completion.*` or `.grade_calculated` events.
+    """
+
+    user_id = None
+    if event_props.get('user_id')is not None:
+        user_id = event_props['user_id']
+    else:
+        context = event_props.get('context')
+        if context.get('user_id') is not None:
+            user_id = context['user_id']
+    return user_id

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -87,10 +87,10 @@ def get_user_id_from_event(event_props):
     """
 
     user_id = None
-    if event_props.get('user_id')is not None:
+    if event_props.get('user_id') is not None:
         user_id = event_props['user_id']
     else:
         context = event_props.get('context')
-        if context.get('user_id') is not None:
-            user_id = context['user_id']
+        if context is not None:
+            user_id = context.get('user_id')
     return user_id


### PR DESCRIPTION
## Change description

Tracking events emitted by Celery workers or otherwise without a request can't get a User from Django crum.   Add util method to try to get this from the event itself.  Use this method to get a User to add Tahoe user metadata (like custom reg field data synced from IdP) to the events.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/BLACK-2783

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
