### PR TITLE
appsembler.eventtracking.utils look in event['event'] for user_id, too

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -87,19 +87,19 @@ def get_user_id_from_event(event_props):
     """
 
     user_id = None
-    if event_props.get('user_id') is not None:
+    if event_props.get('user_id'):
         user_id = event_props['user_id']
     else:
         event = event_props.get('event', {})
         context = event_props.get('context', {})
         event_context = event.get('context', {})
-        if context.get('user_id') is not None:
+        if context.get('user_id'):
             user_id = context.get('user_id')
             return user_id
-        if event.get('user_id') is not None:
+        if event.get('user_id'):
             user_id = event.get('user_id')
             return user_id
-        if event_context.get('user_id') is not None:
+        if event_context.get('user_id'):
             user_id = event_context.get('user_id')
             return user_id
     return user_id

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -90,10 +90,16 @@ def get_user_id_from_event(event_props):
     if event_props.get('user_id') is not None:
         user_id = event_props['user_id']
     else:
+        event = event_props.get('event', {})
         context = event_props.get('context', {})
-        event_context = event_props.get('event', {}).get('context', {})
+        event_context = event.get('context', {})
         if context.get('user_id') is not None:
             user_id = context.get('user_id')
+            return user_id
+        if event.get('user_id') is not None:
+            user_id = event.get('user_id')
+            return user_id
         if event_context.get('user_id') is not None:
             user_id = event_context.get('user_id')
+            return user_id
     return user_id


### PR DESCRIPTION
## Change description

Because of the wonderful multiplicity of event formats, we must look for a user_id for events without a user in  a request
in:
 * event['user_id']
 * event['context']['user_id']
 * event['event']['context']['user_id']
 * and also (added here) event['event']['user_id']

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

[BLACK-2635](https://appsembler.atlassian.net/browse/BLACK-2635)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
