### PR TITLE
Revert to edx-sga v0.11.0 Appsembler fork

### DIFF
--- a/requirements/edx/appsembler.txt
+++ b/requirements/edx/appsembler.txt
@@ -14,7 +14,7 @@ django-hijack-admin==2.1.10
 honeycomb-beeline==2.12.1
 
 # Patched upstream packages
-https://github.com/mitodl/edx-sga/archive/refs/tags/v0.22.0.tar.gz
+https://github.com/appsembler/edx-sga/archive/v0.11.0.appsembler2.tar.gz
 https://github.com/edx-solutions/xblock-google-drive/archive/589d9f51f9b.tar.gz  # v0.2.0 but the repo has no tags
 https://github.com/appsembler/edx-ora2/archive/2.7.6-appsembler.1.tar.gz
 https://github.com/appsembler/edx-proctoring/archive/v2.4.0-appsembler1.tar.gz


### PR DESCRIPTION
## Change description

v0.13 and on have Juniper / Py3.5 incompatibilities. Back to 0.11 for now

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
