### PR TITLE
Catch and retry video module YT IFrame API ready errs

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -184,6 +184,7 @@ function(VideoPlayer, i18n, moment, _) {
                         window.onYouTubeIframeAPIReady.resolve = _youtubeApiDeferred.resolve;
                     } catch (e) {
                         console.error('Error while trying to resolve the Deferred object responsible for calling OnYouTubeIframeAPIReady callbacks.');
+                        console.error('window.onYouTubeIframeAPIReady is ' + window.onYouTubeIframeAPIReady);
                         console.error(e);
                         if (e instanceof TypeError) {
                             setupOnYouTubeIframeAPIReady(); // Try again up to defined max calls.

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -90,6 +90,7 @@ function(VideoPlayer, i18n, moment, _) {
 
         _youtubeApiDeferred = null,
         _oldOnYouTubeIframeAPIReady;
+        const setupOnYouTubeIframeAPIReadyMaxCalls=3;
 
     Initialize.prototype = methodsDict;
 
@@ -165,14 +166,32 @@ function(VideoPlayer, i18n, moment, _) {
                 //
                 // If this global function is already defined, we store it first, and make
                 // sure that it gets executed when our Deferred object is resolved.
+                let setupOnYouTubeIframeAPIReadyCallsCount = 0;
+
                 setupOnYouTubeIframeAPIReady = function() {
+                    setupOnYouTubeIframeAPIReadyCallsCount++;
+                    if (setupOnYouTubeIframeAPIReadyCallsCount > setupOnYouTubeIframeAPIReadyMaxCalls) {
+                        throw new Error('Too many OnYouTubeIframeAPIReady retries after TypeError...giving up.');
+                    }
+
                     _oldOnYouTubeIframeAPIReady = window.onYouTubeIframeAPIReady || undefined;
 
                     window.onYouTubeIframeAPIReady = function() {
                         window.onYouTubeIframeAPIReady.resolve();
                     };
 
-                    window.onYouTubeIframeAPIReady.resolve = _youtubeApiDeferred.resolve;
+                    try {
+                        window.onYouTubeIframeAPIReady.resolve = _youtubeApiDeferred.resolve;
+                    } catch (e) {
+                        console.error('Error while trying to resolve the Deferred object responsible for calling OnYouTubeIframeAPIReady callbacks.');
+                        console.error(e);
+                        if (e instanceof TypeError) {
+                            setupOnYouTubeIframeAPIReady(); // Try again up to defined max calls.
+                        }
+                        else {
+                            throw e;
+                        }
+                    }
                     window.onYouTubeIframeAPIReady.done = _youtubeApiDeferred.done;
 
                     if (_oldOnYouTubeIframeAPIReady) {


### PR DESCRIPTION
## Change description

Retry setting window.onYouTubeIframeAPIReady.resolve to JQuery Deferred obj .resolve
up to 3 times before finally failing
Log err message to console
Catch and retry only TypeErrors which should result from .resolve TypeError

This is direclty in edx-platform since I couldn't figure out how to
override in the theme due to the webpack bundling that is done directly
into VideoBlockPreview.js via add_webpack_to_fragment in video_module.py


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-97

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
