### PR TITLE
Use tahoe-idp 2.4.3

### DIFF
--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/patches.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/patches.py
@@ -1,0 +1,10 @@
+"""
+patching helpers
+"""
+
+from mock import Mock
+
+
+# Keep Signal receivers in tahoe_idp from executing fully when not explicitly testing
+dummy_receivers_idp_not_enabled = Mock()
+dummy_receivers_idp_not_enabled.return_value = False

--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_account_deletion.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_account_deletion.py
@@ -8,6 +8,7 @@ from social_django.models import UserSocialAuth
 
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+
 from rest_framework.test import APITestCase
 from rest_framework import status
 
@@ -17,6 +18,8 @@ from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (
     # Importing this module to allow using `usefixtures("setup_retirement_states")`
     setup_retirement_states,  # pylint: disable=unused-import
 )
+
+from . import patches
 
 
 @patch.dict('django.conf.settings.FEATURES', {'SKIP_EMAIL_VALIDATION': True})
@@ -64,6 +67,7 @@ class MultiTenantDeactivateLogoutViewTest(APITestCase):
         })
         return response
 
+    @patch('tahoe_idp.receivers.helpers.is_tahoe_idp_enabled', new=patches.dummy_receivers_idp_not_enabled)
     @patch('tahoe_idp.api.get_tahoe_idp_id_by_user')
     @patch('tahoe_idp.api.deactivate_user')
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_TAHOE_IDP': True})

--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_email_change.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_email_change.py
@@ -12,6 +12,8 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 from student.models import PendingEmailChange
 from student.tests.factories import PendingEmailChangeFactory, UserFactory
 
+from . import patches
+
 
 @skip_unless_lms
 class EmailChangeWithIdpTests(TestCase):
@@ -37,11 +39,13 @@ class EmailChangeWithIdpTests(TestCase):
             'Should not use idp unless explicitly enabled via ENABLE_TAHOE_IDP'
         )
 
+    @patch('tahoe_idp.receivers.helpers.is_tahoe_idp_enabled', new=patches.dummy_receivers_idp_not_enabled)
     @patch('tahoe_idp.api.update_user_email')
     def test_successful_email_change_with_idp(self, mock_update_user_email):
         """
         Test `confirm_email_change` with ENABLE_TAHOE_IDP = True.
         """
+
         with patch.dict(settings.FEATURES, {'ENABLE_TAHOE_IDP': True}):
             response = self.client.get(reverse('confirm_email_change', args=[self.key]))
 

--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_reset_password.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_idp_reset_password.py
@@ -13,9 +13,12 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from student.tests.factories import UserFactory
 
+from . import patches
+
 
 @ddt.ddt
 @skip_unless_lms
+@patch('tahoe_idp.receivers.helpers.is_tahoe_idp_enabled', new=patches.dummy_receivers_idp_not_enabled)
 @patch('tahoe_idp.api.request_password_reset')
 class TahoeIdpResetPasswordTests(TestCase):
     """

--- a/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_registration_api.py
+++ b/openedx/core/djangoapps/appsembler/tahoe_idp/tests/test_tahoe_registration_api.py
@@ -12,6 +12,8 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from ...multi_tenant_emails.tests.test_utils import with_organization_context
 
+from . import patches
+
 APPSEMBLER_API_VIEWS_MODULE = 'openedx.core.djangoapps.appsembler.api.v1.views'
 
 
@@ -51,6 +53,7 @@ class TahoeIdPDisablesRegisrationAPITest(APITestCase):
             content = response.content.decode('utf-8')
             assert response.status_code == status.HTTP_200_OK, '{} {}'.format(color1, content)
 
+    @patch('tahoe_idp.receivers.helpers.is_tahoe_idp_enabled', new=patches.dummy_receivers_idp_not_enabled)
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_TAHOE_IDP': True})
     @ddt.data(
         reverse_lazy('tahoe-api:v1:registrations-list'),
@@ -60,6 +63,7 @@ class TahoeIdPDisablesRegisrationAPITest(APITestCase):
         """
         Both v1 and v2 API shouldn't work with Tahoe IdP.
         """
+
         color1 = 'red1'
         with with_organization_context(site_color=color1):
             response = self.register_user(url, 'red_learner')

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -23,7 +23,7 @@ https://github.com/appsembler/edx-proctoring/archive/v2.4.0-appsembler1.tar.gz
 django-tiers==0.2.7
 fusionauth-client==1.36.0
 google-cloud-storage==1.32.0
-tahoe-idp==2.3.0
+tahoe-idp==2.4.2
 tahoe-sites==1.3.2
 tahoe-lti==0.3.0
 site-configuration-client==0.2.3

--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -23,7 +23,7 @@ https://github.com/appsembler/edx-proctoring/archive/v2.4.0-appsembler1.tar.gz
 django-tiers==0.2.7
 fusionauth-client==1.36.0
 google-cloud-storage==1.32.0
-tahoe-idp==2.4.2
+tahoe-idp==2.4.3
 tahoe-sites==1.3.2
 tahoe-lti==0.3.0
 site-configuration-client==0.2.3


### PR DESCRIPTION
## Change description

Use tahoe-idp 2.4.3, which adds signal receiver on User and UserProfile to sync name fields to IdP
Bug and test fixes since 2.4.0.

## Type of change
- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-125

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
