### PR TITLE
Fix boolean for TahoeUserMetadataProcessorCache in app.ready and disable for now

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/apps.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/apps.py
@@ -63,7 +63,7 @@ class EventTrackingConfig(AppConfig):
         # only want to prefill the cache on lms runserver...
         if (
             app_variant.is_not_runserver() or
-            app_variant.is_not_lms() or
+            app_variant.is_lms() or
             is_celery_worker()
         ):
             logger.debug("Not initializing metadatacache. This is Studio, Celery, other command.")

--- a/openedx/core/djangoapps/appsembler/eventtracking/apps.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/apps.py
@@ -69,4 +69,5 @@ class EventTrackingConfig(AppConfig):
             logger.debug("Not initializing metadatacache. This is Studio, Celery, other command.")
             return
         else:
-            tahoeusermetadata.prefetch_tahoe_usermetadata_cache.delay(metadatacache)
+            pass
+            # tahoeusermetadata.prefetch_tahoe_usermetadata_cache.delay(metadatacache)


### PR DESCRIPTION
## Change description

Found that there was a bug by running server in foreground `manage.py lms runserver`.  The cache has also not proven necessary in production so far, so simplifying for now and effectively disabling it.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues



## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
