### PR TITLE
Fix: Handle Request objects in Segment fetch override

### DIFF
--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -38,8 +38,8 @@
             signal: resource.signal
           });
         } else {
-          // If it's neither a string nor a Request object, log an error or handle as needed
-          console.error('replaceFetchResourceForSegmentSite was called with an unexpected argument type:', typeof resource, resource);
+          // If it's neither a string nor a Request object, log a warning or handle as needed
+          console.warn('replaceFetchResourceForSegmentSite was called with an unexpected argument type:', typeof resource, resource);
           return resource;
         }
       }

--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -39,7 +39,7 @@
           });
         } else {
           // If it's neither a string nor a Request object, log an error or handle as needed
-          console.error('replaceFetchResourceForSegmentSite was called with an unexpected argument type');
+          console.error('replaceFetchResourceForSegmentSite was called with an unexpected argument type:', typeof resource, resource);
           return resource;
         }
       }

--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -9,18 +9,45 @@
   !function(){
       var originalAPI = '${settings.SEGMENT_ORIGINAL_API}';
       var replicateAPI = '${settings.SEGMENT_REPLICATE_API}';
-      function replaceFetchResourceForSegmentSite(resource){
-        if (resource.substr(0, originalAPI.length) === originalAPI) {
-              resource = replicateAPI + resource.substr(originalAPI.length);
+      function replaceFetchResourceForSegmentSite(resource) {
+        // Helper function to replace the URL
+        function replaceUrl(url) {
+          if (url.substr(0, originalAPI.length) === originalAPI) {
+            return replicateAPI + url.substr(originalAPI.length);
+          }
+          return url;
         }
-        return resource;
+
+        // Check if resource is a string (a URL)
+        if (typeof resource === 'string') {
+          return replaceUrl(resource);
+        } else if (resource instanceof Request) {
+          // If resource is a Request object, create a new Request with a replaced URL
+          const newUrl = replaceUrl(resource.url);
+          return new Request(newUrl, {
+            method: resource.method,
+            headers: resource.headers,
+            body: resource.body,
+            mode: resource.mode,
+            credentials: resource.credentials,
+            cache: resource.cache,
+            redirect: resource.redirect,
+            referrer: resource.referrer,
+            integrity: resource.integrity,
+            keepalive: resource.keepalive,
+            signal: resource.signal
+          });
+        } else {
+          // If it's neither a string nor a Request object, log an error or handle as needed
+          console.error('replaceFetchResourceForSegmentSite was called with an unexpected argument type');
+          return resource;
+        }
       }
-      const { fetch: originalFetch } = window;
+      // Override the fetch function to use the replaceFetchResourceForSegmentSite function
+      const originalFetch = window.fetch;
       window.fetch = async (...args) => {
-          let [resource, config ] = args;
-          resource = replaceFetchResourceForSegmentSite(resource);
-          const response = await originalFetch(resource, config);
-          return response;
+        args[0] = replaceFetchResourceForSegmentSite(args[0]);
+        return originalFetch.apply(window, args);
       };
   }();
   </script>

--- a/lms/templates/widgets/segment-io.html
+++ b/lms/templates/widgets/segment-io.html
@@ -37,6 +37,9 @@
             keepalive: resource.keepalive,
             signal: resource.signal
           });
+        } else if (resource instanceof URL) {
+          // If resource is a URL object, convert it to a string and replace the URL
+          return replaceUrl(resource.href);
         } else {
           // If it's neither a string nor a Request object, log a warning or handle as needed
           console.warn('replaceFetchResourceForSegmentSite was called with an unexpected argument type:', typeof resource, resource);


### PR DESCRIPTION
## Change description

This change fixes the TypeError that was thrown when trying to call `substr` on a Request object and ensures that analytics events are correctly replicated to the appropriate Segment backends.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

https://appsembler.atlassian.net/browse/ENG-334

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
