### PR TITLE
YoutTubeIframeAPIReady issue - Remove newer error handling code and try simple fix

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -164,27 +164,8 @@ function(VideoPlayer, i18n, moment, _) {
                 // so that it resolves our Deferred object, which will call all of the
                 // OnYouTubeIframeAPIReady callbacks.
                 //
-                let setupOnYouTubeIframeAPIReadyCallsCount = 0;
 
                 let setupOnYouTubeIframeAPIReady = function() {
-
-                    setupOnYouTubeIframeAPIReadyCallsCount++;
-
-                    if (setupOnYouTubeIframeAPIReadyCallsCount > setupOnYouTubeIframeAPIReadyMaxCalls) {
-                        throw new Error('Too many OnYouTubeIframeAPIReady retries after TypeError...giving up.');
-                    }
-
-                    handleYTAPIErr = function(ytapierr) {
-                        console.error('Error while trying to resolve the Deferred object responsible for calling OnYouTubeIframeAPIReady callbacks.');
-                        console.debug('window.onYouTubeIframeAPIReady is ' + window.onYouTubeIframeAPIReady);
-                        console.error(ytapierr);
-                        if (ytapierr instanceof TypeError) { // expecting TypeError: window.onYouTubeIframeAPIReady.resolve is not a function
-                            setTimeout(setupOnYouTubeIframeAPIReady, 500); // Try again up to defined max calls.
-                        }
-                        else {
-                            throw ytapierr;
-                        }
-                    };
 
                     // If this global function is already defined, we store it first, and make
                     // sure that it gets executed when our Deferred object is resolved.
@@ -196,9 +177,6 @@ function(VideoPlayer, i18n, moment, _) {
 
                     window.onYouTubeIframeAPIReady.resolve = _youtubeApiDeferred.resolve;
                     window.onYouTubeIframeAPIReady.done = _youtubeApiDeferred.done;
-                    _youtubeApiDeferred.catch(function(err) {
-                        handleYTAPIErr(err);
-                    });
 
                     if (_oldOnYouTubeIframeAPIReady) {
                         window.onYouTubeIframeAPIReady.done(_oldOnYouTubeIframeAPIReady);


### PR DESCRIPTION
## Change description

Just try a simple change in the `.resolve` assignment and remove all of the error handling code I'd added.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-97

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
