### PR TITLE
TahoeUserMetadataProcessor check in event.context not just context, for user_id

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -169,10 +169,13 @@ class TahoeUserMetadataProcessor(object):
         # We should not let this run in any CMS tests and any LMS tests other than from
         # within openedx/core/djangoapps/eventtracking/  Ugh.
         # We don't care about user metadata for Studio, at this point.
+        # Allow to run in LMS or it's own LMS env tests.
         if not app_variant.is_lms():  # this returns False if a test in LMS
             if app_variant.is_test():
-                if not app_variant.is_self_test():
+                if not app_variant.is_self_test():  # expensive, make sure it's a test first.
                     return event
+            else:
+                return event
 
         # eventtracking Processors are loaded before apps are ready
         from django.contrib.auth.models import User

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -90,7 +90,10 @@ def get_user_id_from_event(event_props):
     if event_props.get('user_id') is not None:
         user_id = event_props['user_id']
     else:
-        context = event_props.get('context')
-        if context is not None:
+        context = event_props.get('context', {})
+        event_context = event_props.get('event', {}).get('context', {})
+        if context.get('user_id') is not None:
             user_id = context.get('user_id')
+        if event_context.get('user_id') is not None:
+            user_id = event_context.get('user_id')
     return user_id


### PR DESCRIPTION
## Change description

Some Celery-emitted events only have user_id in tracking event JSON event.context, not context.  Allow for this in TahoeUserMetadataProcessor

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/BLACK-2783

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
