### PR TITLE
Add sanitize function for redirect parameter next

### DIFF
--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -14,7 +14,7 @@ from mock import Mock
 from testfixtures import LogCapture
 
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
-from student.helpers import get_next_url_for_login_page
+from student.helpers import get_next_url_for_login_page, sanitize_next_parameter
 
 LOGGER_NAME = "student.helpers"
 
@@ -156,3 +156,25 @@ class TestLoginHelper(TestCase):
             'LOGIN_REDIRECT_URL': ''  # Falsy or empty URLs should not be used
         }):
             assert '/dashboard' == get_next_url_for_login_page(request), 'Falsy url should default to dashboard'
+
+    def test_sanitize_next_param(self):
+        # Valid URL with plus - change the plus symbol to ASCII code
+        next_param = 'courses/course-v1:abc-sandbox+ACC-PTF+C/course'
+        expected_result = 'courses/course-v1:abc-sandbox%2BACC-PTF%2BC/course'
+        self.assertEqual(sanitize_next_parameter(next_param), expected_result)
+
+        # Valid URL without plus - keep the next_param as it is
+        next_param = 'courses/course-v1:abc-sandbox/course'
+        self.assertEqual(sanitize_next_parameter(next_param), next_param)
+
+        # Empty string - keep the next_param as it is
+        next_param = ''
+        self.assertEqual(sanitize_next_parameter(next_param), next_param)
+
+        # None input - keep the next_param as it is
+        next_param = None
+        self.assertEqual(sanitize_next_parameter(next_param), next_param)
+
+        # Invalid pattern - keep the next_param as it is
+        next_param = 'some/other/path'
+        self.assertEqual(sanitize_next_parameter(next_param), next_param)


### PR DESCRIPTION
## Change description

Problem: The `next` parameter used with the `/login` route is incorrectly decoded, so the redirection happens to the wrong URL.  When the `next` parameter contains a **+** sign, the application encodes it as a **space** value. For example:
`...?next=courses/course-v1:snowflake-sandbox+ACC-PTF+C/course` - at the moment of redirection this route will be encoded as `...?next=courses/course-v1:snowflake-sandbox%20ACC-PTF%20C/course` where the **%20** is encoded **space** symbol. So, the user will see the 404 page instead of the course page.

![image](https://github.com/appsembler/edx-platform/assets/40686030/82febb34-6c87-407f-a408-2c55bbfab0f2)

Fix:
Add the sanitize function which will check the next parameter:
- If the next parameter looks like the course route - replace the + symbols with the right ASCII code **%2B**
- If the next parameter is not the course route - keep this parameter as it is

<img width="598" alt="image" src="https://github.com/appsembler/edx-platform/assets/40686030/b4555445-cd10-4c0d-8f2e-97a901a42521">


## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Related to [ENG-567](https://appsembler.atlassian.net/browse/ENG-567) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
