### PR TITLE
Fix version override: Use edx-sga 0.22.0 via appsembler.txt reqs

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -14,9 +14,9 @@ django-hijack-admin==2.1.10
 honeycomb-beeline==2.12.1
 
 # Patched upstream packages
+https://github.com/mitodl/edx-sga/archive/refs/tags/v0.22.0.tar.gz
 https://github.com/edx-solutions/xblock-google-drive/archive/589d9f51f9b.tar.gz  # v0.2.0 but the repo has no tags
 https://github.com/appsembler/edx-ora2/archive/2.7.6-appsembler.1.tar.gz
-https://github.com/appsembler/edx-sga/archive/v0.11.0.appsembler2.tar.gz
 https://github.com/appsembler/edx-proctoring/archive/v2.4.0-appsembler1.tar.gz
 
 # Tahoe plugins and customizations


### PR DESCRIPTION
## Change description

edx-sga in EDXAPP_EXTRA_REQUIREMENTS via server-vars.yml wasn't overriding the one defined in requirements/edx/appsembler.txt.  Define it directly in our pip requirements.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues



## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
