### PR TITLE
Hide site elements if render in iframe

### DIFF
--- a/common/static/js/src/iframe-render.js
+++ b/common/static/js/src/iframe-render.js
@@ -1,5 +1,5 @@
 // List of the classes to hide while rendered in an iframe
-const classesToHide = ['.global-header', '.wrapper-course-material', 'a--footer'];
+const classesToHide = ['.global-header', '.wrapper-course-material', '.a--footer'];
 
 document.addEventListener('DOMContentLoaded', function () {
   // Check if rendered in iframe

--- a/common/static/js/src/iframe-render.js
+++ b/common/static/js/src/iframe-render.js
@@ -1,0 +1,13 @@
+// List of the classes to hide while rendered in an iframe
+const classesToHide = ['.global-header', '.wrapper-course-material', 'a--footer'];
+
+document.addEventListener('DOMContentLoaded', function () {
+  // Check if rendered in iframe
+  if (window.self !== window.top) {
+    classesToHide.forEach(function (className) {
+      document.querySelectorAll(className).forEach(function (element) {
+        element.classList.add('hidden-in-iframe');
+      });
+    });
+  }
+});

--- a/lms/static/sass/shared-v2/_base.scss
+++ b/lms/static/sass/shared-v2/_base.scss
@@ -24,3 +24,8 @@
   @extend .sr-only;
 }
 
+// Hide element when rendered in iFrame
+.hidden-in-iframe {
+    display: none !important;
+}
+

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -211,6 +211,7 @@ from pipeline_mako import render_require_js_path_overrides
   <script type="text/javascript" src="${static.url('js/header/header.js')}"></script>
   <%static:optional_include_mako file="body-extra.html" is_theming_enabled="True" />
   <script type="text/javascript" src="${static.url('js/src/jquery_extend_patch.js')}"></script>
+  <script type="text/javascript" src="${static.url('js/src/iframe-render.js')}"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Change description

We need to hide the elements like header, footer, nav panel if the site is rendered in iframe. These changes is a part of Seertech IDP integration for Snowflake customer. [ENG-714](https://appsembler.atlassian.net/browse/ENG-714)

Added event listener that check if the site is render in iframe. 
If yes - add the `display: none !important;` to the styles of choosen elements by their className `classesToHide`
If no - nothing changes

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
