### PR TITLE
feat: Add Mandrill Subaccount support

### DIFF
--- a/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
+++ b/openedx/core/djangoapps/appsembler/settings/settings/production_common.py
@@ -48,7 +48,22 @@ def plugin_settings(settings):
             "MANDRILL_API_KEY": settings.MANDRILL_API_KEY,
         }
         settings.INSTALLED_APPS += ['anymail']
-
+    # Mandrill Subaccount Support
+    settings.MANDRILL_SUBACCOUNT = settings.ENV_TOKENS.get("MANDRILL_SUBACCOUNT")
+    if settings.MANDRILL_SUBACCOUNT:
+        subaccount_settings = {
+            "MANDRILL_SEND_DEFAULTS": {
+                "esp_extra": {
+                    "message": {
+                        "subaccount": settings.MANDRILL_SUBACCOUNT
+                    }
+                }
+            }
+        }
+        if settings.ANYMAIL:
+            settings.ANYMAIL.update(subaccount_settings)
+        else:
+            settings.ANYMAIL = subaccount_settings
     # Sentry
     settings.SENTRY_DSN = settings.AUTH_TOKENS.get('SENTRY_DSN', False)
     if settings.SENTRY_DSN:


### PR DESCRIPTION
## Change description

Adding Mandrill Subaccount support. We tried to use dedicated IP for PSU but Mandrill team told us the best way to handle large number of emails is subaccount.  Back in 2021 I added the subaccount support to Hawthorn but seems it never made it to Juniper. https://github.com/appsembler/edx-platform/pull/1035

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
