### PR TITLE
use py2neo-history for access to older release gone from py2neo

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -181,9 +181,7 @@ pillow==7.1.2             # via -r requirements/edx/base.in, edx-enterprise, edx
 pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/paver.txt, edx-django-utils
-# modified from https://github.com/openedx/edx-platform/pull/33453
-# for earlier pip version in use on Juniper release
-py2neo --find-links https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
+py2neo-history==3.1.2
 pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -181,7 +181,9 @@ pillow==7.1.2             # via -r requirements/edx/base.in, edx-enterprise, edx
 pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/paver.txt, edx-django-utils
--e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2 # via -r requirements/edx/github.in             # via -r requirements/edx/base.in
+# modified from https://github.com/openedx/edx-platform/pull/33453
+# for earlier pip version in use on Juniper release
+py2neo --find-links https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
 pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -218,7 +218,9 @@ pkgconfig==1.5.1          # via -r requirements/edx/testing.txt, xmlsec
 pluggy==0.13.1            # via -r requirements/edx/testing.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/testing.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/testing.txt, edx-django-utils
--e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2 # via -r requirements/edx/github.in             # via -r requirements/edx/testing.txt
+# modified from https://github.com/openedx/edx-platform/pull/33453
+# for earlier pip version in use on Juniper release
+py2neo --find-links https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
 py==1.8.1                 # via -r requirements/edx/testing.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.txt, flake8
 pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-client

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -218,9 +218,7 @@ pkgconfig==1.5.1          # via -r requirements/edx/testing.txt, xmlsec
 pluggy==0.13.1            # via -r requirements/edx/testing.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/testing.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/testing.txt, edx-django-utils
-# modified from https://github.com/openedx/edx-platform/pull/33453
-# for earlier pip version in use on Juniper release
-py2neo --find-links https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
+py2neo-history==3.1.2
 py==1.8.1                 # via -r requirements/edx/testing.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.txt, flake8
 pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-client

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -59,9 +59,6 @@ git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
-# modified from https://github.com/openedx/edx-platform/pull/33453
-# for earlier pip version in use on Juniper release
---index-url https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
 
 # The latest 2.0.0 release doesn't yet support Django 2.2, this commit from master does
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -59,7 +59,9 @@ git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
--e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
+# modified from https://github.com/openedx/edx-platform/pull/33453
+# for earlier pip version in use on Juniper release
+--index-url https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
 
 # The latest 2.0.0 release doesn't yet support Django 2.2, this commit from master does
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -211,7 +211,7 @@ polib==1.1.0              # via -r requirements/edx/base.txt, -r requirements/ed
 psutil==1.2.1             # via -r requirements/edx/base.txt, edx-django-utils
 # modified from https://github.com/openedx/edx-platform/pull/33453
 # for earlier pip version in use on Juniper release
-py2neo --find-links https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
+py2neo-history==3.1.2
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.in, flake8
 pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-client

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -209,7 +209,9 @@ pkgconfig==1.5.1          # via -r requirements/edx/base.txt, xmlsec
 pluggy==0.13.1            # via -r requirements/edx/coverage.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/base.txt, edx-django-utils
--e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2 # via -r requirements/edx/github.in             # via -r requirements/edx/base.txt
+# modified from https://github.com/openedx/edx-platform/pull/33453
+# for earlier pip version in use on Juniper release
+py2neo --find-links https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.in, flake8
 pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-client


### PR DESCRIPTION

## Change description

Official py2neo is EOL and releases are gone from GitHub and PyPI so using approach of upstream with modifications to work with earlier pip

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Causing all GitHub checks builds to fail

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
