### PR TITLE
Bugfix: Event tahoe metadata missing or wrong user

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -8,7 +8,6 @@ from json.decoder import JSONDecodeError
 import logging
 
 from celery import task
-from crum import get_current_user
 from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
 

--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -194,15 +194,10 @@ class TahoeUserMetadataProcessor(object):
             )
         else:
             if user_id:
-                try:
-                    user = User.objects.get(id=user_id)
-                except User.DoesNotExist:
-                    pass
-                else:
-                    # Add any Tahoe metadata context
-                    tahoe_user_metadata = self._get_user_tahoe_metadata(user.pk)
-                    if tahoe_user_metadata:
-                        event['context']['tahoe_user_metadata'] = tahoe_user_metadata
+                # Add any Tahoe metadata context
+                tahoe_user_metadata = self._get_user_tahoe_metadata(user_id)
+                if tahoe_user_metadata:
+                    event['context']['tahoe_user_metadata'] = tahoe_user_metadata
         finally:
             return event
 

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -108,8 +108,8 @@ def get_user_id_from_event(event_props):
         return dict(_flatten_dict_gen(d, parent_key, sep))
 
     user_id_props = {
-        key: val for (key, val) in _flatten_dict(event_props).items()
-        if 'user_id' in key and val is not None
+        key: int(val) for (key, val) in _flatten_dict(event_props).items()
+        if 'user_id' in key and val is not None and bool(val) and int(val)
     }
     deepest_user_id_prop = sorted(user_id_props.keys(), key=lambda x: x.count('.'), reverse=True)
     prefer_event_over_context = sorted(deepest_user_id_prop, key=lambda x: 'event' in x, reverse=True)

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -94,7 +94,7 @@ def get_user_id_from_event(event_props):
     user_id = None
 
     # ... typically the most interior object will have a good user_id
-    # search event props to find the deepest user_id :\
+    # search event props to find the deepest valid user_id :\
 
     def _flatten_dict(d, parent_key='', sep='.'):
         def _flatten_dict_gen(d, parent_key, sep):

--- a/openedx/core/djangoapps/appsembler/eventtracking/utils.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/utils.py
@@ -16,6 +16,8 @@ Where? appsembler.eventracking.sites is a likely candidate as the purpose of the
 `get_site_config_for_event` is specific to sites.
 """
 
+
+from collections.abc import MutableMapping
 import logging
 
 from django.core.exceptions import MultipleObjectsReturned
@@ -80,26 +82,40 @@ def get_site_config_for_event(event_props):
 
 def get_user_id_from_event(event_props):
     """
-    Get a user id from event properties.
+    Get a user id from event properties, preferring deepest-nested user_id value.
 
-    For events emitted without a request. This would generally be an event emitted
+    Use in favor of trying to get the user_id from the request (django_crum-based).
+    Needed for all events emitted without a request, e.g., an event emitted
     by a Celery worker, e.g., `edx.bi.completion.*` or `.grade_calculated` events.
+    Some events are also emitted with a user in the request which is an instructor or
+    other initiating user that is not the actual user tied to the event itself.
     """
 
     user_id = None
-    if event_props.get('user_id'):
-        user_id = event_props['user_id']
-    else:
-        event = event_props.get('event', {})
-        context = event_props.get('context', {})
-        event_context = event.get('context', {})
-        if context.get('user_id'):
-            user_id = context.get('user_id')
-            return user_id
-        if event.get('user_id'):
-            user_id = event.get('user_id')
-            return user_id
-        if event_context.get('user_id'):
-            user_id = event_context.get('user_id')
-            return user_id
+
+    # ... typically the most interior object will have a good user_id
+    # search event props to find the deepest user_id :\
+
+    def _flatten_dict(d, parent_key='', sep='.'):
+        def _flatten_dict_gen(d, parent_key, sep):
+            for k, v in d.items():
+                new_key = parent_key + sep + k if parent_key else k
+                if isinstance(v, MutableMapping):
+                    yield from _flatten_dict(v, new_key, sep=sep).items()
+                else:
+                    yield new_key, v
+
+        return dict(_flatten_dict_gen(d, parent_key, sep))
+
+    user_id_props = {
+        key: val for (key, val) in _flatten_dict(event_props).items()
+        if 'user_id' in key and val is not None
+    }
+    deepest_user_id_prop = sorted(user_id_props.keys(), key=lambda x: x.count('.'), reverse=True)
+    prefer_event_over_context = sorted(deepest_user_id_prop, key=lambda x: 'event' in x, reverse=True)
+    try:
+        best_user_id_prop = prefer_event_over_context[0]
+        user_id = user_id_props[best_user_id_prop]
+    except IndexError:
+        pass
     return user_id


### PR DESCRIPTION
## Change description

* TahoeUserMetadataProcesor don't assume user in request is accurate for getting the Tahoe User Metadata
* Rework how to find user_id from event, look through property objects like `event`, `event.context`, `event.context.event` trusting first the innermost definition as context wrappers may end up putting the Instructor's user_id on the context during things like bulk enrollment
* Fix some exception handling in TahoeUserMetadataProcessor which was itself logging an error (though handled by event pipeline)


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/RED-3716
https://appsembler.atlassian.net/browse/BLACK-2635

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
