### PR TITLE
Improve the sanitize_next_parameter method with handling new cases

### DIFF
--- a/.github/workflows/sync_nutmeg_with_juniper.yml
+++ b/.github/workflows/sync_nutmeg_with_juniper.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: pull-request-action
-        uses: vsoch/pull-request-action@1.0.19
+        uses: vsoch/pull-request-action@1.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_PREFIX: "main"

--- a/.github/workflows/sync_prod_with_main.yml
+++ b/.github/workflows/sync_prod_with_main.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: pull-request-action
-        uses: vsoch/pull-request-action@1.0.19
+        uses: vsoch/pull-request-action@1.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_PREFIX: "main"
           PULL_REQUEST_BRANCH: "prod"
           PULL_REQUEST_TITLE: "Update from `main` (production)"
-          PULL_REQUEST_REVIEWERS: "xscrio amirtds bryanlandia"
+          PULL_REQUEST_REVIEWERS: "VladyslavTy daniilly"

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -714,7 +714,27 @@ def sanitize_next_parameter(next_param):
         return next_param
 
     if COURSE_URL_PATTERN.match(next_param):
+        # Sometimes the course id received with incorrect encoding/decoding, we need to
+        # replace it to the correct pattern:
+        # course-v1:test-sandbox PREP-CORE C -> course-v1:test-sandbox+PREP-CORE+C
+        #
+        # Note: We are not expect to have any spaces in course URL
+
+        if ' ' in next_param:
+            next_param = next_param.replace(' ', '+')
+        elif '%20' in next_param:
+            next_param = next_param.replace('%20', '+')
+
         sanitized_next_parameter = re.sub(r'\+', '%2B', next_param)
+
+        log.info(
+            u"The course-like next parameter was detected '%(next_param)s'"
+            u" this will be replaced with sanitized version: '%(sanitized_next_parameter)s'",
+            {
+                "next_param": next_param,
+                "sanitized_next_parameter": sanitized_next_parameter,
+            }
+        )
         return sanitized_next_parameter
 
     return next_param

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -178,3 +178,27 @@ class TestLoginHelper(TestCase):
         # Invalid pattern - keep the next_param as it is
         next_param = 'some/other/path'
         self.assertEqual(sanitize_next_parameter(next_param), next_param)
+
+        # Invalid URL with space - replace the ' ' with '+' and encode it
+        expected_result = 'courses/course-v1:abc-sandbox%2BACC-PTF%2BC/course'
+
+        next_param = 'courses/course-v1:abc-sandbox ACC-PTF C/course'
+        self.assertEqual(sanitize_next_parameter(next_param), expected_result)
+
+        next_param = 'courses/course-v1:abc-sandbox ACC-PTF+C/course'
+        self.assertEqual(sanitize_next_parameter(next_param), expected_result)
+
+        next_param = 'courses/course-v1:abc-sandbox+ACC-PTF C/course'
+        self.assertEqual(sanitize_next_parameter(next_param), expected_result)
+
+        # Invalid URL with encoded space - replace the '%20' with '+' and encode it
+        expected_result = 'courses/course-v1:abc-sandbox%2BACC-PTF%2BC/course'
+
+        next_param = 'courses/course-v1:abc-sandbox%20ACC-PTF%20C/course'
+        self.assertEqual(sanitize_next_parameter(next_param), expected_result)
+
+        next_param = 'courses/course-v1:abc-sandbox%20ACC-PTF+C/course'
+        self.assertEqual(sanitize_next_parameter(next_param), expected_result)
+
+        next_param = 'courses/course-v1:abc-sandbox+ACC-PTF%20C/course'
+        self.assertEqual(sanitize_next_parameter(next_param), expected_result)


### PR DESCRIPTION
## Change description

Handle new cases for sanitize_next_parameter method. The current realization skip the URLs with the following pattern `course-v1:test-sandbox PREP-CORE C`. We are not expecting to have any **space** symbols in course_id, so the changes replace it with '+' .

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
