### PR TITLE
fix: speed up course contents page

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -708,7 +708,7 @@ def get_courses_accessible_to_user(request, org=None):
     return courses, in_process_course_actions
 
 
-def _process_courses_list(courses_iter, in_process_course_actions, split_archived=False):
+def _process_courses_list(courses_iter, in_process_course_actions, split_archived=False, ignore_archived=False):
     """
     Iterates over the list of courses to be displayed to the user, and:
 
@@ -738,6 +738,9 @@ def _process_courses_list(courses_iter, in_process_course_actions, split_archive
     archived_courses = []
 
     for course in courses_iter:
+        if course.has_ended() and ignore_archived:
+            continue
+
         if isinstance(course, ErrorDescriptor) or (course.id in in_process_action_course_keys):
             continue
 
@@ -1118,7 +1121,7 @@ def settings_handler(request, course_key_string):
                 # exclude current course from the list of available courses
                 courses = (course for course in courses if course.id != course_key)
                 if courses:
-                    courses, __ = _process_courses_list(courses, in_process_course_actions)
+                    courses, __ = _process_courses_list(courses, in_process_course_actions, ignore_archived=True)
                 settings_context.update({'possible_pre_requisite_courses': list(courses)})
 
             if credit_eligibility_enabled:

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -738,8 +738,22 @@ def _process_courses_list(courses_iter, in_process_course_actions, split_archive
     archived_courses = []
 
     for course in courses_iter:
+        # BEGIN temp fix for Sounds Write
+
+        # TODO: if a user has tons of courses like Sounds Write (571), some pages will time out.
+        # This is a temporary patch to prevent Sounds-Write requets timing out. The right fix
+        # is to optimize the DB queries.
+
+
+        # This skipping step can be potentially kept since it's just used for the "prerequisite" course list
+        # where we do not need to list archived courses.
         if course.has_ended() and ignore_archived:
             continue
+
+        if course.has_ended() and course.location.org == "sounds-write":
+            continue
+
+        # END temp fix for Sounds Write
 
         if isinstance(course, ErrorDescriptor) or (course.id in in_process_action_course_keys):
             continue


### PR DESCRIPTION
## Change description

This will ignore archived course on the contents page while retaining the original behavior in the other instance where the method is used.