### PR TITLE
Add function to set hideElements cookie

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -19,6 +19,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.core.validators import ValidationError
 from django.db import IntegrityError, transaction
+from django.shortcuts import redirect
 from django.urls import NoReverseMatch, reverse
 from django.utils.translation import ugettext as _
 from pytz import UTC
@@ -739,3 +740,16 @@ def sanitize_next_parameter(next_param):
         return sanitized_next_parameter
 
     return next_param
+
+
+def add_hide_elements_cookie_to_redirect(redirect_to):
+    if 'hide_elements' in redirect_to:
+        # Perform the redirect and set the cookie only if 'hide_elements' is present
+        response = redirect(redirect_to)
+
+        # Set a cookie to indicate that elements should be hidden
+        response.set_cookie('hideElements', 'true', max_age=86400)
+
+        return response
+    else:
+        return redirect(redirect_to)

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -30,7 +30,7 @@ from openedx.features.enterprise_support.utils import (
     handle_enterprise_cookies_for_logistration,
     update_logistration_context_for_enterprise
 )
-from student.helpers import get_next_url_for_login_page
+from student.helpers import get_next_url_for_login_page, add_hide_elements_cookie_to_redirect
 from third_party_auth import pipeline
 from third_party_auth.decorators import xframe_allow_whitelisted
 from util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
@@ -146,12 +146,14 @@ def login_and_registration_form(request, initial_mode="login"):
     #  since Django's SessionAuthentication middleware auto-updates session cookies but not
     #  the other login-related cookies. See ARCH-282.
     if request.user.is_authenticated and are_logged_in_cookies_set(request):
-        return redirect(redirect_to)
+        response = add_hide_elements_cookie_to_redirect(redirect_to)
+        return response
 
     # Tahoe: Disable upstream login/register forms when the Tahoe Identity Provider is enabled.
     tahoe_idp_redirect_url = tahoe_idp_helpers.get_idp_form_url(request, initial_mode, redirect_to)
     if tahoe_idp_redirect_url:
-        return redirect(tahoe_idp_redirect_url)
+        response = add_hide_elements_cookie_to_redirect(tahoe_idp_redirect_url)
+        return response
 
     # Retrieve the form descriptions from the user API
     form_descriptions = _get_form_descriptions(request)


### PR DESCRIPTION
## Change description

Add helper function `add_hide_elements_cookie_to_redirect` to set the `hideElements` cookie if hide_elements parameter exist in redirect url. This should help to speed up hiding the elements from UI.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
