### PR TITLE
If Tiers app not enabled return all orgs as active

### DIFF
--- a/openedx/core/djangoapps/appsembler/sites/utils.py
+++ b/openedx/core/djangoapps/appsembler/sites/utils.py
@@ -88,9 +88,11 @@ def get_active_organizations():
 
     TODO: This helper should live in a future Tahoe Sites package.
     """
-    active_tiers_uuids = get_active_organizations_uuids()
-
-    return get_organizations_from_uuids(uuids=active_tiers_uuids)
+    if settings.FEATURES.get('ENABLE_TIERS_APP', False):
+        active_tiers_uuids = get_active_organizations_uuids()
+        return get_organizations_from_uuids(uuids=active_tiers_uuids)
+    else:
+        return Organization.objects.all()
 
 
 def get_active_sites(order_by='domain'):


### PR DESCRIPTION
## Change description

Mostly for devstacks.  If Tiers app is not enabled, don't try to check its database for active Organizations, just return all.
Fixes devstack Studio errors and simplifies config.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
