### PR TITLE
Ensure samesite=none logged_in cookies are deleted

### DIFF
--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -3,7 +3,6 @@ Utility functions for setting "logged in" cookies used by subdomains.
 """
 
 
-import datetime
 import json
 import logging
 import time
@@ -78,7 +77,7 @@ def delete_logged_in_cookies(response):
             cookie_name,
             '',
             max_age=0,
-            expires=datetime.datetime.utcfromtimestamp(0),
+            expires='Thu, 01 Jan 1970 00:00:00 GMT',
             path='/',
             domain=settings.SESSION_COOKIE_DOMAIN,
             secure=True if settings.HTTPS == 'on' else False

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -3,6 +3,7 @@ Utility functions for setting "logged in" cookies used by subdomains.
 """
 
 
+import datetime
 import json
 import logging
 import time
@@ -73,10 +74,14 @@ def delete_logged_in_cookies(response):
         HttpResponse
     """
     for cookie_name in ALL_LOGGED_IN_COOKIE_NAMES:
-        response.delete_cookie(
+        response.set_cookie(
             cookie_name,
+            '',
             path='/',
-            domain=settings.SESSION_COOKIE_DOMAIN
+            domain=settings.SESSION_COOKIE_DOMAIN,
+            secure=True if settings.HTTPS == 'on' else False,
+            max_age=0,
+            expires=datetime.datetime.utcfromtimestamp(0)
         )
 
     return response

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -77,11 +77,11 @@ def delete_logged_in_cookies(response):
         response.set_cookie(
             cookie_name,
             '',
+            max_age=0,
+            expires=datetime.datetime.utcfromtimestamp(0),
             path='/',
             domain=settings.SESSION_COOKIE_DOMAIN,
-            secure=True if settings.HTTPS == 'on' else False,
-            max_age=0,
-            expires=datetime.datetime.utcfromtimestamp(0)
+            secure=True if settings.HTTPS == 'on' else False
         )
 
     return response


### PR DESCRIPTION
## Change description

Fix an upstream issue with Open edX < Maple / Django < 3.2.7 causing samesite cookie deletion to fail.

Fixes ENG-53
Patch delete_logged_in_cookies to bypass Django < 3.2.7 (Maple+) delete_cookie. It relies on prefix of __SECURE to determine secure cookies, so we have to use set_cookie with an expired date.
Note this will still work with Session cookie domain middleware. Adapted from https://discuss.overhang.io/t/logged-in-cookies-not-deleted-on-logout-over-https-not-reproducible-on-edx-org/1011/6

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-53

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
