### PR TITLE
util method to determine if being run in appsembler.eventtracking tests

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
@@ -7,6 +7,7 @@ Stevedore swallows errors and you are none the wiser :(...
 So, don't add imports to this that will fail before Django has fully loaded.
 """
 
+import inspect
 import os
 import sys
 
@@ -16,20 +17,22 @@ def is_lms():
     return os.getenv("SERVICE_VARIANT") == 'lms'
 
 
-def is_lms_test():
+def is_self_test():
     """
-    Utility function: return False if this is in a test.
+    Utility function: return True if this is in an LMS test from within the
+    openedx.core.djangoapps.appsembler.eventtracking.test_tahoeusermetadata module.
 
-    It's ugly but needed to run in LMS tests and not in CMS tests,
-    to keep SQL query counts as expected.
+    It's ugly but needed to only run in its own tests, to keep SQL query counts as expected
+    in other tests.
     """
-    argstr = ' '.join(sys.argv)
-    return (
-        'pytest ' in argstr and
-        'cms/' not in argstr
+    callstack = inspect.stack()
+    stack_filenames = [fi.filename for fi in callstack]
+    is_own_package_test = any(
+        ['appsembler/eventtracking/tests/' in fi for fi in stack_filenames]
     )
+    return is_own_package_test
 
 
 def is_not_runserver():
-    """Utility function: return False if not runserver command."""
+    """Utility function: return True if not a runserver command."""
     return 'runserver' not in sys.argv

--- a/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
@@ -13,8 +13,12 @@ import sys
 
 
 def is_lms():
-    """Utility function: return True if running in the LMS."""
+    """Utility function: return True if running in the LMS. And not a test."""
     return os.getenv("SERVICE_VARIANT") == 'lms'
+
+
+def is_test():
+    return 'pytest ' not in ' '.join(sys.argv)
 
 
 def is_self_test():

--- a/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/app_variant.py
@@ -18,7 +18,7 @@ def is_lms():
 
 
 def is_test():
-    return 'pytest ' not in ' '.join(sys.argv)
+    return 'pytest ' in ' '.join(sys.argv)
 
 
 def is_self_test():

--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -169,8 +169,11 @@ class TahoeUserMetadataProcessor(object):
         # We should not let this run in any CMS tests and any LMS tests other than from
         # within openedx/core/djangoapps/eventtracking/  Ugh.
         # We don't care about user metadata for Studio, at this point.
-        if not app_variant.is_lms() and not app_variant.is_self_test():
-            return event
+        if not app_variant.is_lms():  # this returns False if a test in LMS
+            if app_variant.is_test():
+                if not app_variant.is_self_test():
+                    return event
+
         # eventtracking Processors are loaded before apps are ready
         from django.contrib.auth.models import User
 

--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -166,9 +166,10 @@ class TahoeUserMetadataProcessor(object):
         # WARNING:
         # We have to be careful to not add SQL queries that would require updating upstream tests
         # which count SQL queries; e.g., `cms.djangoapps.contentstore.views.tests.test_course_index)
-        # Currently we can do this by only enabling the event processor for LMS.
+        # We should not let this run in any CMS tests and any LMS tests other than from
+        # within openedx/core/djangoapps/eventtracking/  Ugh.
         # We don't care about user metadata for Studio, at this point.
-        if not app_variant.is_lms() and not app_variant.is_lms_test():
+        if not app_variant.is_lms() and not app_variant.is_self_test():
             return event
         # eventtracking Processors are loaded before apps are ready
         from django.contrib.auth.models import User


### PR DESCRIPTION
## Change description

I don't know why, but GitHub merged my last PR #1311 while there were tests failing.  These were other LMS tests failing because of incorrect SQL query counts caused by queries in TahoeUserMetadataProcessor calls on event emissions.  This change isolates TahoeUserMetadataProcessor from running outside of LMS and running only appsembler.eventtracking tests.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/BLACK-2783

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
