### PR TITLE
PTAD-requested a11y fixes for Account Settings, Profile

### DIFF
--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -113,16 +113,8 @@ export class StudentAccountDeletion extends React.Component {
               <span>{bodyDeletion2}</span>
         </p>
         <p
-          className="account-settings-header-subtitle"
-          dangerouslySetInnerHTML={{ __html: loseAccessText }}
-        />
-        <p
           className="account-settings-header-subtitle-warning"
           dangerouslySetInnerHTML={{ __html: acctDeletionWarningText }}
-        />
-        <p
-          className="account-settings-header-subtitle"
-          dangerouslySetInnerHTML={{ __html: changeAcctInfoText }}
         />
         <Button
           id="delete-account-btn"

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -167,7 +167,6 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                         <span>{bodyDeletion} </span>
                         <span>{bodyDeletion2}</span>
                       </p>
-                      <p dangerouslySetInnerHTML={{ __html: loseAccessText }} />
                     </div>
                   </div>
                 )}

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -217,7 +217,10 @@
                                 model: userAccountModel,
                                 title: gettext('Education Completed'),
                                 valueAttribute: 'level_of_education',
-                                options: fieldsData.level_of_education.options,
+                                groupOptions: [{
+                                    selectOptions: fieldsData.level_of_education.options,
+                                    nullValueOptionLabel: gettext('(Not Specified)')
+                                }],
                                 persistChanges: true
                             })
                         },
@@ -226,7 +229,10 @@
                                 model: userAccountModel,
                                 title: gettext('Gender'),
                                 valueAttribute: 'gender',
-                                options: fieldsData.gender.options,
+                                groupOptions: [{
+                                    selectOptions: fieldsData.gender.options,
+                                    nullValueOptionLabel: gettext('(Not Specified)')
+                                }],
                                 persistChanges: true
                             })
                         },
@@ -235,7 +241,10 @@
                                 model: userAccountModel,
                                 title: gettext('Year of Birth'),
                                 valueAttribute: 'year_of_birth',
-                                options: fieldsData.year_of_birth.options,
+                                groupOptions: [{
+                                    selectOptions: fieldsData.year_of_birth.options,
+                                    nullValueOptionLabel: gettext('(Not Specified)')
+                                }],
                                 persistChanges: true
                             })
                         },
@@ -244,7 +253,10 @@
                                 model: userAccountModel,
                                 title: gettext('Preferred Language'),
                                 valueAttribute: 'language_proficiencies',
-                                options: fieldsData.preferred_language.options,
+                                groupOptions: [{
+                                    selectOptions: fieldsData.preferred_language.options,
+                                    nullValueOptionLabel: gettext('(Not Specified)')
+                                }],
                                 persistChanges: true
                             })
                         }

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -117,7 +117,10 @@
                 required: true,
                 title: gettext('Country or Region of Residence'),
                 valueAttribute: 'country',
-                options: fieldsData.country.options,
+                groupOptions: [{
+                    selectOptions: fieldsData.country.options,
+                    nullValueOptionLabel: gettext('(Not Specified)')
+                }],
                 persistChanges: true,
                 helpMessage: gettext('The country or region where you live.')
             };
@@ -180,7 +183,10 @@
                                     gettext('The language used throughout this site. This site is currently available in a limited number of languages. Changing the value of this field will cause the page to refresh.'),  // eslint-disable-line max-len
                                     {platform_name: platformName}
                                 ),
-                                options: fieldsData.language.options,
+                                groupOptions: [{
+                                    nullValueOptionLabel: gettext('Default (English)'),
+                                    selectOptions: fieldsData.language.options
+                                }],
                                 persistChanges: true,
                                 focusNextID: '#u-field-select-country'
                             })

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -77,7 +77,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
 <script type="text/javascript">
      window.auth = ${ auth | n, dump_js_escaped_json };
      window.isActive = ${ user.is_active | n, dump_js_escaped_json };
-     window.additionalSiteSpecificDeletionText = "${ static.get_value('SITE_SPECIFIC_DELETION_TEXT', _(' and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School')) | n, js_escaped_string }";
+     window.additionalSiteSpecificDeletionText = "${ static.get_value('SITE_SPECIFIC_DELETION_TEXT', '') | n, js_escaped_string }";
      window.mktgRootLink = "${ static.marketing_link('ROOT') | n, js_escaped_string }";
      window.platformName = "${ platform_name | n, js_escaped_string }";
      window.siteName = "${ static.get_value('SITE_NAME', settings.SITE_NAME) | n, js_escaped_string }";


### PR DESCRIPTION
## Change description

a11y fixes on Account Settings, Profile.

In some cases I just removed text, as we don't need all the warnings and they have broken links or edX specific info.
I did this directly in edx-platform because at this point it's cleaner to do there, easier to track changes than having an entirely new file in edx-theme-codebase and/or edx-theme-customers.  Better to keep it simple for now because these templates are changing anyway, and we may be reworking how we theme when we change away from multitenancy.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-109

and subtasks

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
