### PR TITLE
Fix transcripts encoding for migrate_transcripts script

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -311,7 +311,7 @@ def async_migrate_transcript_subtask(*args, **kwargs):  # pylint: disable=unused
             command_run=command_run,
             edx_video_id=edx_video_id,
             language_code=language_code,
-            transcript_content=transcript_content,
+            transcript_content=transcript_content.encode(),
             file_format=Transcript.SJSON,
             force_update=force_update,
         )


### PR DESCRIPTION
## Change description

The migrate_transcripts.py script was brought from Ironwood to Juniper by Appsembler since we jumped that release.  It never got the encoding fix for S3-storage of transcripts that was done in 

https://github.com/appsembler/edx-platform/commit/8423ab230411f1f0be28ac6f4d85ec1fd5b073cf


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/RED-2378
https://appsembler.atlassian.net/browse/RED-2482

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
