### PR TITLE
Increase YouTube TEST_TIMEOUT  to 2.5s

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/common.py
@@ -89,3 +89,6 @@ def plugin_settings(settings):
 
     # Off by default. See the `site_configuration.tahoe_organization_helpers.py` module.
     settings.FEATURES['TAHOE_SITE_CONFIG_CLIENT_ORGANIZATIONS_SUPPORT'] = False
+
+    # Give a little more time for YT API to load in video_module (default was 1500 ms)
+    settings.YOUTUBE['TEST_TIMEOUT'] = 2500


### PR DESCRIPTION
## Change description

(setTimeout length testing if YT API is ready)
Another attempt to fix ENG-97

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-97

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
