### PR TITLE
Remove redundant Third Party Auth create_user step (gate for production testing with Waffle Flag)

### DIFF
--- a/openedx/core/djangoapps/appsembler/waffle.py
+++ b/openedx/core/djangoapps/appsembler/waffle.py
@@ -36,11 +36,14 @@ def waffle_flags():
     }
 
 
-def disable_tpa_create_user_step():
+def disable_tpa_create_user_step(request):
     """
     Returns whether use of the create_user step in the third_party_auth pipeline is disabled or not.
     It does not appear to be necessary because the hidden registration form POSTs to /user_authn/
     endpoint to create a user prior this step.  The step adds complexity and may not be needed or
-    even cause issues.  Using a Waffle Flag to be able to activate selectively for production testing.
+    even cause issues.  Using a Waffle Flag to be able to activate selectively for production
+    testing.
     """
-    return waffle_flags()[DISABLE_TPA_PIPELINE_SOCIALCORE_CREATE_USER_STEP].is_active()
+    return waffle().flag_is_active(
+        request, waffle_flags()[DISABLE_TPA_PIPELINE_SOCIALCORE_CREATE_USER_STEP]
+    )

--- a/openedx/core/djangoapps/appsembler/waffle.py
+++ b/openedx/core/djangoapps/appsembler/waffle.py
@@ -44,6 +44,4 @@ def disable_tpa_create_user_step(request):
     even cause issues.  Using a Waffle Flag to be able to activate selectively for production
     testing.
     """
-    return waffle().flag_is_active(
-        request, waffle_flags()[DISABLE_TPA_PIPELINE_SOCIALCORE_CREATE_USER_STEP]
-    )
+    return waffle().is_flag_active(DISABLE_TPA_PIPELINE_SOCIALCORE_CREATE_USER_STEP)

--- a/openedx/core/djangoapps/appsembler/waffle.py
+++ b/openedx/core/djangoapps/appsembler/waffle.py
@@ -1,0 +1,46 @@
+"""
+Appsembler-specific Waffle setup for Open edX Django apps.
+
+Waffle namespaces, flags, that are for specific Appsembler Django apps
+should go in those apps.  This module should be used for Flags and Switches
+used to override, rollout, or modify changes to non-Appsembler apps.
+"""
+
+from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
+
+# Namespace
+WAFFLE_NAMESPACE = u'appsembler'
+
+# Flags
+DISABLE_TPA_PIPELINE_SOCIALCORE_CREATE_USER_STEP = 'disable_tpa_pipeline_socialcore_create_user'
+
+
+def waffle():
+    """
+    Returns the namespaced, cached, audited Waffle class for Appsembler.
+    """
+    return WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Appsembler: ')
+
+
+def waffle_flags():
+    """
+    Returns the namespaced, cached, audited Waffle flags dictionary for Appsembler.
+    """
+    namespace = waffle()
+    return {
+        DISABLE_TPA_PIPELINE_SOCIALCORE_CREATE_USER_STEP: WaffleFlag(
+            namespace,
+            DISABLE_TPA_PIPELINE_SOCIALCORE_CREATE_USER_STEP,
+            flag_undefined_default=False,
+        ),
+    }
+
+
+def disable_tpa_create_user_step():
+    """
+    Returns whether use of the create_user step in the third_party_auth pipeline is disabled or not.
+    It does not appear to be necessary because the hidden registration form POSTs to /user_authn/
+    endpoint to create a user prior this step.  The step adds complexity and may not be needed or
+    even cause issues.  Using a Waffle Flag to be able to activate selectively for production testing.
+    """
+    return waffle_flags()[DISABLE_TPA_PIPELINE_SOCIALCORE_CREATE_USER_STEP].is_active()


### PR DESCRIPTION
## Change description

Remove create_user pipeline step from Third Party Auth pipeline when feature is activated with a [waffle Flag ](https://waffle.readthedocs.io/en/stable/types/flag.html)
Add a new waffle module to openedx.core.djangoapps.appsembler for Switches and Flags related to overrides or gating of common Open edX functionality.

We can use this to turn on the Flag per-user, or with the addition of an HTTP header, for example.

## Type of change
- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
