### PR TITLE
ENG-97 Try/Catch around more of the onYouTubeIframeAPIReady code to retry

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -174,14 +174,19 @@ function(VideoPlayer, i18n, moment, _) {
                         throw new Error('Too many OnYouTubeIframeAPIReady retries after TypeError...giving up.');
                     }
 
-                    _oldOnYouTubeIframeAPIReady = window.onYouTubeIframeAPIReady || undefined;
-
-                    window.onYouTubeIframeAPIReady = function() {
-                        window.onYouTubeIframeAPIReady.resolve();
-                    };
-
                     try {
+                        _oldOnYouTubeIframeAPIReady = window.onYouTubeIframeAPIReady || undefined;
+
+                        window.onYouTubeIframeAPIReady = function() {
+                            window.onYouTubeIframeAPIReady.resolve();
+                        };
+
                         window.onYouTubeIframeAPIReady.resolve = _youtubeApiDeferred.resolve;
+                        window.onYouTubeIframeAPIReady.done = _youtubeApiDeferred.done;
+
+                        if (_oldOnYouTubeIframeAPIReady) {
+                            window.onYouTubeIframeAPIReady.done(_oldOnYouTubeIframeAPIReady);
+                        }
                     } catch (e) {
                         console.error('Error while trying to resolve the Deferred object responsible for calling OnYouTubeIframeAPIReady callbacks.');
                         console.error('window.onYouTubeIframeAPIReady is ' + window.onYouTubeIframeAPIReady);
@@ -193,11 +198,7 @@ function(VideoPlayer, i18n, moment, _) {
                             throw e;
                         }
                     }
-                    window.onYouTubeIframeAPIReady.done = _youtubeApiDeferred.done;
 
-                    if (_oldOnYouTubeIframeAPIReady) {
-                        window.onYouTubeIframeAPIReady.done(_oldOnYouTubeIframeAPIReady);
-                    }
                 };
 
                 // If a Deferred object hasn't been created yet, create one now. It will

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -90,7 +90,7 @@ function(VideoPlayer, i18n, moment, _) {
 
         _youtubeApiDeferred = null,
         _oldOnYouTubeIframeAPIReady;
-        const setupOnYouTubeIframeAPIReadyMaxCalls=3;
+        const setupOnYouTubeIframeAPIReadyMaxCalls=5;
 
     Initialize.prototype = methodsDict;
 

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -192,7 +192,7 @@ function(VideoPlayer, i18n, moment, _) {
                         console.error('window.onYouTubeIframeAPIReady is ' + window.onYouTubeIframeAPIReady);
                         console.error(e);
                         if (e instanceof TypeError) {
-                            setupOnYouTubeIframeAPIReady(); // Try again up to defined max calls.
+                            setTimeout(setupOnYouTubeIframeAPIReady, 500); // Try again up to defined max calls.
                         }
                         else {
                             throw e;


### PR DESCRIPTION
## Change description

Still getting onYouTubeIframeAPIReady TypeErrors once in a while when loading YouTube videos in courseware.

When I reproduced it, I didn't see any of the JS console messages that I put in, like 

```
console.error('Error while trying to resolve the Deferred object responsible for calling OnYouTubeIframeAPIReady callbacks.');
console.error('window.onYouTubeIframeAPIReady is ' + window.onYouTubeIframeAPIReady);
```

so the try/catch I put in to retry the function wasn’t getting executed at least in this case.

This PR:

* catches a TypeError in more of the function code
* allows up to 5 retries (was 3)
* waits 500ms before a retry

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-97

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
