### PR TITLE
Apply missing Juniper security patches - template escaping fixes

### DIFF
--- a/cms/templates/js/group-configuration-details.underscore
+++ b/cms/templates/js/group-configuration-details.underscore
@@ -31,9 +31,9 @@
 
     <% if(showGroups) { %>
       <% allocation = Math.floor(100 / groups.length) %>
-      <ol class="collection-items groups groups-<%= index %>">
+      <ol class="collection-items groups groups-<%- index %>">
         <% groups.each(function(group, groupIndex) { %>
-          <li class="item group group-<%= groupIndex %>">
+          <li class="item group group-<%- groupIndex %>">
             <span class="name group-name"><%- group.get('name') %></span>
             <span class="meta group-allocation"><%- allocation %>%</span>
           </li>

--- a/cms/templates/js/maintenance/force-published-course-response.underscore
+++ b/cms/templates/js/maintenance/force-published-course-response.underscore
@@ -3,7 +3,7 @@
         <%- gettext('You have done a dry run of force publishing the course. Nothing has changed. Had you run it, the following course versions would have been change.') %>
     </div>
     <div class="main-output">
-        <%= StringUtils.interpolate(
+        <%- StringUtils.interpolate(
             gettext('The published branch version, {published}, was reset to the draft branch version, {draft}.'),
             {
                 published: current_versions['published-branch'],

--- a/cms/templates/js/mock/mock-xmodule-editor.underscore
+++ b/cms/templates/js/mock/mock-xmodule-editor.underscore
@@ -16,13 +16,13 @@
 
         <script id="metadata-string-entry" type="text/template">
             <div class="wrapper-comp-setting">
-                \t<label class="label setting-label" for="<%= uniqueId %>"><%= model.get('display_name') %></label>
-                \t<input class="input setting-input" type="text" id="<%= uniqueId %>" value='<%= model.get("value") %>'/>
+                \t<label class="label setting-label" for="<%- uniqueId %>"><%- model.get('display_name') %></label>
+                \t<input class="input setting-input" type="text" id="<%- uniqueId %>" value='<%- model.get("value") %>'/>
                 \t<button class="action setting-clear inactive" type="button" name="setting-clear" value="Clear" data-tooltip="Clear">
                 <span class="icon fa fa-undo" aria-hidden="true"></span><span class="sr">"Clear Value"</span>
                 </button>
             </div>
-            <span class="tip setting-help"><%= model.get('help') %></span>
+            <span class="tip setting-help"><%- model.get('help') %></span>
 
         </script>
 


### PR DESCRIPTION
Fix XSS vulnerabilities by changing <%= %> to <%- %> in template files:
- group-configuration-details.underscore (2 fixes)
- force-published-course-response.underscore (1 fix) 
- mock-xmodule-editor.underscore (4 fixes)

This ensures proper HTML escaping of user-controlled data in templates.