### PR TITLE
Bugfix: RED-3716 events from instructors or API users missing tahoe user metadata

### DIFF
--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -183,14 +183,13 @@ class TahoeUserMetadataProcessor(object):
         # a bulk enrollment or exception certificate triggering the event.  Only use the
         # user from event itself.
 
-        event_data = event.get('data')
         try:
-            user_id = utils.get_user_id_from_event(event_data)
+            user_id = utils.get_user_id_from_event(event)
         except AttributeError:
             logger.warning(
                 "TahoeUserMetadataProcessor passed invalid type to "
                 "get_user_id_from_event: {}. Likely innocuous. "
-                "Logging and continuing.".format(event_data)
+                "Logging and continuing.".format(event)
             )
         else:
             if user_id:

--- a/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
+++ b/openedx/core/djangoapps/appsembler/eventtracking/tahoeusermetadata.py
@@ -186,7 +186,7 @@ class TahoeUserMetadataProcessor(object):
         try:
             user_id = utils.get_user_id_from_event(event)
         except AttributeError:
-            logger.warning(
+            logger.debug(
                 "TahoeUserMetadataProcessor passed invalid type to "
                 "get_user_id_from_event: {}. Likely innocuous. "
                 "Logging and continuing.".format(event)


### PR DESCRIPTION
## Change description

Pass full event to get_user_id_from_event to read through full event for a user_id, which works now due to previous change. 

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/RED-3717

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
